### PR TITLE
Do not include posix header on Windows

### DIFF
--- a/test/pathTools.cpp
+++ b/test/pathTools.cpp
@@ -20,8 +20,10 @@
 #include "gtest/gtest.h"
 #include <string>
 #include <vector>
-#include <unistd.h>
-#include <fcntl.h>
+#ifndef _WIN32
+# include <unistd.h>
+# include <fcntl.h>
+#endif
 #include "../include/tools.h"
 #include "../src/tools/pathTools.h"
 


### PR DESCRIPTION
They are included by 3dbcbe5 which need them to test permission rights on
posix only.