### PR TITLE
Use title snippets if available

### DIFF
--- a/include/reader.h
+++ b/include/reader.h
@@ -77,7 +77,7 @@ class SuggestionItem
  * file.
  */
 
-using SuggestionsList_t = std::vector<std::vector<std::string>>;
+using SuggestionsList_t = std::vector<SuggestionItem>;
 class Reader
 {
  public:

--- a/include/reader.h
+++ b/include/reader.h
@@ -38,6 +38,41 @@ namespace kiwix
 {
 
 /**
+ * The SuggestionItem is a helper class that contains the info about a single
+ * suggestion item.
+ */
+
+class SuggestionItem
+{
+  // Functions
+  private:
+    // Create a sugggestion item.
+    explicit SuggestionItem(std::string title, std::string normalizedTitle,
+                            std::string path, std::string snippet = "") :
+      title(title),
+      normalizedTitle(normalizedTitle),
+      path(path),
+      snippet(snippet) {}
+
+  public:
+    const std::string getTitle()           {return title;}
+    const std::string getNormalizedTitle() {return normalizedTitle;}
+    const std::string getPath()            {return path;}
+    const std::string getSnippet()         {return snippet;}
+
+    const bool hasSnippet()                {return !snippet.empty();}
+
+  // Data
+  private:
+    std::string title;
+    std::string normalizedTitle;
+    std::string path;
+    std::string snippet;
+
+  friend class Reader;
+};
+
+/**
  * The Reader class is the class who allow to get an entry content from a zim
  * file.
  */

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -432,12 +432,12 @@ bool Reader::searchSuggestions(const string& prefix,
        article is already in the suggestions list (with an other
        title) */
     bool insert = true;
-    std::vector<std::vector<std::string>>::iterator suggestionItr;
+    std::vector<SuggestionItem>::iterator suggestionItr;
     for (suggestionItr = results.begin();
          suggestionItr != results.end();
          suggestionItr++) {
-      int result = normalizedArticleTitle.compare((*suggestionItr)[2]);
-      if (result == 0 && articleFinalUrl.compare((*suggestionItr)[1]) == 0) {
+      int result = normalizedArticleTitle.compare((*suggestionItr).getNormalizedTitle());
+      if (result == 0 && articleFinalUrl.compare((*suggestionItr).getPath()) == 0) {
         insert = false;
         break;
       } else if (result < 0) {
@@ -447,10 +447,7 @@ bool Reader::searchSuggestions(const string& prefix,
 
     /* Insert if possible */
     if (insert) {
-      std::vector<std::string> suggestion;
-      suggestion.push_back(entry.getTitle());
-      suggestion.push_back(articleFinalUrl);
-      suggestion.push_back(normalizedArticleTitle);
+      SuggestionItem suggestion(entry.getTitle(), normalizedArticleTitle, articleFinalUrl);
       results.insert(suggestionItr, suggestion);
     }
 
@@ -506,11 +503,8 @@ bool Reader::searchSuggestionsSmart(const string& prefix,
     for (auto current = suggestions.begin();
          current != suggestions.end();
          current++) {
-      std::vector<std::string> suggestion;
-      suggestion.push_back(current.getTitle());
-      suggestion.push_back(current.getPath());
-      suggestion.push_back(kiwix::normalize(current.getTitle()));
-      suggestion.push_back(current.getSnippet());
+      SuggestionItem suggestion(current.getTitle(), kiwix::normalize(current.getTitle()),
+                                current.getPath(), current.getSnippet());
       results.push_back(suggestion);
     }
     retVal = true;
@@ -531,7 +525,7 @@ bool Reader::getNextSuggestion(string& title)
 {
   if (this->suggestionsOffset != this->suggestions.end()) {
     /* title */
-    title = (*(this->suggestionsOffset))[0];
+    title = (*(this->suggestionsOffset)).getTitle();
 
     /* increment the cursor for the next call */
     this->suggestionsOffset++;
@@ -546,8 +540,8 @@ bool Reader::getNextSuggestion(string& title, string& url)
 {
   if (this->suggestionsOffset != this->suggestions.end()) {
     /* title */
-    title = (*(this->suggestionsOffset))[0];
-    url = (*(this->suggestionsOffset))[1];
+    title = (*(this->suggestionsOffset)).getTitle();
+    url = (*(this->suggestionsOffset)).getPath();
 
     /* increment the cursor for the next call */
     this->suggestionsOffset++;

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -510,6 +510,7 @@ bool Reader::searchSuggestionsSmart(const string& prefix,
       suggestion.push_back(current.getTitle());
       suggestion.push_back(current.getPath());
       suggestion.push_back(kiwix::normalize(current.getTitle()));
+      suggestion.push_back(current.getSnippet());
       results.push_back(suggestion);
     }
     retVal = true;

--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -414,15 +414,15 @@ std::unique_ptr<Response> InternalServer::handle_suggest(const RequestContext& r
     reader->searchSuggestionsSmart(term, maxSuggestionCount, suggestions);
     for(auto& suggestion:suggestions) {
       MustacheData result;
-      result.set("label", suggestion[0]);
+      result.set("label", suggestion.getTitle());
 
-      if (!suggestion[3].empty()) {
-        result.set("label", suggestion[3]);
+      if (suggestion.hasSnippet()) {
+        result.set("label", suggestion.getSnippet());
       }
 
-      result.set("value", suggestion[0]);
+      result.set("value", suggestion.getTitle());
       result.set("kind", "path");
-      result.set("path", suggestion[1]);
+      result.set("path", suggestion.getPath());
       result.set("first", first);
       first = false;
       results.push_back(result);

--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -415,6 +415,11 @@ std::unique_ptr<Response> InternalServer::handle_suggest(const RequestContext& r
     for(auto& suggestion:suggestions) {
       MustacheData result;
       result.set("label", suggestion[0]);
+
+      if (!suggestion[3].empty()) {
+        result.set("label", suggestion[3]);
+      }
+
       result.set("value", suggestion[0]);
       result.set("kind", "path");
       result.set("path", suggestion[1]);

--- a/static/skin/taskbar.js
+++ b/static/skin/taskbar.js
@@ -34,7 +34,12 @@ jq(document).ready(() => {
                     $( "#kiwixsearchform" ).submit();
                 }
             },
-        });
+        }).data( "ui-autocomplete" )._renderItem = function( ul, item ) {
+            return $( "<li>" )
+              .data( "ui-autocomplete-item", item )
+              .append( item.label )
+              .appendTo( ul );
+        };
     
         /* cybook hack */
         if (navigator.userAgent.indexOf("bookeen/cybook") != -1) {


### PR DESCRIPTION
Fixes #82 

With openzim/libzim#545 we now support snippet generation for titles. It can be used as the display label on the ui for highlighted titles via the "label" field. The old version used plain-title which is still available in the value field.

Changes included in this pr:
- Sets `label` to title snippet if available
- Set up proper rendering of snippet using `_renderItem` property of autocomplete ui