### PR TITLE
Add a new private constructor not deprecated for Reader.

### DIFF
--- a/include/reader.h
+++ b/include/reader.h
@@ -94,7 +94,8 @@ class Reader
    *
    * @param archive The shared pointer to the Archive object.
    */
-  explicit DEPRECATED Reader(const std::shared_ptr<zim::Archive> archive);
+  explicit DEPRECATED Reader(const std::shared_ptr<zim::Archive> archive)
+   : Reader(archive, true) {};
 #ifndef _WIN32
   explicit DEPRECATED Reader(int fd);
   DEPRECATED Reader(int fd, zim::offset_type offset, zim::size_type size);
@@ -490,6 +491,15 @@ class Reader
 
  private:
   std::map<const std::string, unsigned int> parseCounterMetadata() const;
+
+  // Reader is deprecated, so we've marked the constructor as deprecated.
+  // But we still need to construct the reader (in our deprecated code)
+  // To avoid warning because we use deprecated function, we create a
+  // constructor not deprecated. The `bool marker` is unused, it sole purpose
+  // is to change the signature to have a different constructor.
+  // This one is not deprecated and we must use it in our private code.
+  Reader(const std::shared_ptr<zim::Archive> archive, bool marker);
+  friend class Library;
 };
 }
 

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -219,7 +219,7 @@ std::shared_ptr<Reader> Library::getReaderById(const std::string& id)
   if ( !archive )
     return nullptr;
 
-  const auto reader = make_shared<Reader>(archive);
+  const shared_ptr<Reader> reader(new Reader(archive, true));
   std::lock_guard<std::mutex> lock(m_mutex);
   m_readers[id] = reader;
   return reader;

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -52,7 +52,7 @@ Reader::Reader(const string zimFilePath)
   srand(time(nullptr));
 }
 
-Reader::Reader(const std::shared_ptr<zim::Archive> archive)
+Reader::Reader(const std::shared_ptr<zim::Archive> archive, bool _marker)
   : zimArchive(archive),
     zimFilePath(archive->getFilename())
   {}


### PR DESCRIPTION
As we still create a `Reader` in the deprecated code of `Library`,
we need a way to create a reader without raising a deprecated warning.
So we create a another constructor with a dummy argument and we use it.

The constructor is used in `Library::getReaderById`. It was used internally by `make_shared` which silently ignore the warning.
When compiling on Windows with cl, the warning is not ignored and so we have an error.