### PR TITLE
Update libkiwix with search iterator rename in libzim

### DIFF
--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -507,9 +507,9 @@ bool Reader::searchSuggestionsSmart(const string& prefix,
          current != suggestions.end();
          current++) {
       std::vector<std::string> suggestion;
-      suggestion.push_back(current->getTitle());
-      suggestion.push_back(current->getPath());
-      suggestion.push_back(kiwix::normalize(current->getTitle()));
+      suggestion.push_back(current.getTitle());
+      suggestion.push_back(current.getPath());
+      suggestion.push_back(kiwix::normalize(current.getTitle()));
       results.push_back(suggestion);
     }
     retVal = true;

--- a/src/searcher.cpp
+++ b/src/searcher.cpp
@@ -235,19 +235,19 @@ _Result::_Result(zim::SearchResultSet::iterator iterator)
 
 std::string _Result::get_url()
 {
-  return iterator.get_path();
+  return iterator.getPath();
 }
 std::string _Result::get_title()
 {
-  return iterator.get_title();
+  return iterator.getTitle();
 }
 int _Result::get_score()
 {
-  return iterator.get_score();
+  return iterator.getScore();
 }
 std::string _Result::get_snippet()
 {
-  return iterator.get_snippet();
+  return iterator.getSnippet();
 }
 std::string _Result::get_content()
 {
@@ -255,15 +255,15 @@ std::string _Result::get_content()
 }
 int _Result::get_size()
 {
-  return iterator.get_size();
+  return iterator.getSize();
 }
 int _Result::get_wordCount()
 {
-  return iterator.get_wordCount();
+  return iterator.getWordCount();
 }
 int _Result::get_readerIndex()
 {
-  return iterator.get_fileIndex();
+  return iterator.getFileIndex();
 }
 
 


### PR DESCRIPTION
This PR braces libkiwix for openzim/libzim#563

Search iterator API in libzim has been shifted to use camel case naming. This has to be accommodated in libkiwix as well.