### PR TITLE
Support for multiple illustrations in a Book

### DIFF
--- a/include/book.h
+++ b/include/book.h
@@ -74,8 +74,8 @@ class Book
   const uint64_t& getMediaCount() const { return m_mediaCount; }
   const uint64_t& getSize() const { return m_size; }
   const std::string& getFavicon() const;
-  const std::string& getFaviconUrl() const { return m_faviconUrl; }
-  const std::string& getFaviconMimeType() const { return m_faviconMimeType; }
+  const std::string& getFaviconUrl() const;
+  const std::string& getFaviconMimeType() const;
   const std::string& getDownloadId() const { return m_downloadId; }
 
   void setReadOnly(bool readOnly) { m_readOnly = readOnly; }

--- a/include/book.h
+++ b/include/book.h
@@ -96,8 +96,6 @@ class Book
   void setArticleCount(uint64_t articleCount) { m_articleCount = articleCount; }
   void setMediaCount(uint64_t mediaCount) { m_mediaCount = mediaCount; }
   void setSize(uint64_t size) { m_size = size; }
-  void setFavicon(const std::string& favicon) { m_favicon = favicon; }
-  void setFaviconMimeType(const std::string& faviconMimeType) { m_faviconMimeType = faviconMimeType; }
   void setDownloadId(const std::string& downloadId) { m_downloadId = downloadId; }
 
  private:

--- a/include/book.h
+++ b/include/book.h
@@ -142,7 +142,7 @@ class Book
   uint64_t m_mediaCount = 0;
   bool m_readOnly = false;
   uint64_t m_size = 0;
-  std::vector<std::shared_ptr<Illustration>> m_illustrations;
+  std::vector<std::shared_ptr<const Illustration>> m_illustrations;
 
   // Used as the return value of getDefaultIllustration() when no default
   // illustration is found in the book

--- a/include/book.h
+++ b/include/book.h
@@ -107,10 +107,12 @@ class Book
   void setSize(uint64_t size) { m_size = size; }
   void setDownloadId(const std::string& downloadId) { m_downloadId = downloadId; }
 
- private:
+ private: // functions
   std::string getCategoryFromTags() const;
+  const Illustration& getDefaultIllustration() const;
+  Illustration& getMutableDefaultIllustration();
 
- protected:
+ protected: // data
   std::string m_id;
   std::string m_downloadId;
   std::string m_path;

--- a/include/book.h
+++ b/include/book.h
@@ -21,6 +21,8 @@
 #define KIWIX_BOOK_H
 
 #include <string>
+#include <vector>
+#include <memory>
 
 namespace pugi {
 class xml_node;
@@ -139,7 +141,7 @@ class Book
   uint64_t m_mediaCount = 0;
   bool m_readOnly = false;
   uint64_t m_size = 0;
-  Illustration m_illustration;
+  std::vector<std::shared_ptr<Illustration>> m_illustrations;
 };
 
 }

--- a/include/book.h
+++ b/include/book.h
@@ -48,6 +48,8 @@ class Book
   {
     friend class Book;
    public:
+    uint16_t width = 48;
+    uint16_t height = 48;
     std::string mimeType;
     std::string url;
 

--- a/include/book.h
+++ b/include/book.h
@@ -120,7 +120,6 @@ class Book
  private: // functions
   std::string getCategoryFromTags() const;
   const Illustration& getDefaultIllustration() const;
-  Illustration& getMutableDefaultIllustration();
 
  protected: // data
   std::string m_id;

--- a/include/book.h
+++ b/include/book.h
@@ -59,6 +59,8 @@ class Book
     mutable std::string data;
   };
 
+  typedef std::vector<std::shared_ptr<const Illustration>> Illustrations;
+
  public: // functions
   Book();
   ~Book();
@@ -94,6 +96,8 @@ class Book
   const std::string& getFavicon() const;
   const std::string& getFaviconUrl() const;
   const std::string& getFaviconMimeType() const;
+
+  Illustrations getIllustrations() const;
 
   const std::string& getDownloadId() const { return m_downloadId; }
 
