### PR TITLE
Update libkiwix with new suggestion API in libzim

### DIFF
--- a/include/searcher.h
+++ b/include/searcher.h
@@ -52,6 +52,7 @@ class Result
 };
 
 struct SearcherInternal;
+struct SuggestionInternal;
 /**
  * The Searcher class is reponsible to do different kind of search using the
  * fulltext index.
@@ -160,6 +161,7 @@ class Searcher
 
   std::vector<Reader*> readers;
   std::unique_ptr<SearcherInternal> internal;
+  std::unique_ptr<SuggestionInternal> suggestionInternal;
   std::string searchPattern;
   unsigned int estimatedResultCount;
   unsigned int resultStart;

--- a/test/searcher.cpp
+++ b/test/searcher.cpp
@@ -22,12 +22,37 @@ TEST(Searcher, search) {
   ASSERT_EQ(result->get_title(), "Wikibooks");
 }
 
+TEST(Searcher, suggestion) {
+  Reader reader("./test/zimfile.zim");
+
+  Searcher searcher;
+  searcher.add_reader(&reader);
+  ASSERT_EQ(searcher.get_reader(0)->getTitle(), reader.getTitle());
+
+  std::string query = "ray";
+  searcher.suggestions(query, true);
+  searcher.restart_search();
+
+  auto result = searcher.getNextResult();
+  ASSERT_EQ(result->get_title(), "Charles, Ray");
+  ASSERT_EQ(result->get_url(), "A/Charles,_Ray");
+  ASSERT_EQ(result->get_snippet(), "Charles, <b>Ray</b>");
+  ASSERT_EQ(result->get_score(), 0);
+  ASSERT_EQ(result->get_content(), "");
+  ASSERT_EQ(result->get_size(), 0);
+  ASSERT_EQ(result->get_wordCount(), 0);
+  ASSERT_EQ(result->get_zimId(), "");
+
+  result = searcher.getNextResult();
+  ASSERT_EQ(result->get_title(), "Ray (film)");
+}
+
 TEST(Searcher, incrementalRange) {
   // Attempt to get 50 results in steps of 5
   zim::Archive archive("./test/zimfile.zim");
   zim::Searcher ftsearcher(archive);
   zim::Query query;
-  query.setQuery("ray", false);
+  query.setQuery("ray");
   auto search = ftsearcher.search(query);
 
   int suggCount = 0;


### PR DESCRIPTION
Fixes #605 
This PR braces libkiwix for openzim/libzim#574

Now, suggestion and ft search have two different APIs in libzim. This offers us the capability to get suggestions from libzim directly even if the database is absent. 

- This pr focuses on fully fixing **the internal server**.
- This PR is not optimal for `kiwix::Searcher` and `kiwix::Reader` and only focuses on fixing the compilation as we will drop these two soon.

