### PR TITLE
Add mappings for languages not given by libicu

### DIFF
--- a/src/opds_dumper.cpp
+++ b/src/opds_dumper.cpp
@@ -127,43 +127,43 @@ BooksData getBooksData(const Library* library, const std::vector<std::string>& b
 }
 
 std::map<std::string, std::string> iso639_3 = {
-  {"atj","atikamekw"},
-  {"azb","آذربایجان دیلی"},
-  {"bcl","central bikol"},
-  {"bgs","tagabawa"},
-  {"bxr","буряад хэлэн"},
-  {"cbk","chavacano"},
-  {"cdo","閩東語"},
-  {"diq","dimli"},
-  {"dty","डोटेली"},
-  {"eml","emiliân-rumagnōl"},
-  {"fbs","српскохрватски"},
-  {"kbp","kabɩyɛ"},
-  {"kld","Gamilaraay"},
-  {"lbe","лакку маз"},
-  {"lbj","ལ་དྭགས་སྐད་"},
-  {"map","Austronesian"},
-  {"mhr","марий йылме"},
-  {"mnw","ဘာသာမန်"},
-  {"myn","mayan"},
-  {"nah","nahuatl"},
-  {"nai","north American Indian"},
-  {"nds","plattdütsch"},
-  {"nrm","bhasa narom"},
-  {"olo","livvi"},
-  {"pih","Pitcairn-Norfolk"},
-  {"pnb","Western Panjabi"},
-  {"rmr","Caló"},
-  {"rmy","romani shib"},
-  {"roa","romance languages"},
-  {"twi","twi"},
-  {"ido","ido"},
-  {"dag", "Dagbani"}
+  {"atj", "atikamekw"},
+  {"azb", "آذربایجان دیلی"},
+  {"bcl", "central bikol"},
+  {"bgs", "tagabawa"},
+  {"bxr", "буряад хэлэн"},
+  {"cbk", "chavacano"},
+  {"cdo", "閩東語"},
+  {"dag", "Dagbani"},
+  {"diq", "dimli"},
+  {"dty", "डोटेली"},
+  {"eml", "emiliân-rumagnōl"},
+  {"fbs", "српскохрватски"},
+  {"ido", "ido"},
+  {"kbp", "kabɩyɛ"},
+  {"kld", "Gamilaraay"},
+  {"lbe", "лакку маз"},
+  {"lbj", "ལ་དྭགས་སྐད་"},
+  {"map", "Austronesian"},
+  {"mhr", "марий йылме"},
+  {"mnw", "ဘာသာမန်"},
+  {"myn", "mayan"},
+  {"nah", "nahuatl"},
+  {"nai", "north American Indian"},
+  {"nds", "plattdütsch"},
+  {"nrm", "bhasa narom"},
+  {"olo", "livvi"},
+  {"pih", "Pitcairn-Norfolk"},
+  {"pnb", "Western Panjabi"},
+  {"rmr", "Caló"},
+  {"rmy", "romani shib"},
+  {"roa", "romance languages"},
+  {"twi", "twi"}
 };
 
 std::once_flag fillLanguagesFlag;
 
-void fillLanguagesMap() 
+void fillLanguagesMap()
 {
   for (auto icuLangPtr = icu::Locale::getISOLanguages(); *icuLangPtr != NULL; ++icuLangPtr) {
     auto lang = *icuLangPtr;

--- a/src/opds_dumper.cpp
+++ b/src/opds_dumper.cpp
@@ -157,7 +157,8 @@ std::map<std::string, std::string> iso639_3 = {
   {"rmy","romani shib"},
   {"roa","romance languages"},
   {"twi","twi"},
-  {"ido","ido"}
+  {"ido","ido"},
+  {"dag", "Dagbani"}
 };
 
 std::once_flag fillLanguagesFlag;

--- a/src/opds_dumper.cpp
+++ b/src/opds_dumper.cpp
@@ -126,13 +126,62 @@ BooksData getBooksData(const Library* library, const std::vector<std::string>& b
   return booksData;
 }
 
+std::map<std::string, std::string> iso639_3 = {
+  {"atj","atikamekw"},
+  {"azb","آذربایجان دیلی"},
+  {"bcl","central bikol"},
+  {"bgs","tagabawa"},
+  {"bxr","буряад хэлэн"},
+  {"cbk","chavacano"},
+  {"cdo","閩東語"},
+  {"diq","dimli"},
+  {"dty","डोटेली"},
+  {"eml","emiliân-rumagnōl"},
+  {"fbs","српскохрватски"},
+  {"kbp","kabɩyɛ"},
+  {"kld","Gamilaraay"},
+  {"lbe","лакку маз"},
+  {"lbj","ལ་དྭགས་སྐད་"},
+  {"map","Austronesian"},
+  {"mhr","марий йылме"},
+  {"mnw","ဘာသာမန်"},
+  {"myn","mayan"},
+  {"nah","nahuatl"},
+  {"nai","north American Indian"},
+  {"nds","plattdütsch"},
+  {"nrm","bhasa narom"},
+  {"olo","livvi"},
+  {"pih","Pitcairn-Norfolk"},
+  {"pnb","Western Panjabi"},
+  {"rmr","Caló"},
+  {"rmy","romani shib"},
+  {"roa","romance languages"},
+  {"twi","twi"},
+  {"ido","ido"}
+};
+
+std::once_flag fillLanguagesFlag;
+
+void fillLanguagesMap() 
+{
+  for (auto icuLangPtr = icu::Locale::getISOLanguages(); *icuLangPtr != NULL; ++icuLangPtr) {
+    auto lang = *icuLangPtr;
+    const icu::Locale locale(lang);
+    icu::UnicodeString ustring;
+    locale.getDisplayLanguage(locale, ustring);
+    std::string displayLanguage;
+    ustring.toUTF8String(displayLanguage);
+    std::string iso3LangCode = locale.getISO3Language();
+    iso639_3.insert({iso3LangCode, displayLanguage});
+  }
+}
+
 std::string getLanguageSelfName(const std::string& lang) {
-  const icu::Locale locale(lang.c_str());
-  icu::UnicodeString ustring;
-  locale.getDisplayLanguage(locale, ustring);
-  std::string result;
-  ustring.toUTF8String(result);
-  return result;
+  const auto itr = iso639_3.find(lang);
+  if (itr != iso639_3.end()) {
+    return itr->second;
+  }
+  return lang;
 };
 
 } // unnamed namespace
@@ -210,6 +259,7 @@ std::string OPDSDumper::languagesOPDSFeed() const
 {
   const auto now = gen_date_str();
   kainjow::mustache::list languageData;
+  std::call_once(fillLanguagesFlag, fillLanguagesMap);
   for ( const auto& langAndBookCount : library->getBooksLanguagesWithCounts() ) {
     const std::string languageCode = langAndBookCount.first;
     const int bookCount = langAndBookCount.second;

--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -146,7 +146,6 @@ bool InternalServer::start() {
   if (m_verbose.load())
     flags |= MHD_USE_DEBUG;
 
-
   struct sockaddr_in sockAddr;
   memset(&sockAddr, 0, sizeof(sockAddr));
   sockAddr.sin_family = AF_INET;


### PR DESCRIPTION
Fixes #611 

There are 7,893 languages under ISO 639-3. I could not find a mapping between lang code and native names (there's this [langCode vs english names](https://iso639-3.sil.org/sites/iso639-3/files/downloads/iso-639-3_Name_Index.tab) but we display native names).
Instead, this just adds the languages missed by libicu in library.kiwix.org. If this way is *approved*, I would like to ask:
* Should the map be rather moved to C++?