@@ -142,7 +146,7 @@ class Book
   uint64_t m_mediaCount = 0;
   bool m_readOnly = false;
   uint64_t m_size = 0;
-  std::vector<std::shared_ptr<const Illustration>> m_illustrations;
+  Illustrations m_illustrations;
 
   // Used as the return value of getDefaultIllustration() when no default
   // illustration is found in the book

--- a/include/book.h
+++ b/include/book.h
@@ -23,6 +23,7 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include <mutex>
 
 namespace pugi {
 class xml_node;
@@ -57,6 +58,7 @@ class Book
 
    private:
     mutable std::string data;
+    mutable std::mutex mutex;
   };
 
   typedef std::vector<std::shared_ptr<const Illustration>> Illustrations;

--- a/include/book.h
+++ b/include/book.h
@@ -41,7 +41,15 @@ class Reader;
  */
 class Book
 {
- public:
+ public: // types
+  struct Illustration
+  {
+    std::string mimeType;
+    std::string url;
+    mutable std::string data;
+  };
+
+ public: // functions
   Book();
   ~Book();
 
@@ -76,6 +84,7 @@ class Book
   const std::string& getFavicon() const;
   const std::string& getFaviconUrl() const;
   const std::string& getFaviconMimeType() const;
+
   const std::string& getDownloadId() const { return m_downloadId; }
 
   void setReadOnly(bool readOnly) { m_readOnly = readOnly; }
@@ -122,9 +131,7 @@ class Book
   uint64_t m_mediaCount = 0;
   bool m_readOnly = false;
   uint64_t m_size = 0;
-  mutable std::string m_favicon;
-  std::string m_faviconUrl;
-  std::string m_faviconMimeType;
+  Illustration m_illustration;
 };
 
 }

--- a/include/book.h
+++ b/include/book.h
@@ -143,6 +143,10 @@ class Book
   bool m_readOnly = false;
   uint64_t m_size = 0;
   std::vector<std::shared_ptr<Illustration>> m_illustrations;
+
+  // Used as the return value of getDefaultIllustration() when no default
+  // illustration is found in the book
+  static const Illustration missingDefaultIllustration;
 };
 
 }

--- a/include/book.h
+++ b/include/book.h
@@ -42,10 +42,16 @@ class Reader;
 class Book
 {
  public: // types
-  struct Illustration
+  class Illustration
   {
+    friend class Book;
+   public:
     std::string mimeType;
     std::string url;
+
+    const std::string& getData() const;
+
+   private:
     mutable std::string data;
   };
 

--- a/src/book.cpp
+++ b/src/book.cpp
@@ -108,9 +108,16 @@ void Book::update(const zim::Archive& archive) {
   m_mediaCount = getArchiveMediaCount(archive);
   m_size = static_cast<uint64_t>(getArchiveFileSize(archive)) << 10;
 
-  Illustration& favicon = getMutableDefaultIllustration();
-  getArchiveFavicon(archive, 48, favicon.data, favicon.mimeType);
-  // XXX: isn't favicon.url neglected here?
+  m_illustrations.clear();
+  for ( const auto illustrationSize : archive.getIllustrationSizes() ) {
+    const auto illustration = std::make_shared<Illustration>();
+    const zim::Item illustrationItem = archive.getIllustrationItem(illustrationSize);
+    illustration->width = illustration->height = illustrationSize;
+    illustration->mimeType = illustrationItem.getMimetype();
+    illustration->data = illustrationItem.getData();
+    // NOTE: illustration->url is left uninitialized
+    m_illustrations.push_back(illustration);
+  }
 }
 
 #define ATTR(name) node.attribute(name).value()

--- a/src/book.cpp
+++ b/src/book.cpp
@@ -104,6 +104,7 @@ void Book::update(const zim::Archive& archive) {
 
   Illustration& favicon = getMutableDefaultIllustration();
   getArchiveFavicon(archive, 48, favicon.data, favicon.mimeType);
+  // XXX: isn't favicon.url neglected here?
 }
 
 #define ATTR(name) node.attribute(name).value()
@@ -182,6 +183,7 @@ void Book::updateFromOpds(const pugi::xml_node& node, const std::string& urlHost
     }
     if (rel == "http://opds-spec.org/image/thumbnail") {
       Illustration& favicon = getMutableDefaultIllustration();
+      // XXX: shouldn't favicon.data be cleared()?
       favicon.url = urlHost + linkNode.attribute("href").value();
       favicon.mimeType = linkNode.attribute("type").value();
     }

--- a/src/book.cpp
+++ b/src/book.cpp
@@ -55,27 +55,7 @@ bool Book::update(const kiwix::Book& other)
   if (m_id != other.m_id)
     return false;
 
-  m_readOnly = other.m_readOnly;
-  m_path = other.m_path;
-  m_pathValid = other.m_pathValid;
-  m_title = other.m_title;
-  m_description = other.m_description;
-  m_language = other.m_language;
-  m_creator = other.m_creator;
-  m_publisher = other.m_publisher;
-  m_date = other.m_date;
-  m_url = other.m_url;
-  m_name = other.m_name;
-  m_flavour = other.m_flavour;
-  m_tags = other.m_tags;
-  m_category = other.m_category;
-  m_origId = other.m_origId;
-  m_articleCount = other.m_articleCount;
-  m_mediaCount = other.m_mediaCount;
-  m_size = other.m_size;
-  m_illustrations = other.m_illustrations;
-  m_downloadId = other.m_downloadId;
-
+  *this = other;
   return true;
 }
 

