### PR TITLE
JNI search  methods for android

### DIFF
--- a/src/wrapper/java/org/kiwix/kiwixlib/Author.java
+++ b/src/wrapper/java/org/kiwix/kiwixlib/Author.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2019-2021 Kiwix
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU  General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+package org.kiwix.kiwixlib;
+
+
+public class Author {
+    // Author name e.g wikipedia, TED
+    String authorName;
+    //Gets the book list url of the author
+    String authorBooksListurl;
+    // Authors url logo
+    String authorImageLogoUrl;
+    // How many zim files have the author list
+    Int bookscount;
+}
+
+
+

--- a/src/wrapper/java/org/kiwix/kiwixlib/Book.java
+++ b/src/wrapper/java/org/kiwix/kiwixlib/Book.java
@@ -45,4 +45,17 @@ public class Book
   private native void allocate();
   private native void dispose();
   private long nativeHandle;
+
+    /**
+     * Only use the book's id to generate a hash code
+     * Returns a hash code for this string in this case we should use the id of book
+     */
+  public native long hashCode();
+
+   /**
+    * Two books are equal if their ids match
+    * @param object will assume as [Book] object.
+    * @return true if their id's match
+    */
+  public native boolean equals(Object object);
 }

--- a/src/wrapper/java/org/kiwix/kiwixlib/OpdsUriUtills.java
+++ b/src/wrapper/java/org/kiwix/kiwixlib/OpdsUriUtills.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2021 Kiwix
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU  General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+package org.kiwix.kiwixlib;
+class OpdsUriUtills {
+    /**
+     * Returns the author list of the object
+     **/
+    public native List<Author> getTheAuthorsList();
+
+
+    /**
+     * returns the [Uri] of the given tags
+     *
+     * @param author   the author name
+     * @param category which category they want to search
+     * @param tags  which tags they want to search
+     * @return url of the given query
+     **/
+    public native String getUrlFromTags(String author, String...languageList, String...categories);
+
+
+    /**
+     *  URL of the file to download e.g http://download.kiwix.org/foobar.zim
+     * @param book which book they want to download
+     * @returns the url of zim file
+     */
+    public native String getTheDownlaodUrlOfBook(Book book);
+}


### PR DESCRIPTION
Created all search methods that we need for searching in `kiwix-android`
libkiwix already has filters and class that we want to search e.g [Book](https://github.com/kiwix/libkiwix/blob/master/src/wrapper/java/org/kiwix/kiwixlib/Book.java) and [Filter](https://github.com/kiwix/libkiwix/blob/master/src/wrapper/java/org/kiwix/kiwixlib/Filter.java) that we will reuse in android to filter all sort of things.
After this process will be in android
1. libkiwix will build the URL 
2. client shares the OPDS feed with libkiwix which parse it and in returns gives the list of books as an object 
 