### PR TITLE
Check if bookName is available in url parameters

### DIFF
--- a/static/skin/taskbar.js
+++ b/static/skin/taskbar.js
@@ -7,7 +7,10 @@ const jq = jQuery.noConflict(true);
 jq(document).ready(() => {
     (function ($) {
         const root = $( `link[type='root']` ).attr("href");
-        const bookName = window.location.pathname.split(`${root}/`)[1].split('/')[0];
+
+        const bookName = (window.location.pathname == `${root}/search`)
+               ? (new URLSearchParams(window.location.search)).get('content') 
+               : window.location.pathname.split(`${root}/`)[1].split('/')[0];
     
         $( "#kiwixsearchbox" ).autocomplete({
     


### PR DESCRIPTION
Fixes #496 

In certain pages like the search result page, `bookName` is not of the form `/bookName/endpoint?parameters` which is the assumption here:
https://github.com/kiwix/libkiwix/blob/51883558781008d006b983991bd4ff35e53f3e79/static/skin/taskbar.js#L7-L10
Rather it is available as a query parameter in `/endpoint?content=bookName&otherParameters`. From these pages, `bookName` should be assigned from parameters.

Changes included in this pr:
- Checks if the URL has a `content` parameter. If yes, assign `bookName` to this parameter.