--- a/src/book.cpp
+++ b/src/book.cpp
@@ -73,11 +73,7 @@ bool Book::update(const kiwix::Book& other)
   m_articleCount = other.m_articleCount;
   m_mediaCount = other.m_mediaCount;
   m_size = other.m_size;
-  m_illustrations.clear();
-  for ( const auto& ill : other.m_illustrations ) {
-    m_illustrations.push_back(std::make_shared<Illustration>(*ill));
-  }
-
+  m_illustrations = other.m_illustrations;
   m_downloadId = other.m_downloadId;
 
   return true;

--- a/src/book.cpp
+++ b/src/book.cpp
@@ -40,8 +40,6 @@ Book::Book() :
   m_pathValid(false),
   m_readOnly(false)
 {
-  const auto illustration = std::make_shared<Illustration>();
-  m_illustrations.assign(1, illustration);
 }
 
 /* Destructor */
@@ -241,12 +239,6 @@ const Book::Illustration& Book::getDefaultIllustration() const
     }
   }
   throw std::runtime_error("No default illustration");
-}
-
-Book::Illustration& Book::getMutableDefaultIllustration()
-{
-  const Book* const const_this = this;
-  return const_cast<Illustration&>(const_this->getDefaultIllustration());
 }
 
 const std::string& Book::Illustration::getData() const

--- a/src/book.cpp
+++ b/src/book.cpp
@@ -231,6 +231,8 @@ void Book::setPath(const std::string& path)
    : path;
 }
 
+const Book::Illustration Book::missingDefaultIllustration;
+
 const Book::Illustration& Book::getDefaultIllustration() const
 {
   for ( const auto& ilPtr : m_illustrations ) {
@@ -238,7 +240,7 @@ const Book::Illustration& Book::getDefaultIllustration() const
       return *ilPtr;
     }
   }
-  throw std::runtime_error("No default illustration");
+  return missingDefaultIllustration;
 }
 
 const std::string& Book::Illustration::getData() const

--- a/src/book.cpp
+++ b/src/book.cpp
@@ -47,6 +47,11 @@ Book::~Book()
 {
 }
 
