### PR TITLE
Avoid windows header to define min/max macros.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -56,6 +56,10 @@ if target_machine.system() == 'windows' and static_deps
   extra_cflags += '-DCURL_STATICLIB'
 endif
 
+if target_machine.system() == 'windows'
+  add_project_arguments('-DNOMINMAX', language: 'cpp')
+endif
+
 all_deps = [thread_dep, libicu_dep, libzim_dep, pugixml_dep, libcurl_dep, microhttpd_dep, zlib_dep, xapian_dep]
 
 inc = include_directories('include', extra_include)


### PR DESCRIPTION
PR #507 use std::min.
But on windows, the header define min and max macros and so the
compilation is broken.
Add `-NOMINMAX` define to avoid that.