### PR TITLE
UrlEncode the `content_id`.

### DIFF
--- a/src/opds_dumper.cpp
+++ b/src/opds_dumper.cpp
@@ -81,7 +81,7 @@ kainjow::mustache::object getSingleBookData(const Book& book)
       {"title", book.getTitle()},
       {"description", book.getDescription()},
       {"language", book.getLanguage()},
-      {"content_id",  book.getHumanReadableIdFromPath()},
+      {"content_id",  urlEncode(book.getHumanReadableIdFromPath(), true)},
       {"updated", book.getDate() + "T00:00:00Z"},
       {"category", book.getCategory()},
       {"flavour", book.getFlavour()},

--- a/test/data/library.xml
+++ b/test/data/library.xml
@@ -35,8 +35,8 @@
       ></book>
   <book
         id="charlesray"
-        path="./zimfile.zim"
-        url="https://github.com/kiwix/libkiwix/raw/master/test/data/zimfile.zim"
+        path="./zimfile&amp;other.zim"
+        url="https://github.com/kiwix/libkiwix/raw/master/test/data/zimfile%26other.zim"
         title="Charles, Ray"
         description="Wikipedia articles about Ray Charles"
         language="fra"

--- a/test/data/zimfile&other.zim
+++ b/test/data/zimfile&other.zim
@@ -1,0 +1,1 @@
+zimfile.zim

--- a/test/meson.build
+++ b/test/meson.build
@@ -29,6 +29,7 @@ if gtest_dep.found() and not meson.is_cross_build()
     data_files = [
       'example.zim',
       'zimfile.zim',
+      'zimfile&other.zim',
       'corner_cases.zim',
       'library.xml'
     ]

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -701,14 +701,14 @@ std::string maskVariableOPDSFeedData(std::string s)
     "    <tags>unittest;wikipedia;_category:jazz;_pictures:no;_videos:no;_details:no;_ftindex:yes</tags>\n" \
     "    <articleCount>284</articleCount>\n"                            \
     "    <mediaCount>2</mediaCount>\n"                                  \
-    "    <link type=\"text/html\" href=\"/ROOT/zimfile\" />\n"               \
+    "    <link type=\"text/html\" href=\"/ROOT/zimfile%26other\" />\n"               \
     "    <author>\n"                                                    \
     "      <name>Wikipedia</name>\n"                                    \
     "    </author>\n"                                                   \
     "    <publisher>\n"                                                 \
     "      <name>Kiwix</name>\n"                                        \
     "    </publisher>\n"                                                \
-    "    <link rel=\"http://opds-spec.org/acquisition/open-access\" type=\"application/x-zim\" href=\"https://github.com/kiwix/libkiwix/raw/master/test/data/zimfile.zim\" length=\"569344\" />\n" \
+    "    <link rel=\"http://opds-spec.org/acquisition/open-access\" type=\"application/x-zim\" href=\"https://github.com/kiwix/libkiwix/raw/master/test/data/zimfile%26other.zim\" length=\"569344\" />\n" \
     "  </entry>\n"
 
 #define RAY_CHARLES_CATALOG_ENTRY \


### PR DESCRIPTION
The HumanReadableId can contains special char (`&`/`=`/...)
As it is used as to create a url in the opds template,
we must url encode it.

- We don't need to encode the book id as it is a uuid, it never contains
special char.
- We don't need to encode the book url as it is read from the library and
the url must already be correctly encoded in the library.xml.
(tests modified accordingly)

Fix #670 