+Book::Illustrations Book::getIllustrations() const
+{
+  return m_illustrations;
+}
+
 bool Book::update(const kiwix::Book& other)
 {
   if (m_readOnly)

--- a/src/book.cpp
+++ b/src/book.cpp
@@ -40,7 +40,10 @@ Book::Book() :
   m_pathValid(false),
   m_readOnly(false)
 {
+  const auto illustration = std::make_shared<Illustration>();
+  m_illustrations.assign(1, illustration);
 }
+
 /* Destructor */
 Book::~Book()
 {
@@ -72,7 +75,10 @@ bool Book::update(const kiwix::Book& other)
   m_articleCount = other.m_articleCount;
   m_mediaCount = other.m_mediaCount;
   m_size = other.m_size;
-  m_illustration = other.m_illustration;
+  m_illustrations.clear();
+  for ( const auto& ill : other.m_illustrations ) {
+    m_illustrations.push_back(std::make_shared<Illustration>(*ill));
+  }
 
   m_downloadId = other.m_downloadId;
 
@@ -220,12 +226,14 @@ void Book::setPath(const std::string& path)
 
 const Book::Illustration& Book::getDefaultIllustration() const
 {
-  return m_illustration;
+  assert(m_illustrations.size() == 1);
+  return *m_illustrations.front();
 }
 
 Book::Illustration& Book::getMutableDefaultIllustration()
 {
-  return m_illustration;
+  const Book* const const_this = this;
+  return const_cast<Illustration&>(const_this->getDefaultIllustration());
 }
 
 const std::string& Book::Illustration::getData() const

--- a/src/book.cpp
+++ b/src/book.cpp
@@ -227,10 +227,13 @@ const Book::Illustration& Book::getDefaultIllustration() const
 const std::string& Book::Illustration::getData() const
 {
   if (data.empty() && !url.empty()) {
-    try {
-      data = download(url);
-    } catch(...) {
-      std::cerr << "Cannot download favicon from " << url;
+    const std::lock_guard<std::mutex> l(mutex);
+    if ( data.empty() ) {
+      try {
+        data = download(url);
+      } catch(...) {
+        std::cerr << "Cannot download favicon from " << url;
+      }
     }
   }
   return data;

--- a/src/book.cpp
+++ b/src/book.cpp
@@ -72,9 +72,7 @@ bool Book::update(const kiwix::Book& other)
   m_articleCount = other.m_articleCount;
   m_mediaCount = other.m_mediaCount;
   m_size = other.m_size;
-  m_favicon = other.m_favicon;
-  m_faviconMimeType = other.m_faviconMimeType;
-  m_faviconUrl = other.m_faviconUrl;
+  m_illustration = other.m_illustration;
 
   m_downloadId = other.m_downloadId;
 
@@ -104,7 +102,7 @@ void Book::update(const zim::Archive& archive) {
   m_mediaCount = getArchiveMediaCount(archive);
   m_size = static_cast<uint64_t>(getArchiveFileSize(archive)) << 10;
 
-  getArchiveFavicon(archive, 48, m_favicon, m_faviconMimeType);
+  getArchiveFavicon(archive, 48, m_illustration.data, m_illustration.mimeType);
 }
 
 #define ATTR(name) node.attribute(name).value()
@@ -131,9 +129,9 @@ void Book::updateFromXml(const pugi::xml_node& node, const std::string& baseDir)
   m_articleCount = strtoull(ATTR("articleCount"), 0, 0);
   m_mediaCount = strtoull(ATTR("mediaCount"), 0, 0);
   m_size = strtoull(ATTR("size"), 0, 0) << 10;
-  m_favicon = base64_decode(ATTR("favicon"));
-  m_faviconMimeType = ATTR("faviconMimeType");
-  m_faviconUrl = ATTR("faviconUrl");
+  m_illustration.data = base64_decode(ATTR("favicon"));
+  m_illustration.mimeType = ATTR("faviconMimeType");
+  m_illustration.url = ATTR("faviconUrl");
   try {
     m_downloadId = ATTR("downloadId");
   } catch(...) {}
@@ -181,8 +179,8 @@ void Book::updateFromOpds(const pugi::xml_node& node, const std::string& urlHost
       m_size = strtoull(linkNode.attribute("length").value(), 0, 0);
     }
     if (rel == "http://opds-spec.org/image/thumbnail") {
-      m_faviconUrl = urlHost + linkNode.attribute("href").value();
-      m_faviconMimeType = linkNode.attribute("type").value();
+      m_illustration.url = urlHost + linkNode.attribute("href").value();
+      m_illustration.mimeType = linkNode.attribute("type").value();
     }
  }
 
@@ -216,24 +214,24 @@ void Book::setPath(const std::string& path)
 }
 
 const std::string& Book::getFavicon() const {
-  if (m_favicon.empty() && !m_faviconUrl.empty()) {
+  if (m_illustration.data.empty() && !m_illustration.url.empty()) {
     try {
-      m_favicon = download(m_faviconUrl);
+      m_illustration.data = download(m_illustration.url);
     } catch(...) {
-      std::cerr << "Cannot download favicon from " << m_faviconUrl;
+      std::cerr << "Cannot download favicon from " << m_illustration.url;
     }
   }
-  return m_favicon;
+  return m_illustration.data;
 }
 
 const std::string& Book::getFaviconUrl() const
 {
-  return m_faviconUrl;
+  return m_illustration.url;
 }
 
 const std::string& Book::getFaviconMimeType() const
 {
-  return m_faviconMimeType;
+  return m_illustration.mimeType;
 }
 
 std::string Book::getTagStr(const std::string& tagName) const {

--- a/src/book.cpp
+++ b/src/book.cpp
@@ -226,16 +226,20 @@ Book::Illustration& Book::getMutableDefaultIllustration()
   return m_illustration;
 }
 
-const std::string& Book::getFavicon() const {
-  const Illustration& favicon = getDefaultIllustration();
-  if (favicon.data.empty() && !favicon.url.empty()) {
+const std::string& Book::Illustration::getData() const
+{
+  if (data.empty() && !url.empty()) {
     try {
-      favicon.data = download(favicon.url);
+      data = download(url);
     } catch(...) {
-      std::cerr << "Cannot download favicon from " << favicon.url;
+      std::cerr << "Cannot download favicon from " << url;
     }
   }
-  return favicon.data;
+  return data;
+}
+
+const std::string& Book::getFavicon() const {
+  return getDefaultIllustration().getData();
 }
 
 const std::string& Book::getFaviconUrl() const

--- a/src/book.cpp
+++ b/src/book.cpp
@@ -226,6 +226,16 @@ const std::string& Book::getFavicon() const {
   return m_favicon;
 }
 
+const std::string& Book::getFaviconUrl() const
+{
+  return m_faviconUrl;
+}
+
+const std::string& Book::getFaviconMimeType() const
+{
+  return m_faviconMimeType;
+}
+
 std::string Book::getTagStr(const std::string& tagName) const {
   return getTagValueFromTagList(convertTags(m_tags), tagName);
 }

--- a/src/book.cpp
+++ b/src/book.cpp
@@ -144,10 +144,11 @@ void Book::updateFromXml(const pugi::xml_node& node, const std::string& baseDir)
   m_articleCount = strtoull(ATTR("articleCount"), 0, 0);
   m_mediaCount = strtoull(ATTR("mediaCount"), 0, 0);
   m_size = strtoull(ATTR("size"), 0, 0) << 10;
-  Illustration& favicon = getMutableDefaultIllustration();
-  favicon.data = base64_decode(ATTR("favicon"));
-  favicon.mimeType = ATTR("faviconMimeType");
-  favicon.url = ATTR("faviconUrl");
+  const auto favicon = std::make_shared<Illustration>();
+  favicon->data = base64_decode(ATTR("favicon"));
+  favicon->mimeType = ATTR("faviconMimeType");
+  favicon->url = ATTR("faviconUrl");
+  m_illustrations.assign(1, favicon);
   try {
     m_downloadId = ATTR("downloadId");
   } catch(...) {}

--- a/src/book.cpp
+++ b/src/book.cpp
@@ -226,8 +226,12 @@ void Book::setPath(const std::string& path)
 
 const Book::Illustration& Book::getDefaultIllustration() const
 {
-  assert(m_illustrations.size() == 1);
-  return *m_illustrations.front();
+  for ( const auto& ilPtr : m_illustrations ) {
+    if (ilPtr->width == 48 && ilPtr->height == 48) {
+      return *ilPtr;
+    }
+  }
+  throw std::runtime_error("No default illustration");
 }
 
 Book::Illustration& Book::getMutableDefaultIllustration()

--- a/src/book.cpp
+++ b/src/book.cpp
@@ -196,10 +196,11 @@ void Book::updateFromOpds(const pugi::xml_node& node, const std::string& urlHost
       m_size = strtoull(linkNode.attribute("length").value(), 0, 0);
     }
     if (rel == "http://opds-spec.org/image/thumbnail") {
-      Illustration& favicon = getMutableDefaultIllustration();
-      // XXX: shouldn't favicon.data be cleared()?
-      favicon.url = urlHost + linkNode.attribute("href").value();
-      favicon.mimeType = linkNode.attribute("type").value();
+      const auto favicon = std::make_shared<Illustration>();
+      favicon->data.clear();
+      favicon->url = urlHost + linkNode.attribute("href").value();
+      favicon->mimeType = linkNode.attribute("type").value();
+      m_illustrations.assign(1, favicon);
     }
  }
 

--- a/src/opds_dumper.cpp
+++ b/src/opds_dumper.cpp
@@ -58,10 +58,10 @@ IllustrationInfo getBookIllustrationInfo(const Book& book)
 {
     kainjow::mustache::list illustrations;
     if ( book.isPathValid() ) {
-      for ( auto illustration_size : zim::Archive(book.getPath()).getIllustrationSizes() ) {
+      for ( const auto& illustration : book.getIllustrations() ) {
         illustrations.push_back(kainjow::mustache::object{
-          {"icon_width", to_string(illustration_size)},
-          {"icon_height", to_string(illustration_size)},
+          {"icon_width", to_string(illustration->width)},
+          {"icon_height", to_string(illustration->height)},
           {"icon_scale", "1"},
         });
       }

--- a/test/book.cpp
+++ b/test/book.cpp
@@ -68,6 +68,9 @@ TEST(BookTest, updateFromXMLTest)
             articleCount="123456"
             mediaCount="234567"
             size="345678"
+            favicon="ZmFrZS1ib29rLWZhdmljb24tZGF0YQ=="
+            faviconMimeType="text/plain"
+            faviconUrl="http://who.org/zara.fav"
           >
       </book>
     )");
@@ -85,6 +88,9 @@ TEST(BookTest, updateFromXMLTest)
     EXPECT_EQ(book.getArticleCount(), 123456U);
     EXPECT_EQ(book.getMediaCount(), 234567U);
     EXPECT_EQ(book.getSize(), 345678U*1024U);
+    EXPECT_EQ(book.getFavicon(), "fake-book-favicon-data");
+    EXPECT_EQ(book.getFaviconMimeType(), "text/plain");
+    EXPECT_EQ(book.getFaviconUrl(), "http://who.org/zara.fav");
 }
 
 TEST(BookTest, updateFromXMLCategoryHandlingTest)

--- a/test/book.cpp
+++ b/test/book.cpp
@@ -2,42 +2,6 @@
 #include "../include/book.h"
 #include <pugixml.hpp>
 
-TEST(BookTest, updateTest)
-{
-    kiwix::Book book;
-
-    book.setId("xyz");
-    book.setReadOnly(false);
-    book.setPath("/home/user/Downloads/skin-of-color-society_en_all_2019-11.zim");
-    book.setPathValid(true);
-    book.setUrl("book-url");
-    book.setTags("youtube;_videos:yes;_ftindex:yes;_ftindex:yes;_pictures:yes;_details:yes");
-    book.setName("skin-of-color-society_en_all");
-    book.setFavicon("book-favicon");
-    book.setFaviconMimeType("book-favicon-mimetype");
-
-    kiwix::Book newBook;
-
-    newBook.setReadOnly(true);
-    EXPECT_FALSE(newBook.update(book));
-
-    newBook.setReadOnly(false);
-    EXPECT_FALSE(newBook.update(book));
-
-    newBook.setId("xyz");
-    EXPECT_TRUE(newBook.update(book));
-
-    EXPECT_EQ(newBook.readOnly(), book.readOnly());
-    EXPECT_EQ(newBook.getPath(), book.getPath());
-    EXPECT_EQ(newBook.isPathValid(), book.isPathValid());
-    EXPECT_EQ(newBook.getUrl(), book.getUrl());
-    EXPECT_EQ(newBook.getTags(), book.getTags());
-    EXPECT_EQ(newBook.getCategory(), book.getCategory());
-    EXPECT_EQ(newBook.getName(), book.getName());
-    EXPECT_EQ(newBook.getFavicon(), book.getFavicon());
-    EXPECT_EQ(newBook.getFaviconMimeType(), book.getFaviconMimeType());
-}
-
 namespace
 {
 
@@ -171,4 +135,40 @@ TEST(BookTest, updateCopiesCategory)
     EXPECT_EQ(newBook.getCategory(), "");
     newBook.update(book);
     EXPECT_EQ(newBook.getCategory(), "ted");
+}
+
+TEST(BookTest, updateTest)
+{
+    kiwix::Book book;
+
+    book.setId("xyz");
+    book.setReadOnly(false);
+    book.setPath("/home/user/Downloads/skin-of-color-society_en_all_2019-11.zim");
+    book.setPathValid(true);
+    book.setUrl("book-url");
+    book.setTags("youtube;_videos:yes;_ftindex:yes;_ftindex:yes;_pictures:yes;_details:yes");
+    book.setName("skin-of-color-society_en_all");
+    book.setFavicon("book-favicon");
+    book.setFaviconMimeType("book-favicon-mimetype");
+
+    kiwix::Book newBook;
+
+    newBook.setReadOnly(true);
+    EXPECT_FALSE(newBook.update(book));
+
+    newBook.setReadOnly(false);
+    EXPECT_FALSE(newBook.update(book));
+
+    newBook.setId("xyz");
+    EXPECT_TRUE(newBook.update(book));
+
+    EXPECT_EQ(newBook.readOnly(), book.readOnly());
+    EXPECT_EQ(newBook.getPath(), book.getPath());
+    EXPECT_EQ(newBook.isPathValid(), book.isPathValid());
+    EXPECT_EQ(newBook.getUrl(), book.getUrl());
+    EXPECT_EQ(newBook.getTags(), book.getTags());
+    EXPECT_EQ(newBook.getCategory(), book.getCategory());
+    EXPECT_EQ(newBook.getName(), book.getName());
+    EXPECT_EQ(newBook.getFavicon(), book.getFavicon());
+    EXPECT_EQ(newBook.getFaviconMimeType(), book.getFaviconMimeType());
 }

--- a/test/book.cpp
+++ b/test/book.cpp
@@ -139,17 +139,23 @@ TEST(BookTest, updateCopiesCategory)
 
 TEST(BookTest, updateTest)
 {
-    kiwix::Book book;
+    const XMLDoc xml(R"(
+      <book id="xyz"
+            path="/home/user/Downloads/skin-of-color-society_en_all_2019-11.zim"
+            url="book-url"
+            name="skin-of-color-society_en_all"
+            tags="youtube;_videos:yes;_ftindex:yes;_ftindex:yes;_pictures:yes;_details:yes"
+            favicon="Ym9vay1mYXZpY29u"
+            faviconMimeType="book-favicon-mimetype"
+          >
+      </book>
+    )");
 
-    book.setId("xyz");
+    kiwix::Book book;
+    book.updateFromXml(xml.child("book"), "/data/zim");
+
     book.setReadOnly(false);
-    book.setPath("/home/user/Downloads/skin-of-color-society_en_all_2019-11.zim");
     book.setPathValid(true);
-    book.setUrl("book-url");
-    book.setTags("youtube;_videos:yes;_ftindex:yes;_ftindex:yes;_pictures:yes;_details:yes");
-    book.setName("skin-of-color-society_en_all");
-    book.setFavicon("book-favicon");
-    book.setFaviconMimeType("book-favicon-mimetype");
 
     kiwix::Book newBook;
 


### PR DESCRIPTION
Fixes #625.

Note that this fix only adds support for multiple illustrations inside the `kiwix::Book` class, **without** enhancing the library format. As a result, ZIM files with multiple illustrations will not appear as such in the OPDS output if the kiwix server is started with a trusted library.

