### PR TITLE
Safer testing of HTML responses

### DIFF
--- a/test/server.cpp
+++ b/test/server.cpp
@@ -369,34 +369,16 @@ ExpectedResponseData operator&&(const ExpectedResponseData& a,
   };
 }
 
-class TestContentIn404HtmlResponse
+class TestContentIn404HtmlResponse : public ExpectedResponseData
 {
 public:
   TestContentIn404HtmlResponse(const std::string& url,
                                const ExpectedResponseData& erd)
-    : url(url)
-    , bookName(erd.bookName)
-    , bookTitle(erd.bookTitle)
-    , expectedBody(erd.expectedBody)
+    : ExpectedResponseData(erd)
+    , url(url)
   {}
 
-  TestContentIn404HtmlResponse(const std::string& url,
-                               const std::string& expectedBody)
-    : url(url)
-    , expectedBody(expectedBody)
-  {}
-
-  TestContentIn404HtmlResponse(const std::string& url,
-                               const std::string& bookName,
-                               const std::string& bookTitle,
-                               const std::string& expectedBody)
-    : url(url)
-    , bookName(bookName)
-    , bookTitle(bookTitle)
-    , expectedBody(expectedBody)
-  {}
-
-  const std::string url, bookName, bookTitle, expectedBody;
+  const std::string url;
 
   std::string expectedResponse() const;
 


### PR DESCRIPTION
This PR is the next small change extracted from #679 that became too big. 

Before this change the meaning of test data in the `ServerTest.404WithBodyTesting` unit test entirely depended on the number of entries:

- 2 entries: url, expected body
- 4 entries: url, book name, book title and expected body

This was fragile and non scalable (if other combinations of expected response data are needed).

This PR defines a mini-DSL taking advantage of operator overloading that allows to define test data in a robust way with the help of the compiler.