### PR TITLE
Use encoded URLs for searchSuggestionHtml 

### DIFF
--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -798,7 +798,7 @@ std::unique_ptr<Response> InternalServer::handle_content(const RequestContext& r
   } catch (const std::out_of_range& e) {}
 
   if (archive == nullptr) {
-    std::string searchURL = m_root+"/search?pattern="+pattern; // Make a full search on the entire library.
+    std::string searchURL = m_root + "/search?pattern=" + kiwix::urlEncode(pattern, true); // Make a full search on the entire library.
     const std::string details = searchSuggestionHTML(searchURL, kiwix::urlDecode(pattern));
 
     return Response::build_404(*this, request.get_full_url(), bookName, "", details);
@@ -831,7 +831,7 @@ std::unique_ptr<Response> InternalServer::handle_content(const RequestContext& r
     if (m_verbose.load())
       printf("Failed to find %s\n", urlStr.c_str());
 
-    std::string searchURL = m_root+"/search?content="+bookName+"&pattern="+pattern; // Make a search on this specific book only.
+    std::string searchURL = m_root + "/search?content=" + bookName + "&pattern=" + kiwix::urlEncode(pattern, true); // Make a search on this specific book only.
     const std::string details = searchSuggestionHTML(searchURL, kiwix::urlDecode(pattern));
 
     return Response::build_404(*this, request.get_full_url(), bookName, getArchiveTitle(*archive), details);

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -512,6 +512,30 @@ TEST_F(ServerTest, 404WithBodyTesting)
     </p>
 )"  },
 
+    { /* url */ R"(/ROOT/"><svg onload=alert(1)>)",
+      /* expected body */ R"(
+    <h1>Not Found</h1>
+    <p>
+      The requested URL "/ROOT/&quot;&gt;&lt;svg onload=alert(1)&gt;" was not found on this server.
+    </p>
+    <p>
+      Make a full text search for <a href="/ROOT/search?pattern=%22%3E%3Csvg%20onload%3Dalert(1)%3E">&quot;&gt;&lt;svg onload=alert(1)&gt;</a>
+    </p>
+)"  },
+
+    { /* url */ R"(/ROOT/zimfile/"><svg onload=alert(1)>)",
+      /* book name */  "zimfile",
+      /* book title */ "Ray Charles",
+      /* expected body */ R"(
+    <h1>Not Found</h1>
+    <p>
+      The requested URL "/ROOT/zimfile/&quot;&gt;&lt;svg onload=alert(1)&gt;" was not found on this server.
+    </p>
+    <p>
+      Make a full text search for <a href="/ROOT/search?content=zimfile&pattern=%22%3E%3Csvg%20onload%3Dalert(1)%3E">&quot;&gt;&lt;svg onload=alert(1)&gt;</a>
+    </p>
+)"  },
+
     { /* url */ "/ROOT/raw/no-such-book/meta/Title",
       /* expected body */ R"(
     <h1>Not Found</h1>


### PR DESCRIPTION
Previously, the seachURL was not encoded.
This resulted in an XSS vulnerability, a concept of proof is:

start kiwix-serve
visit - `http://192.168.18.1:8081/"><svg onload=alert(1)>`
This would display an alert message.

This encodes the searchURL before passing it to searchSuggestionHtml