### PR TITLE
Fix method call for new libzim API.

### DIFF
--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -591,7 +591,7 @@ std::unique_ptr<Response> InternalServer::handle_search(const RequestContext& re
         if (! searcher) {
           searcher = std::make_shared<zim::Searcher>(*currentArchive);
         } else {
-          searcher->add_archive(*currentArchive);
+          searcher->addArchive(*currentArchive);
         }
       }
     }


### PR DESCRIPTION
`add_archive` is now `addArchive`.

See openzim/libzim#627