### PR TITLE
OpdsCatalog::getSearchUrl()

### DIFF
--- a/include/opds_catalog.h
+++ b/include/opds_catalog.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 Veloman Yunkan <veloman.yunkan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU  General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+#ifndef KIWIX_OPDS_CATALOG_H
+#define KIWIX_OPDS_CATALOG_H
+
+
+#include "library.h"
+
+namespace kiwix
+{
+
+std::string getSearchUrl(const Filter& f);
+
+} // namespace kiwix
+
+#endif // KIWIX_OPDS_CATALOG_H

--- a/src/meson.build
+++ b/src/meson.build
@@ -26,7 +26,8 @@ kiwix_sources = [
   'server/request_context.cpp',
   'server/response.cpp',
   'server/internalServer.cpp',
-  'server/internalServer_catalog_v2.cpp'
+  'server/internalServer_catalog_v2.cpp',
+  'opds_catalog.cpp'
 ]
 kiwix_sources += lib_resources
 

--- a/src/opds_catalog.cpp
+++ b/src/opds_catalog.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021 Veloman Yunkan <veloman.yunkan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU  General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+#include "opds_catalog.h"
+#include "tools/stringTools.h"
+
+#include <sstream>
+
+namespace kiwix
+{
+
+namespace
+{
+const char opdsSearchEndpoint[] = "/catalog/v2/entries";
+
+enum Separator { AMP };
+
+std::ostringstream& operator<<(std::ostringstream& oss, Separator sep)
+{
+  if ( oss.tellp() > 0 )
+    oss << "&";
+  return oss;
+}
+
+std::string buildSearchString(const Filter& f)
+{
+  std::ostringstream oss;
+  if ( f.hasQuery() )
+    oss << AMP << "q=" << urlEncode(f.getQuery());
+
+  if ( f.hasCategory() )
+    oss << AMP << "category=" << urlEncode(f.getCategory());
+
+  if ( f.hasLang() )
+    oss << AMP << "lang=" << urlEncode(f.getLang());
+
+  if ( f.hasName() )
+    oss << AMP << "name=" << urlEncode(f.getName());
+
+  if ( !f.getAcceptTags().empty() )
+    oss << AMP << "tag=" << urlEncode(join(f.getAcceptTags(), ";"));
+
+  return oss.str();
+}
+
+} // unnamed namespace
+
+std::string getSearchUrl(const Filter& f)
+{
+  const std::string searchString = buildSearchString(f);
+
+  if ( searchString.empty() )
+    return opdsSearchEndpoint;
+  else
+    return opdsSearchEndpoint + ("?" + searchString);
+}
+
+} // namespace kiwix

--- a/test/meson.build
+++ b/test/meson.build
@@ -8,6 +8,7 @@ tests = [
     'kiwixserve',
     'book',
     'manager',
+    'opds_catalog',
 ]
 
 if build_machine.system() != 'windows'

--- a/test/opds_catalog.cpp
+++ b/test/opds_catalog.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2021 Veloman Yunkan <veloman.yunkan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * is provided AS IS, WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, and
+ * NON-INFRINGEMENT.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ */
+
+#include "../include/opds_catalog.h"
+
+#include "gtest/gtest.h"
+
+using namespace kiwix;
+
+TEST(OpdsCatalog, getSearchUrl)
+{
+  #define EXPECT_SEARCH_URL(url) EXPECT_EQ(url, getSearchUrl(f))
+  {
+    Filter f;
+    EXPECT_SEARCH_URL("/catalog/v2/entries");
+  }
+  {
+    Filter f;
+    f.query("abc");
+    EXPECT_SEARCH_URL("/catalog/v2/entries?q=abc");
+  }
+  {
+    Filter f;
+    f.query("abc def");
+    EXPECT_SEARCH_URL("/catalog/v2/entries?q=abc%20def");
+  }
+  {
+    Filter f;
+    f.category("ted");
+    EXPECT_SEARCH_URL("/catalog/v2/entries?category=ted");
+  }
+  {
+    Filter f;
+    f.lang("eng");
+    EXPECT_SEARCH_URL("/catalog/v2/entries?lang=eng");
+  }
+  {
+    Filter f;
+    f.name("second");
+    EXPECT_SEARCH_URL("/catalog/v2/entries?name=second");
+  }
+  {
+    Filter f;
+    f.acceptTags({"paper", "plastic"});
+    EXPECT_SEARCH_URL("/catalog/v2/entries?tag=paper;plastic");
+  }
+  {
+    Filter f;
+    f.query("abc");
+    f.category("ted");
+    EXPECT_SEARCH_URL("/catalog/v2/entries?q=abc&category=ted");
+  }
+  {
+    Filter f;
+    f.category("ted");
+    f.query("abc");
+    EXPECT_SEARCH_URL("/catalog/v2/entries?q=abc&category=ted");
+  }
+  {
+    Filter f;
+    f.query("peru");
+    f.category("scifi");
+    f.lang("html");
+    f.name("edsonarantesdonascimento");
+    f.acceptTags({"body", "script"});
+    EXPECT_SEARCH_URL("/catalog/v2/entries?q=peru&category=scifi&lang=html&name=edsonarantesdonascimento&tag=body;script");
+  }
+  #undef EXPECT_SEARCH_URL
+}


### PR DESCRIPTION
Fixes #480.

Must be merged after #526.

This is a **preliminary** implementation of OPDS search url generation targeting the new API introduced by the yet unmerged #492.

Note that #488 has enabled us to search by all fields via the query parameter. For example a search by category can be done in two ways:
1. (old) `search_endpoint?category=whatever`
2. (new) `search_endpoint?q=category:whatever`

Internally, the old approach is converted to an equivalent of the new one with the slight difference of not assuming partial query (which is the default mode for the `q` parameter).

Some fields (creator, publisher) are not exposed for searching in the old scheme but are available via the new scheme.

Now the question is which one of the two schemes should be utilized for the search URL generation?

Another question is what should be done about the filtering criteria `Filter::local()`, `Filter::remote()`, `Filter::remote()`? They have never been exposed through the OPDS search API.

TODOs:
- Don't ignore the `Filter::maxSize()` & `Filter::rejectTags()` filtering criteria.