### PR TITLE
Fix search rendered for book title

### DIFF
--- a/include/search_renderer.h
+++ b/include/search_renderer.h
@@ -49,10 +49,24 @@ class SearchRenderer
   /**
    * Construct a SearchRenderer from a SearchResultSet.
    *
+   * The constructed version of the SearchRendered will not introduce
+   * the book name for each result. It is better to use the another constructor
+   * with a Library pointer to have a better html page.
+   *
    * @param srs The `SearchResultSet` to render.
    * @param mapper The `NameMapper` to use to do the rendering.
-   * @param library The `Library` to use to look up book details for search
-   *        results
+   * @param start The start offset used for the srs.
+   * @param estimatedResultCount The estimatedResultCount of the whole search
+   */
+  SearchRenderer(zim::SearchResultSet srs, NameMapper* mapper,
+                 unsigned int start, unsigned int estimatedResultCount);
+
+  /**
+   * Construct a SearchRenderer from a SearchResultSet.
+   *
+   * @param srs The `SearchResultSet` to render.
+   * @param mapper The `NameMapper` to use to do the rendering.
+   * @param library The `Library` to use to look up book details for search results.
    * @param start The start offset used for the srs.
    * @param estimatedResultCount The estimatedResultCount of the whole search
    */

--- a/include/search_renderer.h
+++ b/include/search_renderer.h
@@ -49,8 +49,8 @@ class SearchRenderer
   /**
    * Construct a SearchRenderer from a SearchResultSet.
    *
-   * The constructed version of the SearchRendered will not introduce
-   * the book name for each result. It is better to use the another constructor
+   * The constructed version of the SearchRenderer will not introduce
+   * the book name for each result. It is better to use the other constructor
    * with a Library pointer to have a better html page.
    *
    * @param srs The `SearchResultSet` to render.

--- a/src/search_renderer.cpp
+++ b/src/search_renderer.cpp
@@ -39,12 +39,12 @@ namespace kiwix
 
 /* Constructor */
 SearchRenderer::SearchRenderer(Searcher* searcher, NameMapper* mapper)
-    : m_srs(searcher->getSearchResultSet()),
-      mp_nameMapper(mapper),
-      protocolPrefix("zim://"),
-      searchProtocolPrefix("search://?"),
-      estimatedResultCount(searcher->getEstimatedResultCount()),
-      resultStart(searcher->getResultStart())
+    : SearchRenderer(
+        searcher->getSearchResultSet(),
+        mapper,
+        nullptr,
+        searcher->getEstimatedResultCount(),
+        searcher->getResultStart())
 {}
 
 SearchRenderer::SearchRenderer(zim::SearchResultSet srs, NameMapper* mapper,

--- a/src/search_renderer.cpp
+++ b/src/search_renderer.cpp
@@ -95,12 +95,11 @@ std::string SearchRenderer::getHtml()
     result.set("title", it.getTitle());
     result.set("url", it.getPath());
     result.set("snippet", it.getSnippet());
-    std::ostringstream s;
-    s << it.getZimId();
-    result.set("resultContentId", mp_nameMapper->getNameForId(s.str()));
+    std::string zim_id(it.getZimId());
+    result.set("resultContentId", mp_nameMapper->getNameForId(zim_id));
     std::shared_ptr<zim::Archive> archive;
     try {
-       result.set("bookTitle", mp_library->getBookById(s.str()).getTitle());
+      result.set("bookTitle", mp_library->getBookById(zim_id).getTitle());
     } catch (const std::out_of_range& e) {}
 
     if (it.getWordCount() >= 0) {

--- a/src/search_renderer.cpp
+++ b/src/search_renderer.cpp
@@ -98,9 +98,11 @@ std::string SearchRenderer::getHtml()
     std::string zim_id(it.getZimId());
     result.set("resultContentId", mp_nameMapper->getNameForId(zim_id));
     std::shared_ptr<zim::Archive> archive;
-    try {
+    if (!mp_library) {
+      result.set("bookTitle", kainjow::mustache::data(false));
+    } else {
       result.set("bookTitle", mp_library->getBookById(zim_id).getTitle());
-    } catch (const std::out_of_range& e) {}
+    }
 
     if (it.getWordCount() >= 0) {
       result.set("wordCount", kiwix::beautifyInteger(it.getWordCount()));

--- a/src/search_renderer.cpp
+++ b/src/search_renderer.cpp
@@ -47,6 +47,11 @@ SearchRenderer::SearchRenderer(Searcher* searcher, NameMapper* mapper)
       resultStart(searcher->getResultStart())
 {}
 
+SearchRenderer::SearchRenderer(zim::SearchResultSet srs, NameMapper* mapper,
+                      unsigned int start, unsigned int estimatedResultCount)
+    : SearchRenderer(srs, mapper, nullptr, start, estimatedResultCount)
+{}
+
 SearchRenderer::SearchRenderer(zim::SearchResultSet srs, NameMapper* mapper, Library* library,
                       unsigned int start, unsigned int estimatedResultCount)
     : m_srs(srs),

--- a/src/search_renderer.cpp
+++ b/src/search_renderer.cpp
@@ -97,7 +97,6 @@ std::string SearchRenderer::getHtml()
     result.set("snippet", it.getSnippet());
     std::string zim_id(it.getZimId());
     result.set("resultContentId", mp_nameMapper->getNameForId(zim_id));
-    std::shared_ptr<zim::Archive> archive;
     if (!mp_library) {
       result.set("bookTitle", kainjow::mustache::data(false));
     } else {

--- a/static/templates/search_result.html
+++ b/static/templates/search_result.html
@@ -125,9 +125,9 @@
             {{#snippet}}
               <cite>{{>snippet}}...</cite>
             {{/snippet}}
-	    {{#bookTitle}}
-	      <div class="book-title">from {{bookTitle}}</div>
-	    {{/bookTitle}}
+            {{#bookTitle}}
+              <div class="book-title">from {{bookTitle}}</div>
+            {{/bookTitle}}
             {{#wordCount}}
               <div class="informations">{{wordCount}} words</div>
             {{/wordCount}}


### PR DESCRIPTION
This PR fix issues introduced by #705

- Do not break the API
- Fix crash when user code doesn't provide a library to the rendered.

This supersedes #717 