### PR TITLE
Use new libzim illustration API

### DIFF
--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -184,8 +184,7 @@ Entry Reader::getMainPage() const
 bool Reader::getFavicon(string& content, string& mimeType) const
 {
   try {
-    auto entry = zimArchive->getFaviconEntry();
-    auto item = entry.getItem(true);
+    auto item = zimArchive->getIllustrationItem();
     content = item.getData();
     mimeType = item.getMimetype();
     return true;


### PR DESCRIPTION
fixes #558 
With openzim/libzim#540 we now have a new function to get illustration(previously favicon in 48x48 size and unity scale) in multiple sizes. We need to replace getFaviconEntry with this new getIllustrationItem method.

Changes in this PR:
- use `Archive::getIllustrationItem()` to get an illustration for the archive in 48x48 size(previously favicon)