### PR TITLE
Support for multiple illustrations in OPDS entry

### DIFF
--- a/src/book.cpp
+++ b/src/book.cpp
@@ -104,7 +104,7 @@ void Book::update(const zim::Archive& archive) {
   m_mediaCount = getArchiveMediaCount(archive);
   m_size = static_cast<uint64_t>(getArchiveFileSize(archive)) << 10;
 
-  getArchiveFavicon(archive, m_favicon, m_faviconMimeType);
+  getArchiveFavicon(archive, 48, m_favicon, m_faviconMimeType);
 }
 
 #define ATTR(name) node.attribute(name).value()

--- a/src/opds_dumper.cpp
+++ b/src/opds_dumper.cpp
@@ -52,6 +52,22 @@ namespace
 
 typedef kainjow::mustache::data MustacheData;
 typedef kainjow::mustache::list BookData;
+typedef kainjow::mustache::list IllustrationInfo;
+
+IllustrationInfo getBookIllustrationInfo(const Book& book)
+{
+    kainjow::mustache::list illustrations;
+    if ( book.isPathValid() ) {
+      for ( auto illustration_size : zim::Archive(book.getPath()).getIllustrationSizes() ) {
+        illustrations.push_back(kainjow::mustache::object{
+          {"icon_width", to_string(illustration_size)},
+          {"icon_height", to_string(illustration_size)},
+          {"icon_scale", "1"},
+        });
+      }
+    }
+    return illustrations;
+}
 
 BookData getBookData(const Library* library, const std::vector<std::string>& bookIds)
 {
@@ -78,6 +94,7 @@ BookData getBookData(const Library* library, const std::vector<std::string>& boo
       {"publisher_name", book.getPublisher()},
       {"url", bookUrl},
       {"size", to_string(book.getSize())},
+      {"icons", getBookIllustrationInfo(book)},
     });
   }
 

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -134,7 +134,7 @@ Entry Reader::getMainPage() const
 
 bool Reader::getFavicon(string& content, string& mimeType) const
 {
-  return kiwix::getArchiveFavicon(*zimArchive, content, mimeType);
+  return kiwix::getArchiveFavicon(*zimArchive, 48, content, mimeType);
 }
 
 string Reader::getZimFilePath() const

--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -94,6 +94,16 @@ inline std::string normalizeRootUrl(std::string rootUrl)
   return rootUrl.empty() ? rootUrl : "/" + rootUrl;
 }
 
+unsigned parseIllustration(const std::string& s)
+{
+  int nw(0), nh(0), nEnd(0);
+  long int w(-1), h(-1);
+  if ( sscanf(s.c_str(), "Illustration_%n%ldx%n%ld@1%n)", &nw, &w, &nh, &h, &nEnd) == 2
+     && nEnd == (int)s.size() && !isspace(s[nw]) && !isspace(s[nh]) && w == h && w >= 0) {
+    return w;
+  }
+  return 0;
+}
 } // unnamed namespace
 
 static IdNameMapper defaultNameMapper;
@@ -408,7 +418,9 @@ std::unique_ptr<Response> InternalServer::handle_meta(const RequestContext& requ
   } else if (meta_name == "publisher") {
     content = getMetaPublisher(*archive);
   } else if (meta_name == "favicon") {
-    getArchiveFavicon(*archive, content, mimeType);
+    getArchiveFavicon(*archive, 48, content, mimeType);
+  } else if (const unsigned illustrationSize = parseIllustration(meta_name)) {
+    getArchiveFavicon(*archive, illustrationSize, content, mimeType);
   } else {
     return Response::build_404(*this, request, bookName, "");
   }

--- a/src/tools/archiveTools.cpp
+++ b/src/tools/archiveTools.cpp
@@ -97,10 +97,10 @@ std::string getArchiveId(const zim::Archive& archive) {
   return (std::string) archive.getUuid();
 }
 
