### PR TITLE
Run the CI on pull request.

### DIFF
--- a/.github/workflows/check_pr.yml
+++ b/.github/workflows/check_pr.yml
@@ -1,6 +1,6 @@
-name: CI
+name: Check PR
 
-on: [push]
+on: [pull_request]
 
 jobs:
   Macos:


### PR DESCRIPTION
This is needed to have the CI run on pull request created from of fork
repository.

Fixes #410