### PR TITLE
debian: Have libkiwix-dev depend on libkainjow-mustache-dev

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -27,7 +27,8 @@ Depends: libkiwix10 (= ${binary:Version}), ${misc:Depends}, python3,
  libicu-dev,
  libpugixml-dev,
  libcurl4-gnutls-dev,
- libmicrohttpd-dev
+ libmicrohttpd-dev,
+ libkainjow-mustache-dev
 Description: library of common code for Kiwix (development)
  Kiwix is an offline Wikipedia reader. libkiwix provides the
  software core for Kiwix, and contains the code shared by all


### PR DESCRIPTION
Software trying to build against libkiwix-dev now need to have
libkainjow-mustache-dev installed since tools/otherTools.h includes it.

This should fix the PPA builds in kiwix-tools.