-bool getArchiveFavicon(const zim::Archive& archive,
+bool getArchiveFavicon(const zim::Archive& archive, unsigned size,
                            std::string& content, std::string& mimeType){
   try {
-    auto item = archive.getIllustrationItem();
+    auto item = archive.getIllustrationItem(size);
     content = item.getData();
     mimeType = item.getMimetype();
     return true;

--- a/src/tools/archiveTools.h
+++ b/src/tools/archiveTools.h
@@ -42,7 +42,7 @@ namespace kiwix
     std::string getMetaFlavour(const zim::Archive& archive);
     std::string getArchiveId(const zim::Archive& archive);
 
-    bool getArchiveFavicon(const zim::Archive& archive,
+    bool getArchiveFavicon(const zim::Archive& archive, unsigned size,
                            std::string& content, std::string& mimeType);
 
     unsigned int getArchiveMediaCount(const zim::Archive& archive);

--- a/static/templates/catalog_entries.xml
+++ b/static/templates/catalog_entries.xml
@@ -22,7 +22,11 @@
     <tags>{{tags}}</tags>
     <articleCount>{{article_count}}</articleCount>
     <mediaCount>{{media_count}}</mediaCount>
-    <icon>/meta?name=favicon&amp;content={{{content_id}}}</icon>
+    {{#icons}}
+    <link rel="http://opds-spec.org/image/thumbnail"
+          href="/meta?name=Illustration_{{icon_width}}x{{icon_height}}@{{icon_scale}}&amp;content={{{content_id}}}"
+          type="image/png;width={{icon_width}};height={{icon_height}};scale={{icon_scale}}"/>
+    {{/icons}}
     <link type="text/html" href="/{{{content_id}}}" />
     <author>
       <name>{{author_name}}</name>

--- a/static/templates/catalog_v2_entries.xml
+++ b/static/templates/catalog_v2_entries.xml
@@ -34,7 +34,11 @@
     <tags>{{tags}}</tags>
     <articleCount>{{article_count}}</articleCount>
     <mediaCount>{{media_count}}</mediaCount>
-    <icon>/meta?name=favicon&amp;content={{{content_id}}}</icon>
+    {{#icons}}
+    <link rel="http://opds-spec.org/image/thumbnail"
+          href="/meta?name=Illustration_{{icon_width}}x{{icon_height}}@{{icon_scale}}&amp;content={{{content_id}}}"
+          type="image/png;width={{icon_width}};height={{icon_height}};scale={{icon_scale}}"/>
+    {{/icons}}
     <link type="text/html" href="/{{{content_id}}}" />
     <author>
       <name>{{author_name}}</name>

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -626,7 +626,9 @@ std::string maskVariableOPDSFeedData(std::string s)
     "    <tags>unittest;wikipedia;_category:jazz;_pictures:no;_videos:no;_details:no;_ftindex:yes</tags>\n" \
     "    <articleCount>284</articleCount>\n"                            \
     "    <mediaCount>2</mediaCount>\n"                                  \
-    "    <icon>/meta?name=favicon&amp;content=zimfile</icon>\n"         \
+    "    <link rel=\"http://opds-spec.org/image/thumbnail\"\n"          \
+    "          href=\"/meta?name=Illustration_48x48@1&amp;content=zimfile\"\n" \
+    "          type=\"image/png;width=48;height=48;scale=1\"/>\n"               \
     "    <link type=\"text/html\" href=\"/zimfile\" />\n"               \
     "    <author>\n"                                                    \
     "      <name>Wikipedia</name>\n"                                    \
@@ -650,7 +652,9 @@ std::string maskVariableOPDSFeedData(std::string s)
     "    <tags>unittest;wikipedia;_category:wikipedia;_pictures:no;_videos:no;_details:no;_ftindex:yes</tags>\n" \
     "    <articleCount>284</articleCount>\n"                            \
     "    <mediaCount>2</mediaCount>\n"                                  \
-    "    <icon>/meta?name=favicon&amp;content=zimfile</icon>\n"         \
+    "    <link rel=\"http://opds-spec.org/image/thumbnail\"\n"          \
+    "          href=\"/meta?name=Illustration_48x48@1&amp;content=zimfile\"\n" \
+    "          type=\"image/png;width=48;height=48;scale=1\"/>\n"               \
     "    <link type=\"text/html\" href=\"/zimfile\" />\n"               \
     "    <author>\n"                                                    \
     "      <name>Wikipedia</name>\n"                                    \
@@ -674,7 +678,9 @@ std::string maskVariableOPDSFeedData(std::string s)
     "    <tags>unittest;wikipedia;_pictures:no;_videos:no;_details:no</tags>\n" \
     "    <articleCount>284</articleCount>\n"                            \
     "    <mediaCount>2</mediaCount>\n"                                  \
-    "    <icon>/meta?name=favicon&amp;content=zimfile</icon>\n"         \
+    "    <link rel=\"http://opds-spec.org/image/thumbnail\"\n"          \
+    "          href=\"/meta?name=Illustration_48x48@1&amp;content=zimfile\"\n" \
+    "          type=\"image/png;width=48;height=48;scale=1\"/>\n"               \
     "    <link type=\"text/html\" href=\"/zimfile\" />\n"               \
     "    <author>\n"                                                    \
     "      <name>Wikipedia</name>\n"                                    \

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -197,6 +197,7 @@ const ResourceCollection resources200Uncompressible{
   { WITH_ETAG, "/meta?content=zimfile&name=creator" },
   { WITH_ETAG, "/meta?content=zimfile&name=publisher" },
   { WITH_ETAG, "/meta?content=zimfile&name=favicon" },
+  { WITH_ETAG, "/meta?content=zimfile&name=Illustration_48x48@1" },
 
   { WITH_ETAG, "/zimfile/I/m/Ray_Charles_classic_piano_pose.jpg" },
 


### PR DESCRIPTION
Fixes #533

Things to note:

- the output is modified in both old and new (v2) OPDS API
- the code is not tested on a ZIM file with multiple illustrations for the lack of such a ZIM file