### PR TITLE
Add `get_zimId` method to Result

### DIFF
--- a/include/searcher.h
+++ b/include/searcher.h
@@ -48,7 +48,6 @@ class Result
   virtual std::string get_content() = 0;
   virtual int get_wordCount() = 0;
   virtual int get_size() = 0;
-  virtual int get_readerIndex() = 0;
   virtual std::string get_zimId() = 0;
 };
 

--- a/include/searcher.h
+++ b/include/searcher.h
@@ -49,6 +49,7 @@ class Result
   virtual int get_wordCount() = 0;
   virtual int get_size() = 0;
   virtual int get_readerIndex() = 0;
+  virtual std::string get_zimId() = 0;
 };
 
 struct SearcherInternal;

--- a/src/search_renderer.cpp
+++ b/src/search_renderer.cpp
@@ -77,9 +77,7 @@ std::string SearchRenderer::getHtml()
     result.set("title", p_result->get_title());
     result.set("url", p_result->get_url());
     result.set("snippet", p_result->get_snippet());
-    auto readerIndex = p_result->get_readerIndex();
-    auto reader = mp_searcher->get_reader(readerIndex);
-    result.set("resultContentId", mp_nameMapper->getNameForId(reader->getId()));
+    result.set("resultContentId", mp_nameMapper->getNameForId(p_result->get_zimId()));
 
     if (p_result->get_wordCount() >= 0) {
       result.set("wordCount", kiwix::beautifyInteger(p_result->get_wordCount()));

--- a/src/searcher.cpp
+++ b/src/searcher.cpp
@@ -46,6 +46,7 @@ class _Result : public Result
   virtual int get_wordCount();
   virtual int get_size();
   virtual int get_readerIndex();
+  virtual std::string get_zimId();
 
  private:
   zim::SearchResultSet::iterator iterator;
@@ -264,6 +265,12 @@ int _Result::get_wordCount()
 int _Result::get_readerIndex()
 {
   return iterator.getFileIndex();
+}
+std::string _Result::get_zimId()
+{
+  std::ostringstream s;
+  s << iterator.getZimId();
+  return s.str();
 }
 
 

--- a/src/searcher.cpp
+++ b/src/searcher.cpp
@@ -45,7 +45,6 @@ class _Result : public Result
   virtual std::string get_content();
   virtual int get_wordCount();
   virtual int get_size();
-  virtual int get_readerIndex();
   virtual std::string get_zimId();
 
  private:
@@ -261,10 +260,6 @@ int _Result::get_size()
 int _Result::get_wordCount()
 {
   return iterator.getWordCount();
-}
-int _Result::get_readerIndex()
-{
-  return iterator.getFileIndex();
 }
 std::string _Result::get_zimId()
 {


### PR DESCRIPTION
Fixes #107 

Must be merged after #526.

`get_zimId` method allows the user to get the uuid of the archive from which a result is retrieved directly from the search result itself. 

*Note*: With this, we might want to get rid of the method `get_readerIndex` later since we can directly identify the archive from the search result with this change.

Changes included in this pr:
- Add a new method `get_zimId` to the `Results`

**This PR depends on openzim/libzim#557**