### PR TITLE
PPA: Fix libzim-dev dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Maintainer: Kiwix team <kiwix@kiwix.org>
 Build-Depends: debhelper-compat (= 13),
  meson,
  pkg-config,
- libzim-dev (>= 7.2.0),
+ libzim-dev (>= 7.2.0~),
  libcurl4-gnutls-dev,
  libicu-dev,
  libgtest-dev,
@@ -23,7 +23,7 @@ Section: libdevel
 Architecture: any
 Multi-Arch: same
 Depends: libkiwix10 (= ${binary:Version}), ${misc:Depends}, python3,
- libzim-dev (>= 7.2.0),
+ libzim-dev (>= 7.2.0~),
  libicu-dev,
  libpugixml-dev,
  libcurl4-gnutls-dev,


### PR DESCRIPTION
```
Our libzim packages are "7.2.0~focal" but the ~ means that "7.2.0" is greater than
"7.2.0~focal" so the dependency can't be satisfied. Depending on "7.2.0~" will
allow "7.2.0~focal" to satisfy the dependency.
```