### PR TITLE
Include missing `algorithm` header.

### DIFF
--- a/src/server/byte_range.cpp
+++ b/src/server/byte_range.cpp
@@ -23,6 +23,7 @@
 #include "tools/stringTools.h"
 
 #include <cassert>
+#include <algorithm>
 
 namespace kiwix {
 


### PR DESCRIPTION
`min` and `max` functions are defined here.