### PR TITLE
Searcher::add_reader() rejects duplicate readers

### DIFF
--- a/src/searcher.cpp
+++ b/src/searcher.cpp
@@ -94,6 +94,12 @@ bool Searcher::add_reader(Reader* reader)
   if (!reader->hasFulltextIndex()) {
       return false;
   }
+
+  for ( const Reader* const existing_reader : readers ) {
+    if ( existing_reader->getZimFilePath() == reader->getZimFilePath() )
+      return false;
+  }
+
   this->readers.push_back(reader);
   return true;
 }

--- a/src/searcher.cpp
+++ b/src/searcher.cpp
@@ -96,7 +96,7 @@ bool Searcher::add_reader(Reader* reader)
   }
 
   for ( const Reader* const existing_reader : readers ) {
-    if ( existing_reader->getZimFilePath() == reader->getZimFilePath() )
+    if ( existing_reader->getZimArchive()->getUuid() == reader->getZimArchive()->getUuid() )
       return false;
   }
 

--- a/test/searcher.cpp
+++ b/test/searcher.cpp
@@ -14,9 +14,7 @@ TEST(Searcher, add_reader) {
   ASSERT_TRUE (searcher.add_reader(&reader1));
   ASSERT_FALSE(searcher.add_reader(&reader1));
   ASSERT_FALSE(searcher.add_reader(&reader2));
-
-  // equivalence of resolved paths is not checked by Searcher::add_reader
-  ASSERT_TRUE(searcher.add_reader(&reader3));
+  ASSERT_FALSE(searcher.add_reader(&reader3));
 }
 
 TEST(Searcher, search) {

--- a/test/searcher.cpp
+++ b/test/searcher.cpp
@@ -5,6 +5,20 @@
 namespace kiwix
 {
 
+TEST(Searcher, add_reader) {
+  Reader reader1("./test/example.zim");
+  Reader reader2("./test/example.zim");
+  Reader reader3("./test/../test/example.zim");
+
+  Searcher searcher;
+  ASSERT_TRUE (searcher.add_reader(&reader1));
+  ASSERT_FALSE(searcher.add_reader(&reader1));
+  ASSERT_FALSE(searcher.add_reader(&reader2));
+
+  // equivalence of resolved paths is not checked by Searcher::add_reader
+  ASSERT_TRUE(searcher.add_reader(&reader3));
+}
+
 TEST(Searcher, search) {
   Reader reader("./test/example.zim");
 


### PR DESCRIPTION
Fixes #108

The simplest solution relying on linear search among previously added readers is implemented on the assumption that `Searcher::add_reader()` will hardly be the bottleneck if we need to search in hundreds of ZIM files.