### PR TITLE
Better handling of multi search

### DIFF
--- a/include/library.h
+++ b/include/library.h
@@ -141,6 +141,22 @@ private: // functions
     bool accept(const Book& book) const;
 };
 
+
+class ZimSearcher : public zim::Searcher
+{
+  public:
+    explicit ZimSearcher(zim::Searcher&& searcher)
+      : zim::Searcher(searcher)
+    {}
+
+    std::unique_lock<std::mutex> getLock() {
+      return std::unique_lock<std::mutex>(m_mutex);
+    }
+    virtual ~ZimSearcher() = default;
+  private:
+    std::mutex m_mutex;
+};
+
 /**
  * A Library store several books.
  */
@@ -209,10 +225,10 @@ class Library
 
   DEPRECATED std::shared_ptr<Reader> getReaderById(const std::string& id);
   std::shared_ptr<zim::Archive> getArchiveById(const std::string& id);
-  std::shared_ptr<zim::Searcher> getSearcherById(const std::string& id) {
+  std::shared_ptr<ZimSearcher> getSearcherById(const std::string& id) {
     return getSearcherByIds(BookIdSet{id});
   }
-  std::shared_ptr<zim::Searcher> getSearcherByIds(const BookIdSet& ids);
+  std::shared_ptr<ZimSearcher> getSearcherByIds(const BookIdSet& ids);
 
   /**
    * Remove a book from the library.

--- a/include/library.h
+++ b/include/library.h
@@ -338,7 +338,7 @@ private: // functions
   std::vector<std::string> getBookPropValueSet(BookStrPropMemFn p) const;
   BookIdCollection filterViaBookDB(const Filter& filter) const;
   void updateBookDB(const Book& book);
-  void dropReader(const std::string& bookId);
+  void dropCache(const std::string& bookId);
 
 private: //data
   std::unique_ptr<Impl> mp_impl;

--- a/include/library.h
+++ b/include/library.h
@@ -153,6 +153,7 @@ class Library
   typedef uint64_t Revision;
   typedef std::vector<std::string> BookIdCollection;
   typedef std::map<std::string, int> AttributeCounts;
+  typedef std::set<std::string> BookIdSet;
 
  public:
   Library();
@@ -208,7 +209,10 @@ class Library
 
   DEPRECATED std::shared_ptr<Reader> getReaderById(const std::string& id);
   std::shared_ptr<zim::Archive> getArchiveById(const std::string& id);
-  std::shared_ptr<zim::Searcher> getSearcherById(const std::string& id);
+  std::shared_ptr<zim::Searcher> getSearcherById(const std::string& id) {
+    return getSearcherByIds(BookIdSet{id});
+  }
+  std::shared_ptr<zim::Searcher> getSearcherByIds(const BookIdSet& ids);
 
   /**
    * Remove a book from the library.

--- a/include/library.h
+++ b/include/library.h
@@ -26,6 +26,7 @@
 #include <memory>
 #include <mutex>
 #include <zim/archive.h>
+#include <zim/search.h>
 
 #include "book.h"
 #include "bookmark.h"
@@ -207,6 +208,7 @@ class Library
 
   DEPRECATED std::shared_ptr<Reader> getReaderById(const std::string& id);
   std::shared_ptr<zim::Archive> getArchiveById(const std::string& id);
+  std::shared_ptr<zim::Searcher> getSearcherById(const std::string& id);
 
   /**
    * Remove a book from the library.

--- a/include/search_renderer.h
+++ b/include/search_renderer.h
@@ -81,9 +81,9 @@ class SearchRenderer
   void setSearchPattern(const std::string& pattern);
 
   /**
-   * Set the search content id.
+   * Set the book names used to do the search.
    */
-  void setSearchContent(const std::string& name);
+  void setSearchBookIds(const std::set<std::string>& bookIds);
 
   /**
    * Set protocol prefix.
@@ -112,7 +112,7 @@ class SearchRenderer
   zim::SearchResultSet m_srs;
   NameMapper* mp_nameMapper;
   Library* mp_library;
-  std::string searchContent;
+  std::set<std::string> searchBookIds;
   std::string searchPattern;
   std::string protocolPrefix;
   std::string searchProtocolPrefix;

--- a/include/search_renderer.h
+++ b/include/search_renderer.h
@@ -81,9 +81,9 @@ class SearchRenderer
   void setSearchPattern(const std::string& pattern);
 
   /**
-   * Set the book names used to do the search.
+   * Set the querystring used to select books
    */
-  void setSearchBookIds(const std::set<std::string>& bookIds);
+  void setSearchBookQuery(const std::string& bookQuery);
 
   /**
    * Set protocol prefix.
@@ -112,7 +112,7 @@ class SearchRenderer
   zim::SearchResultSet m_srs;
   NameMapper* mp_nameMapper;
   Library* mp_library;
-  std::set<std::string> searchBookIds;
+  std::string searchBookQuery;
   std::string searchPattern;
   std::string protocolPrefix;
   std::string searchProtocolPrefix;

--- a/include/server.h
+++ b/include/server.h
@@ -54,6 +54,7 @@ namespace kiwix
        void setAddress(const std::string& addr) { m_addr = addr; }
        void setPort(int port) { m_port = port; }
        void setNbThreads(int threads) { m_nbThreads = threads; }
+       void setMultiZimSearchLimit(unsigned int limit) { m_multizimSearchLimit = limit; }
        void setIpConnectionLimit(int limit) { m_ipConnectionLimit = limit; }
        void setVerbose(bool verbose) { m_verbose = verbose; }
        void setIndexTemplateString(const std::string& indexTemplateString) { m_indexTemplateString = indexTemplateString; }
@@ -63,7 +64,7 @@ namespace kiwix
         { m_blockExternalLinks = blockExternalLinks; }
        int getPort();
        std::string getAddress();
-       
+
      protected:
        Library* mp_library;
        NameMapper* mp_nameMapper;
@@ -72,6 +73,7 @@ namespace kiwix
        std::string m_indexTemplateString = "";
        int m_port = 80;
        int m_nbThreads = 1;
+       unsigned int m_multizimSearchLimit = 0;
        bool m_verbose = false;
        bool m_withTaskbar = true;
        bool m_withLibraryButton = true;

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -108,8 +108,8 @@ struct Library::Impl
 };
 
 Library::Impl::Impl()
-  : mp_archiveCache(new ArchiveCache(std::max(getEnvVar<int>("ARCHIVE_CACHE_SIZE", 1), 1))),
-    mp_searcherCache(new SearcherCache(std::max(getEnvVar<int>("SEARCHER_CACHE_SIZE", 1), 1))),
+  : mp_archiveCache(new ArchiveCache(std::max(getEnvVar<int>("KIWIX_ARCHIVE_CACHE_SIZE", 1), 1))),
+    mp_searcherCache(new SearcherCache(std::max(getEnvVar<int>("KIWIX_SEARCHER_CACHE_SIZE", 1), 1))),
     m_bookDB("", Xapian::DB_BACKEND_INMEMORY)
 {
 }
@@ -176,10 +176,10 @@ bool Library::addBook(const Book& book)
     static_cast<Book&>(newEntry) = book;
     newEntry.lastUpdatedRevision = mp_impl->m_revision;
     size_t new_cache_size = std::ceil(mp_impl->getBookCount(true, true)*0.1);
-    if (getEnvVar<int>("ARCHIVE_CACHE_SIZE", -1) <= 0) {
+    if (getEnvVar<int>("KIWIX_ARCHIVE_CACHE_SIZE", -1) <= 0) {
       mp_impl->mp_archiveCache->setMaxSize(new_cache_size);
     }
-    if (getEnvVar<int>("SEARCHER_CACHE_SIZE", -1) <= 0) {
+    if (getEnvVar<int>("KIWIX_SEARCHER_CACHE_SIZE", -1) <= 0) {
       mp_impl->mp_searcherCache->setMaxSize(new_cache_size);
     }
     return true;

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -304,17 +304,21 @@ std::shared_ptr<zim::Archive> Library::getArchiveById(const std::string& id)
   }
 }
 
-std::shared_ptr<zim::Searcher> Library::getSearcherById(const std::string& id)
+std::shared_ptr<zim::Searcher> Library::getSearcherByIds(const BookIdSet& ids)
 {
-  std::set<std::string> ids {id};
+  assert(!ids.empty());
   try {
     return mp_impl->mp_searcherCache->getOrPut(ids,
     [&](){
-      auto archive = getArchiveById(id);
-      if(!archive) {
-        throw std::invalid_argument("");
+      std::vector<zim::Archive> archives;
+      for(auto& id:ids) {
+        auto archive = getArchiveById(id);
+        if(!archive) {
+          throw std::invalid_argument("");
+        }
+        archives.push_back(*archive);
       }
-      return std::make_shared<zim::Searcher>(*archive);
+      return std::make_shared<zim::Searcher>(archives);
     });
   } catch (std::invalid_argument&) {
     return nullptr;

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -93,7 +93,7 @@ struct Library::Impl
   std::map<std::string, Entry> m_books;
   using ArchiveCache = ConcurrentCache<std::string, std::shared_ptr<zim::Archive>>;
   std::unique_ptr<ArchiveCache> mp_archiveCache;
-  using SearcherCache = MultiKeyCache<std::string, std::shared_ptr<zim::Searcher>>;
+  using SearcherCache = MultiKeyCache<std::string, std::shared_ptr<ZimSearcher>>;
   std::unique_ptr<SearcherCache> mp_searcherCache;
   std::vector<kiwix::Bookmark> m_bookmarks;
   Xapian::WritableDatabase m_bookDB;
@@ -304,7 +304,7 @@ std::shared_ptr<zim::Archive> Library::getArchiveById(const std::string& id)
   }
 }
 
-std::shared_ptr<zim::Searcher> Library::getSearcherByIds(const BookIdSet& ids)
+std::shared_ptr<ZimSearcher> Library::getSearcherByIds(const BookIdSet& ids)
 {
   assert(!ids.empty());
   try {
@@ -318,7 +318,7 @@ std::shared_ptr<zim::Searcher> Library::getSearcherByIds(const BookIdSet& ids)
         }
         archives.push_back(*archive);
       }
-      return std::make_shared<zim::Searcher>(archives);
+      return std::make_shared<ZimSearcher>(zim::Searcher(archives));
     });
   } catch (std::invalid_argument&) {
     return nullptr;

--- a/src/search_renderer.cpp
+++ b/src/search_renderer.cpp
@@ -71,9 +71,9 @@ void SearchRenderer::setSearchPattern(const std::string& pattern)
   searchPattern = pattern;
 }
 
-void SearchRenderer::setSearchBookIds(const std::set<std::string>& bookIds)
+void SearchRenderer::setSearchBookQuery(const std::string& bookQuery)
 {
-  searchBookIds = bookIds;
+  searchBookQuery = bookQuery;
 }
 
 void SearchRenderer::setProtocolPrefix(const std::string& prefix)
@@ -90,15 +90,13 @@ kainjow::mustache::data buildQueryData
 (
   const std::string& searchProtocolPrefix,
   const std::string& pattern,
-  const std::set<std::string>& bookIds
+  const std::string& bookQuery
 ) {
   kainjow::mustache::data query;
   query.set("pattern", kiwix::encodeDiples(pattern));
   std::ostringstream ss;
   ss << searchProtocolPrefix << "?pattern=" << urlEncode(pattern, true);
-  for (auto& bookId: bookIds) {
-    ss << "&books.id="<<urlEncode(bookId, true);
-  }
+  ss << "&" << bookQuery;
   query.set("unpaginatedQuery", ss.str());
   return query;
 }
@@ -199,7 +197,7 @@ std::string SearchRenderer::getHtml()
   kainjow::mustache::data query = buildQueryData(
     searchProtocolPrefix,
     searchPattern,
-    searchBookIds
+    searchBookQuery
   );
 
   std::string template_str = RESOURCE::templates::search_result_html;

--- a/src/search_renderer.cpp
+++ b/src/search_renderer.cpp
@@ -71,9 +71,9 @@ void SearchRenderer::setSearchPattern(const std::string& pattern)
   searchPattern = pattern;
 }
 
-void SearchRenderer::setSearchContent(const std::string& content)
+void SearchRenderer::setSearchBookIds(const std::set<std::string>& bookIds)
 {
-  searchContent = content;
+  searchBookIds = bookIds;
 }
 
 void SearchRenderer::setProtocolPrefix(const std::string& prefix)
@@ -90,13 +90,15 @@ kainjow::mustache::data buildQueryData
 (
   const std::string& searchProtocolPrefix,
   const std::string& pattern,
-  const std::string& searchContent
+  const std::set<std::string>& bookIds
 ) {
   kainjow::mustache::data query;
   query.set("pattern", kiwix::encodeDiples(pattern));
   std::ostringstream ss;
   ss << searchProtocolPrefix << "?pattern=" << urlEncode(pattern, true);
-  ss << "&content=" << urlEncode(searchContent, true);
+  for (auto& bookId: bookIds) {
+    ss << "&books.id="<<urlEncode(bookId, true);
+  }
   query.set("unpaginatedQuery", ss.str());
   return query;
 }
@@ -197,7 +199,7 @@ std::string SearchRenderer::getHtml()
   kainjow::mustache::data query = buildQueryData(
     searchProtocolPrefix,
     searchPattern,
-    searchContent
+    searchBookIds
   );
 
   std::string template_str = RESOURCE::templates::search_result_html;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -45,6 +45,7 @@ bool Server::start() {
     m_port,
     m_root,
     m_nbThreads,
+    m_multizimSearchLimit,
     m_verbose,
     m_withTaskbar,
     m_withLibraryButton,

--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -704,11 +704,13 @@ std::unique_ptr<Response> InternalServer::handle_search(const RequestContext& re
 
     /* Make the search */
     // Try to get a search from the searchInfo, else build it
+    auto searcher = mp_library->getSearcherByIds(bookIds);
+    auto lock(searcher->getLock());
+
     std::shared_ptr<zim::Search> search;
     try {
       search = searchCache.getOrPut(searchInfo,
         [=](){
-          auto searcher = mp_library->getSearcherByIds(bookIds);
           return make_shared<zim::Search>(searcher->search(searchInfo.getZimQuery(m_verbose.load())));
         }
       );

--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -237,6 +237,14 @@ std::pair<std::string, Library::BookIdSet> InternalServer::selectBooks(const Req
     if (id_vec.empty()) {
       throw Error(noValueForArgMsg("books.id"));
     }
+    for(const auto& bookId: id_vec) {
+      try {
+        // This is a silly way to check that bookId exists
+        mp_nameMapper->getNameForId(bookId);
+      } catch (const std::out_of_range&) {
+        throw Error(noSuchBookErrorMsg(bookId));
+      }
+    }
     const auto bookIds = Library::BookIdSet(id_vec.begin(), id_vec.end());
     const auto queryString = request.get_query([&](const std::string& key){return key == "books.id";}, true);
     return {queryString, bookIds};

--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -711,8 +711,7 @@ std::unique_ptr<Response> InternalServer::handle_search(const RequestContext& re
     SearchRenderer renderer(search->getResults(start, pageLength), mp_nameMapper, mp_library, start,
                             search->getEstimatedMatches());
     renderer.setSearchPattern(searchInfo.pattern);
-    //[TODO]
-    //renderer.setSearchContent(searchInfo.bookNames);
+    renderer.setSearchBookIds(bookIds);
     renderer.setProtocolPrefix(m_root + "/");
     renderer.setSearchProtocolPrefix(m_root + "/search");
     renderer.setPageLength(pageLength);

--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -596,21 +596,15 @@ std::unique_ptr<Response> InternalServer::handle_search(const RequestContext& re
     try {
       search = searchCache.getOrPut(searchInfo,
         [=](){
-          std::shared_ptr<zim::Searcher> searcher;
+          Library::BookIdSet bookIds;
           if(!bookId.empty()) {
-            searcher = mp_library->getSearcherById(bookId);
+            bookIds.insert(bookId);
           } else {
             for (auto& bookId: mp_library->filter(kiwix::Filter().local(true).valid(true))) {
-              auto currentArchive = mp_library->getArchiveById(bookId);
-              if (currentArchive) {
-                if (! searcher) {
-                  searcher = std::make_shared<zim::Searcher>(*currentArchive);
-                } else {
-                  searcher->addArchive(*currentArchive);
-                }
-              }
-           }
+              bookIds.insert(bookId);
+            }
           }
+          auto searcher = mp_library->getSearcherByIds(bookIds);
           return make_shared<zim::Search>(searcher->search(searchInfo.getZimQuery(m_verbose.load())));
         }
       );

--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -207,7 +207,7 @@ void checkBookNumber(const Library::BookIdSet& bookIds, size_t limit) {
   if (bookIds.empty()) {
     throw Error(nonParameterizedMessage("no-book-found"));
   }
-  if (bookIds.size() > limit) {
+  if (limit > 0 && bookIds.size() > limit) {
     throw Error(tooManyBooksMsg(bookIds.size(), limit));
   }
 }
@@ -269,7 +269,7 @@ Library::BookIdSet InternalServer::selectBooks(const RequestContext& request) co
 SearchInfo InternalServer::getSearchInfo(const RequestContext& request) const
 {
   auto bookIds = selectBooks(request);
-  checkBookNumber(bookIds, 5);
+  checkBookNumber(bookIds, m_multizimSearchLimit);
   auto pattern = request.get_optional_param<std::string>("pattern", "");
   GeoQuery geoQuery;
 
@@ -332,6 +332,7 @@ InternalServer::InternalServer(Library* library,
                                int port,
                                std::string root,
                                int nbThreads,
+                               unsigned int multizimSearchLimit,
                                bool verbose,
                                bool withTaskbar,
                                bool withLibraryButton,
@@ -342,6 +343,7 @@ InternalServer::InternalServer(Library* library,
   m_port(port),
   m_root(normalizeRootUrl(root)),
   m_nbThreads(nbThreads),
+  m_multizimSearchLimit(multizimSearchLimit),
   m_verbose(verbose),
   m_withTaskbar(withTaskbar),
   m_withLibraryButton(withLibraryButton),

--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -129,6 +129,51 @@ std::vector<T> subrange(const std::vector<T>& v, size_t s, size_t n)
   return std::vector<T>(v.begin()+std::min(v.size(), s), v.begin()+e);
 }
 
+std::string renderUrl(const std::string& root, const std::string& urlTemplate)
+{
+  MustacheData data;
+  data.set("root", root);
+  auto url = kainjow::mustache::mustache(urlTemplate).render(data);
+  if ( url.back() == '\n' )
+    url.pop_back();
+  return url;
+}
+
+std::string makeFulltextSearchSuggestion(const std::string& lang, const std::string& queryString)
+{
+  return i18n::expandParameterizedString(lang, "suggest-full-text-search",
+               {
+                  {"SEARCH_TERMS", queryString}
+               }
+         );
+}
+
+ParameterizedMessage noSuchBookErrorMsg(const std::string& bookName)
+{
+  return ParameterizedMessage("no-such-book", { {"BOOK_NAME", bookName} });
+}
+
+ParameterizedMessage invalidRawAccessMsg(const std::string& dt)
+{
+  return ParameterizedMessage("invalid-raw-data-type", { {"DATATYPE", dt} });
+}
+
+ParameterizedMessage rawEntryNotFoundMsg(const std::string& dt, const std::string& entry)
+{
+  return ParameterizedMessage("raw-entry-not-found",
+                              {
+                                {"DATATYPE", dt},
+                                {"ENTRY", entry},
+                              }
+  );
+}
+
+ParameterizedMessage nonParameterizedMessage(const std::string& msgId)
+{
+  const ParameterizedMessage::Parameters noParams;
+  return ParameterizedMessage(msgId, noParams);
+}
+
 } // unnamed namespace
 
 Library::BookIdSet InternalServer::selectBooks(const RequestContext& request) const
@@ -508,56 +553,6 @@ SuggestionsList_t getSuggestions(SuggestionSearcherCache& cache, const zim::Arch
   }
   return suggestions;
 }
-
-namespace
-{
-
-std::string renderUrl(const std::string& root, const std::string& urlTemplate)
-{
-  MustacheData data;
-  data.set("root", root);
-  auto url = kainjow::mustache::mustache(urlTemplate).render(data);
-  if ( url.back() == '\n' )
-    url.pop_back();
-  return url;
-}
-
-std::string makeFulltextSearchSuggestion(const std::string& lang, const std::string& queryString)
-{
-  return i18n::expandParameterizedString(lang, "suggest-full-text-search",
-               {
-                  {"SEARCH_TERMS", queryString}
-               }
-         );
-}
-
-ParameterizedMessage noSuchBookErrorMsg(const std::string& bookName)
-{
-  return ParameterizedMessage("no-such-book", { {"BOOK_NAME", bookName} });
-}
-
-ParameterizedMessage invalidRawAccessMsg(const std::string& dt)
-{
-  return ParameterizedMessage("invalid-raw-data-type", { {"DATATYPE", dt} });
-}
-
-ParameterizedMessage rawEntryNotFoundMsg(const std::string& dt, const std::string& entry)
-{
-  return ParameterizedMessage("raw-entry-not-found",
-                              {
-                                {"DATATYPE", dt},
-                                {"ENTRY", entry},
-                              }
-  );
-}
-
-ParameterizedMessage nonParameterizedMessage(const std::string& msgId)
-{
-  const ParameterizedMessage::Parameters noParams;
-  return ParameterizedMessage(msgId, noParams);
-}
-
-} // unnamed namespace
 
 std::unique_ptr<Response> InternalServer::handle_suggest(const RequestContext& request)
 {

--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -95,29 +95,29 @@ inline std::string normalizeRootUrl(std::string rootUrl)
   return rootUrl.empty() ? rootUrl : "/" + rootUrl;
 }
 
-Filter get_search_filter(const RequestContext& request)
+Filter get_search_filter(const RequestContext& request, const std::string& prefix="")
 {
     auto filter = kiwix::Filter().valid(true).local(true);
     try {
-      filter.query(request.get_argument("q"));
+      filter.query(request.get_argument(prefix+"q"));
     } catch (const std::out_of_range&) {}
     try {
-      filter.maxSize(request.get_argument<unsigned long>("maxsize"));
+      filter.maxSize(request.get_argument<unsigned long>(prefix+"maxsize"));
     } catch (...) {}
     try {
-      filter.name(request.get_argument("name"));
+      filter.name(request.get_argument(prefix+"name"));
     } catch (const std::out_of_range&) {}
     try {
-      filter.category(request.get_argument("category"));
+      filter.category(request.get_argument(prefix+"category"));
     } catch (const std::out_of_range&) {}
     try {
-      filter.lang(request.get_argument("lang"));
+      filter.lang(request.get_argument(prefix+"lang"));
     } catch (const std::out_of_range&) {}
     try {
-      filter.acceptTags(kiwix::split(request.get_argument("tag"), ";"));
+      filter.acceptTags(kiwix::split(request.get_argument(prefix+"tag"), ";"));
     } catch (...) {}
     try {
-      filter.rejectTags(kiwix::split(request.get_argument("notag"), ";"));
+      filter.rejectTags(kiwix::split(request.get_argument(prefix+"notag"), ";"));
     } catch (...) {}
     return filter;
 }

--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -95,18 +95,6 @@ inline std::string normalizeRootUrl(std::string rootUrl)
   return rootUrl.empty() ? rootUrl : "/" + rootUrl;
 }
 
-// Returns the value of env var `name` if found, otherwise returns defaultVal
-unsigned int getCacheLength(const char* name, unsigned int defaultVal) {
-  try {
-    const char* envString = std::getenv(name);
-    if (envString == nullptr) {
-      throw std::runtime_error("Environment variable not set");
-    }
-    return extractFromString<unsigned int>(envString);
-  } catch (...) {}
-
-  return defaultVal;
-}
 } // unnamed namespace
 
 SearchInfo::SearchInfo(const std::string& pattern)
@@ -194,9 +182,9 @@ InternalServer::InternalServer(Library* library,
   mp_daemon(nullptr),
   mp_library(library),
   mp_nameMapper(nameMapper ? nameMapper : &defaultNameMapper),
-  searcherCache(getCacheLength("SEARCHER_CACHE_SIZE", std::max((unsigned int) (mp_library->getBookCount(true, true)*0.1), 1U))),
-  searchCache(getCacheLength("SEARCH_CACHE_SIZE", DEFAULT_CACHE_SIZE)),
-  suggestionSearcherCache(getCacheLength("SUGGESTION_SEARCHER_CACHE_SIZE", std::max((unsigned int) (mp_library->getBookCount(true, true)*0.1), 1U)))
+  searcherCache(getEnvVar<int>("SEARCHER_CACHE_SIZE", std::max((unsigned int) (mp_library->getBookCount(true, true)*0.1), 1U))),
+  searchCache(getEnvVar<int>("SEARCH_CACHE_SIZE", DEFAULT_CACHE_SIZE)),
+  suggestionSearcherCache(getEnvVar<int>("SUGGESTION_SEARCHER_CACHE_SIZE", std::max((unsigned int) (mp_library->getBookCount(true, true)*0.1), 1U)))
 {}
 
 bool InternalServer::start() {

--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -329,8 +329,8 @@ InternalServer::InternalServer(Library* library,
   mp_daemon(nullptr),
   mp_library(library),
   mp_nameMapper(nameMapper ? nameMapper : &defaultNameMapper),
-  searchCache(getEnvVar<int>("SEARCH_CACHE_SIZE", DEFAULT_CACHE_SIZE)),
-  suggestionSearcherCache(getEnvVar<int>("SUGGESTION_SEARCHER_CACHE_SIZE", std::max((unsigned int) (mp_library->getBookCount(true, true)*0.1), 1U)))
+  searchCache(getEnvVar<int>("KIWIX_SEARCH_CACHE_SIZE", DEFAULT_CACHE_SIZE)),
+  suggestionSearcherCache(getEnvVar<int>("KIWIX_SUGGESTION_SEARCHER_CACHE_SIZE", std::max((unsigned int) (mp_library->getBookCount(true, true)*0.1), 1U)))
 {}
 
 bool InternalServer::start() {

--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -221,7 +221,7 @@ std::pair<std::string, Library::BookIdSet> InternalServer::selectBooks(const Req
     auto bookName = request.get_argument("content");
     try {
       const auto bookIds = Library::BookIdSet{mp_nameMapper->getIdForName(bookName)};
-      const auto queryString = request.get_query([&](const std::string& key){return key == "content";});
+      const auto queryString = request.get_query([&](const std::string& key){return key == "content";}, true);
       return {queryString, bookIds};
     } catch (const std::out_of_range&) {
       throw Error(noSuchBookErrorMsg(bookName));
@@ -238,7 +238,7 @@ std::pair<std::string, Library::BookIdSet> InternalServer::selectBooks(const Req
       throw Error(noValueForArgMsg("books.id"));
     }
     const auto bookIds = Library::BookIdSet(id_vec.begin(), id_vec.end());
-    const auto queryString = request.get_query([&](const std::string& key){return key == "books.id";});
+    const auto queryString = request.get_query([&](const std::string& key){return key == "books.id";}, true);
     return {queryString, bookIds};
   } catch(const std::out_of_range&) {}
 
@@ -256,7 +256,7 @@ std::pair<std::string, Library::BookIdSet> InternalServer::selectBooks(const Req
         throw Error(noSuchBookErrorMsg(bookName));
       }
     }
-    const auto queryString = request.get_query([&](const std::string& key){return key == "books.name";});
+    const auto queryString = request.get_query([&](const std::string& key){return key == "books.name";}, true);
     return {queryString, bookIds};
   } catch(const std::out_of_range&) {}
 
@@ -267,7 +267,7 @@ std::pair<std::string, Library::BookIdSet> InternalServer::selectBooks(const Req
     throw Error(nonParameterizedMessage("no-book-found"));
   }
   const auto bookIds = Library::BookIdSet(id_vec.begin(), id_vec.end());
-  const auto queryString = request.get_query([&](const std::string& key){return startsWith(key, "books.filter.");});
+  const auto queryString = request.get_query([&](const std::string& key){return startsWith(key, "books.filter.");}, true);
   return {queryString, bookIds};
 }
 

--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -177,8 +177,8 @@ ParameterizedMessage tooManyBooksMsg(size_t nbBooks, size_t limit)
 {
   return ParameterizedMessage("too-many-books",
                               {
-                                {"NB_BOOKS", nbBooks},
-                                {"LIMIT", limit},
+                                {"NB_BOOKS", beautifyInteger(nbBooks)},
+                                {"LIMIT", beautifyInteger(limit)},
                               }
   );
 }

--- a/src/server/internalServer.h
+++ b/src/server/internalServer.h
@@ -88,7 +88,6 @@ class SearchInfo {
 
 
 typedef kainjow::mustache::data MustacheData;
-typedef ConcurrentCache<string, std::shared_ptr<zim::Searcher>> SearcherCache;
 typedef ConcurrentCache<SearchInfo, std::shared_ptr<zim::Search>> SearchCache;
 typedef ConcurrentCache<string, std::shared_ptr<zim::SuggestionSearcher>> SuggestionSearcherCache;
 
@@ -167,7 +166,6 @@ class InternalServer {
     Library* mp_library;
     NameMapper* mp_nameMapper;
 
-    SearcherCache searcherCache;
     SearchCache searchCache;
     SuggestionSearcherCache suggestionSearcherCache;
 

--- a/src/server/internalServer.h
+++ b/src/server/internalServer.h
@@ -68,7 +68,7 @@ struct GeoQuery {
 
 class SearchInfo {
   public:
-    SearchInfo(const std::string& pattern, GeoQuery geoQuery, const Library::BookIdSet& bookIds);
+    SearchInfo(const std::string& pattern, GeoQuery geoQuery, const Library::BookIdSet& bookIds, const std::string& bookFilterString);
 
     zim::Query getZimQuery(bool verbose) const;
     const Library::BookIdSet& getBookIds() const { return bookIds; }
@@ -83,6 +83,7 @@ class SearchInfo {
     std::string pattern;
     GeoQuery geoQuery;
     Library::BookIdSet bookIds;
+    std::string bookFilterQuery;
 };
 
 
@@ -149,7 +150,7 @@ class InternalServer {
 
     bool etag_not_needed(const RequestContext& r) const;
     ETag get_matching_if_none_match_etag(const RequestContext& request) const;
-    Library::BookIdSet selectBooks(const RequestContext& r) const;
+    std::pair<std::string, Library::BookIdSet> selectBooks(const RequestContext& r) const;
     SearchInfo getSearchInfo(const RequestContext& r) const;
 
   private: // data

--- a/src/server/internalServer.h
+++ b/src/server/internalServer.h
@@ -76,14 +76,14 @@ class SearchInfo {
 
     friend bool operator<(const SearchInfo& l, const SearchInfo& r)
     {
-        return std::tie(l.bookName, l.pattern, l.geoQuery)
-             < std::tie(r.bookName, r.pattern, r.geoQuery); // keep the same order
+        return std::tie(l.bookNames, l.pattern, l.geoQuery)
+             < std::tie(r.bookNames, r.pattern, r.geoQuery); // keep the same order
     }
 
   public: //data
     std::string pattern;
     GeoQuery geoQuery;
-    std::string bookName;
+    std::set<std::string> bookNames;
 };
 
 

--- a/src/server/internalServer.h
+++ b/src/server/internalServer.h
@@ -101,6 +101,7 @@ class InternalServer {
                    int port,
                    std::string root,
                    int nbThreads,
+                   unsigned int multizimSearchLimit,
                    bool verbose,
                    bool withTaskbar,
                    bool withLibraryButton,
@@ -156,6 +157,7 @@ class InternalServer {
     int m_port;
     std::string m_root;
     int m_nbThreads;
+    unsigned int m_multizimSearchLimit;
     std::atomic_bool m_verbose;
     bool m_withTaskbar;
     bool m_withLibraryButton;

--- a/src/server/internalServer.h
+++ b/src/server/internalServer.h
@@ -149,6 +149,7 @@ class InternalServer {
 
     bool etag_not_needed(const RequestContext& r) const;
     ETag get_matching_if_none_match_etag(const RequestContext& request) const;
+    Library::BookIdSet selectBooks(const RequestContext& r) const;
 
   private: // data
     std::string m_addr;

--- a/src/server/internalServer.h
+++ b/src/server/internalServer.h
@@ -68,22 +68,21 @@ struct GeoQuery {
 
 class SearchInfo {
   public:
-    SearchInfo(const std::string& pattern);
-    SearchInfo(const std::string& pattern, GeoQuery geoQuery);
-    SearchInfo(const RequestContext& request);
+    SearchInfo(const std::string& pattern, GeoQuery geoQuery, const Library::BookIdSet& bookIds);
 
     zim::Query getZimQuery(bool verbose) const;
+    const Library::BookIdSet& getBookIds() const { return bookIds; }
 
     friend bool operator<(const SearchInfo& l, const SearchInfo& r)
     {
-        return std::tie(l.bookNames, l.pattern, l.geoQuery)
-             < std::tie(r.bookNames, r.pattern, r.geoQuery); // keep the same order
+        return std::tie(l.bookIds, l.pattern, l.geoQuery)
+             < std::tie(r.bookIds, r.pattern, r.geoQuery); // keep the same order
     }
 
   public: //data
     std::string pattern;
     GeoQuery geoQuery;
-    std::set<std::string> bookNames;
+    Library::BookIdSet bookIds;
 };
 
 
@@ -150,6 +149,7 @@ class InternalServer {
     bool etag_not_needed(const RequestContext& r) const;
     ETag get_matching_if_none_match_etag(const RequestContext& request) const;
     Library::BookIdSet selectBooks(const RequestContext& r) const;
+    SearchInfo getSearchInfo(const RequestContext& r) const;
 
   private: // data
     std::string m_addr;

--- a/src/server/request_context.cpp
+++ b/src/server/request_context.cpp
@@ -189,18 +189,6 @@ std::string RequestContext::get_header(const std::string& name) const {
   return headers.at(lcAll(name));
 }
 
-std::string RequestContext::get_query() const {
-  std::string q;
-  const char* sep = "";
-  for ( const auto& a : arguments ) {
-    for (const auto& v: a.second) {
-      q += sep + a.first + '=' + v;
-      sep = "&";
-    }
-  }
-  return q;
-}
-
 std::string RequestContext::get_user_language() const
 {
   try {

--- a/src/server/request_context.cpp
+++ b/src/server/request_context.cpp
@@ -106,7 +106,7 @@ MHD_Result RequestContext::fill_argument(void *__this, enum MHD_ValueKind kind,
                                          const char *key, const char* value)
 {
   RequestContext *_this = static_cast<RequestContext*>(__this);
-  _this->arguments[key] = value == nullptr ? "" : value;
+  _this->arguments[key].push_back(value == nullptr ? "" : value);
   return MHD_YES;
 }
 
@@ -121,8 +121,14 @@ void RequestContext::print_debug_info() const {
     printf(" - %s : '%s'\n", it->first.c_str(), it->second.c_str());
   }
   printf("arguments :\n");
-  for (auto it=arguments.begin(); it!=arguments.end(); it++) {
-    printf(" - %s : '%s'\n", it->first.c_str(), it->second.c_str());
+  for (auto& pair:arguments) {
+    printf(" - %s :", pair.first.c_str());
+    bool first = true;
+    for (auto& v: pair.second) {
+      printf("%s %s", first?"":",", v.c_str());
+      first = false;
+    }
+    printf("\n");
   }
   printf("Parsed : \n");
   printf("full_url: %s\n", full_url.c_str());
@@ -176,7 +182,7 @@ ByteRange RequestContext::get_range() const {
 
 template<>
 std::string RequestContext::get_argument(const std::string& name) const {
-  return arguments.at(name);
+  return arguments.at(name)[0];
 }
 
 std::string RequestContext::get_header(const std::string& name) const {
@@ -187,8 +193,10 @@ std::string RequestContext::get_query() const {
   std::string q;
   const char* sep = "";
   for ( const auto& a : arguments ) {
-    q += sep + a.first + '=' + a.second;
-    sep = "&";
+    for (const auto& v: a.second) {
+      q += sep + a.first + '=' + v;
+      sep = "&";
+    }
   }
   return q;
 }

--- a/src/server/request_context.h
+++ b/src/server/request_context.h
@@ -92,20 +92,21 @@ class RequestContext {
     std::string get_url_part(int part) const;
     std::string get_full_url() const;
 
-    std::string get_query() const {
-      return get_query([](const std::string& key) {return true;});
+    std::string get_query(bool mustEncode = false) const {
+      return get_query([](const std::string& key) {return true;}, mustEncode);
     }
 
     template<class F>
-    std::string get_query(F filter) const {
+    std::string get_query(F filter, bool mustEncode) const {
       std::string q;
       const char* sep = "";
+      auto encode = [=](const std::string& value) { return mustEncode?urlEncode(value, true):value; };
       for ( const auto& a : arguments ) {
         if (!filter(a.first)) {
           continue;
         }
         for (const auto& v: a.second) {
-          q += sep + a.first + '=' + v;
+          q += sep + encode(a.first) + '=' + encode(v);
           sep = "&";
         }
       }

--- a/src/server/request_context.h
+++ b/src/server/request_context.h
@@ -25,6 +25,7 @@
 #include <string>
 #include <sstream>
 #include <map>
+#include <vector>
 #include <stdexcept>
 
 #include "byte_range.h"
@@ -69,7 +70,11 @@ class RequestContext {
     std::string get_header(const std::string& name) const;
     template<typename T=std::string>
     T get_argument(const std::string& name) const {
-        return extractFromString<T>(arguments.at(name));
+        return extractFromString<T>(get_argument(name));
+    }
+
+    std::vector<std::string> get_arguments(const std::string& name) const {
+      return arguments.at(name);
     }
 
     template<class T>
@@ -105,7 +110,7 @@ class RequestContext {
 
     ByteRange byteRange_;
     std::map<std::string, std::string> headers;
-    std::map<std::string, std::string> arguments;
+    std::map<std::string, std::vector<std::string>> arguments;
 
   private: // functions
     static MHD_Result fill_header(void *, enum MHD_ValueKind, const char*, const char*);

--- a/src/server/request_context.h
+++ b/src/server/request_context.h
@@ -91,7 +91,26 @@ class RequestContext {
     std::string get_url() const;
     std::string get_url_part(int part) const;
     std::string get_full_url() const;
-    std::string get_query() const;
+
+    std::string get_query() const {
+      return get_query([](const std::string& key) {return true;});
+    }
+
+    template<class F>
+    std::string get_query(F filter) const {
+      std::string q;
+      const char* sep = "";
+      for ( const auto& a : arguments ) {
+        if (!filter(a.first)) {
+          continue;
+        }
+        for (const auto& v: a.second) {
+          q += sep + a.first + '=' + v;
+          sep = "&";
+        }
+      }
+      return q;
+    }
 
     ByteRange get_range() const;
 

--- a/src/tools/concurrent_cache.h
+++ b/src/tools/concurrent_cache.h
@@ -90,7 +90,7 @@ public: // types
     return  impl_.setMaxSize(new_size);
   }
 
-private: // data
+protected: // data
   Impl impl_;
   std::mutex lock_;
 };

--- a/src/tools/concurrent_cache.h
+++ b/src/tools/concurrent_cache.h
@@ -95,6 +95,113 @@ protected: // data
   std::mutex lock_;
 };
 
+
+/**
+  WeakStore represent a thread safe store (map) of weak ptr.
+  It allows to store weak_ptr from shared_ptr and retrieve shared_ptr from
+  potential non expired weak_ptr.
+  It is not limited in size.
+*/
+template<typename Key, typename Value>
+class WeakStore {
+  private: // types
+    typedef std::weak_ptr<Value> WeakValue;
+
+  public:
+    explicit WeakStore() = default;
+
+    std::shared_ptr<Value> get(const Key& key)
+    {
+      std::lock_guard<std::mutex> l(m_lock);
+      auto it = m_weakMap.find(key);
+      if (it != m_weakMap.end()) {
+        auto shared = it->second.lock();
+        if (shared) {
+          return shared;
+        } else {
+          m_weakMap.erase(it);
+        }
+      }
+      throw std::runtime_error("No weak ptr");
+    }
+
+    void add(const Key& key, std::shared_ptr<Value> shared)
+    {
+      std::lock_guard<std::mutex> l(m_lock);
+      m_weakMap[key] = WeakValue(shared);
+    }
+
+
+  private: //data
+    std::map<Key, WeakValue> m_weakMap;
+    std::mutex m_lock;
+};
+
+template <typename Key, typename RawValue>
+class ConcurrentCache<Key, std::shared_ptr<RawValue>>
+{
+private: // types
+  typedef std::shared_ptr<RawValue> Value;
+  typedef std::shared_future<Value> ValuePlaceholder;
+  typedef lru_cache<Key, ValuePlaceholder> Impl;
+
+public: // types
+  explicit ConcurrentCache(size_t maxEntries)
+    : impl_(maxEntries)
+  {}
+
+  // Gets the entry corresponding to the given key. If the entry is not in the
+  // cache, it is obtained by calling f() (without any arguments) and the
+  // result is put into the cache.
+  //
+  // The cache as a whole is locked only for the duration of accessing
+  // the respective slot. If, in the case of the a cache miss, the generation
+  // of the missing element takes a long time, only attempts to access that
+  // element will block - the rest of the cache remains open to concurrent
+  // access.
+  template<class F>
+  Value getOrPut(const Key& key, F f)
+  {
+    std::promise<Value> valuePromise;
+    std::unique_lock<std::mutex> l(lock_);
+    const auto x = impl_.getOrPut(key, valuePromise.get_future().share());
+    l.unlock();
+    if ( x.miss() ) {
+      // Try to get back the shared_ptr from the weak_ptr first.
+      try {
+        valuePromise.set_value(m_weakStore.get(key));
+      } catch(const std::runtime_error& e) {
+        try {
+          const auto value = f();
+          valuePromise.set_value(value);
+          m_weakStore.add(key, value);
+        } catch (std::exception& e) {
+          drop(key);
+          throw;
+        }
+      }
+    }
+
+    return x.value().get();
+  }
+
+  bool drop(const Key& key)
+  {
+    std::unique_lock<std::mutex> l(lock_);
+    return impl_.drop(key);
+  }
+
+  size_t setMaxSize(size_t new_size) {
+    std::unique_lock<std::mutex> l(lock_);
+    return  impl_.setMaxSize(new_size);
+  }
+
+protected: // data
+  std::mutex lock_;
+  Impl impl_;
+  WeakStore<Key, RawValue> m_weakStore;
+};
+
 } // namespace kiwix
 
 #endif // ZIM_CONCURRENT_CACHE_H

--- a/src/tools/concurrent_cache.h
+++ b/src/tools/concurrent_cache.h
@@ -1,3 +1,4 @@
+
 /*
  * Copyright (C) 2021 Matthieu Gautier <mgautier@kymeria.fr>
  * Copyright (C) 2020 Veloman Yunkan
@@ -82,6 +83,11 @@ public: // types
   {
     std::unique_lock<std::mutex> l(lock_);
     return impl_.drop(key);
+  }
+
+  size_t setMaxSize(size_t new_size) {
+    std::unique_lock<std::mutex> l(lock_);
+    return  impl_.setMaxSize(new_size);
   }
 
 private: // data

--- a/src/tools/lrucache.h
+++ b/src/tools/lrucache.h
@@ -138,12 +138,18 @@ public: // functions
     return _cache_items_map.size();
   }
 
+  size_t setMaxSize(size_t new_size) {
+    size_t previous = _max_size;
+    _max_size = new_size;
+    return previous;
+  }
+
 private: // functions
   void putMissing(const key_t& key, const value_t& value) {
     assert(_cache_items_map.find(key) == _cache_items_map.end());
     _cache_items_list.push_front(key_value_pair_t(key, value));
     _cache_items_map[key] = _cache_items_list.begin();
-    if (_cache_items_map.size() > _max_size) {
+    while (_cache_items_map.size() > _max_size) {
       _cache_items_map.erase(_cache_items_list.back().first);
       _cache_items_list.pop_back();
     }

--- a/src/tools/lrucache.h
+++ b/src/tools/lrucache.h
@@ -40,6 +40,7 @@
 
 #include <map>
 #include <list>
+#include <set>
 #include <cstddef>
 #include <stdexcept>
 #include <cassert>

--- a/src/tools/lrucache.h
+++ b/src/tools/lrucache.h
@@ -144,6 +144,14 @@ public: // functions
     return previous;
   }
 
+  std::set<key_t> keys() const  {
+    std::set<key_t> keys;
+    for(auto& item:_cache_items_map) {
+      keys.insert(item.first);
+    }
+    return keys;
+  }
+
 private: // functions
   void putMissing(const key_t& key, const value_t& value) {
     assert(_cache_items_map.find(key) == _cache_items_map.end());

--- a/src/tools/otherTools.h
+++ b/src/tools/otherTools.h
@@ -23,8 +23,11 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <cstdlib>
 #include <zim/zim.h>
 #include <mustache.hpp>
+
+#include "stringTools.h"
 
 namespace pugi {
   class xml_node;
@@ -53,6 +56,20 @@ namespace kiwix
   kainjow::mustache::data onlyAsNonEmptyMustacheValue(const std::string& s);
 
   std::string render_template(const std::string& template_str, kainjow::mustache::data data);
+
+  template<typename T>
+  T getEnvVar(const char* name, const T& defaultValue)
+  {
+    try {
+      const char* envString = std::getenv(name);
+      if (envString == nullptr) {
+        throw std::runtime_error("Environment variable not set");
+      }
+      return extractFromString<T>(envString);
+    } catch (...) {}
+
+    return defaultValue;
+  }
 }
 
 #endif

--- a/static/i18n/en.json
+++ b/static/i18n/en.json
@@ -6,6 +6,7 @@
 	"name":"English",
 	"suggest-full-text-search" : "containing '{{{SEARCH_TERMS}}}'..."
 	, "no-such-book" : "No such book: {{BOOK_NAME}}"
+	, "too-many-books" : "Too many books requested ({{NB_BOOKS}}) where limit is {{LIMIT}}"
 	, "no-book-found" : "No book matches selection criteria"
 	, "url-not-found" : "The requested URL \"{{url}}\" was not found on this server."
 	, "suggest-search" : "Make a full text search for <a href=\"{{{SEARCH_URL}}}\">{{PATTERN}}</a>"

--- a/static/i18n/en.json
+++ b/static/i18n/en.json
@@ -4,12 +4,15 @@
 		]
 	},
 	"name":"English",
-	"suggest-full-text-search": "containing '{{{SEARCH_TERMS}}}'..."
-	, "no-such-book": "No such book: {{BOOK_NAME}}"
+	"suggest-full-text-search" : "containing '{{{SEARCH_TERMS}}}'..."
+	, "no-such-book" : "No such book: {{BOOK_NAME}}"
+	, "no-book-found" : "No book matches selection criteria"
 	, "url-not-found" : "The requested URL \"{{url}}\" was not found on this server."
 	, "suggest-search" : "Make a full text search for <a href=\"{{{SEARCH_URL}}}\">{{PATTERN}}</a>"
 	, "random-article-failure" :  "Oops! Failed to pick a random article :("
 	, "invalid-raw-data-type" : "{{DATATYPE}} is not a valid request for raw content."
+	, "no-value-for-arg": "No value provided for argument {{ARGUMENT}}"
+	, "no-query" : "No query provided."
 	, "raw-entry-not-found" : "Cannot find {{DATATYPE}} entry {{ENTRY}}"
 	, "400-page-title" : "Invalid request"
 	, "400-page-heading" : "Invalid request"

--- a/static/i18n/qqq.json
+++ b/static/i18n/qqq.json
@@ -2,16 +2,20 @@
 	"@metadata": {
 		"authors": [
 			"Veloman Yunkan",
-			"Verdy p"
+			"Verdy p",
+			"Matthieu Gautier"
 		]
 	},
 	"name": "{{Doc-important|Don't write \"English\" in your language!}}\n\n'''Write the name of ''your'' language in its native script.'''\n\nCurrent language to which the string is being translated to.\n\nFor example, write \"français\" when translating to French, or \"Deutsch\" when translating to German.\n\n'''Important:''' Do not use your language’s word for “English”. Use the word that your language uses to refer to itself. If you translate this message to mean “English” in your language, your change will be reverted.",
 	"suggest-full-text-search": "Text appearing in the suggestion list that, when selected, runs a full text search instead of the title search",
 	"no-such-book": "Error text when the requested book is not found in the library",
 	"url-not-found": "Error text about wrong URL for an HTTP 404 error",
+	"no-book-found": "Error text when no book matches the selection criteria",
 	"suggest-search": "Suggest a search when the URL points to a non existing article",
 	"random-article-failure": "Failure of the random article selection procedure",
 	"invalid-raw-data-type": "Invalid DATATYPE was used with the /raw endpoint (/raw/<book>/DATATYPE/...); allowed values are 'meta' and 'content'",
+	"no-value-for-arg" : "Error text when no value has been provided for ARGUMENT in the request's query string",
+	"no-query" : "Error text when no query has been provided for fulltext search",
 	"raw-entry-not-found": "Entry requested via the /raw endpoint was not found",
 	"400-page-title": "Title of the 400 error page",
 	"400-page-heading": "Heading of the 400 error page",

--- a/static/i18n/qqq.json
+++ b/static/i18n/qqq.json
@@ -9,6 +9,7 @@
 	"name": "{{Doc-important|Don't write \"English\" in your language!}}\n\n'''Write the name of ''your'' language in its native script.'''\n\nCurrent language to which the string is being translated to.\n\nFor example, write \"français\" when translating to French, or \"Deutsch\" when translating to German.\n\n'''Important:''' Do not use your language’s word for “English”. Use the word that your language uses to refer to itself. If you translate this message to mean “English” in your language, your change will be reverted.",
 	"suggest-full-text-search": "Text appearing in the suggestion list that, when selected, runs a full text search instead of the title search",
 	"no-such-book": "Error text when the requested book is not found in the library",
+	"too-many-books":"Error text when user request more books than the limit set by the administrator",
 	"url-not-found": "Error text about wrong URL for an HTTP 404 error",
 	"no-book-found": "Error text when no book matches the selection criteria",
 	"suggest-search": "Suggest a search when the URL points to a non existing article",

--- a/test/lrucache.cpp
+++ b/test/lrucache.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2014, lamerman
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of lamerman nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "../src/tools/lrucache.h"
+#include "../src/tools/concurrent_cache.h"
+#include "gtest/gtest.h"
+
+const unsigned int NUM_OF_TEST2_RECORDS = 100;
+const unsigned int TEST2_CACHE_CAPACITY = 50;
+
+TEST(CacheTest, SimplePut) {
+    kiwix::lru_cache<int, int> cache_lru(1);
+    cache_lru.put(7, 777);
+    EXPECT_TRUE(cache_lru.exists(7));
+    EXPECT_EQ(777, cache_lru.get(7));
+    EXPECT_EQ(1U, cache_lru.size());
+}
+
+TEST(CacheTest, OverwritingPut) {
+    kiwix::lru_cache<int, int> cache_lru(1);
+    cache_lru.put(7, 777);
+    cache_lru.put(7, 222);
+    EXPECT_TRUE(cache_lru.exists(7));
+    EXPECT_EQ(222, cache_lru.get(7));
+    EXPECT_EQ(1U, cache_lru.size());
+}
+
+TEST(CacheTest, MissingValue) {
+    kiwix::lru_cache<int, int> cache_lru(1);
+    EXPECT_TRUE(cache_lru.get(7).miss());
+    EXPECT_FALSE(cache_lru.get(7).hit());
+    EXPECT_THROW(cache_lru.get(7).value(), std::range_error);
+}
+
+TEST(CacheTest, DropValue) {
+    kiwix::lru_cache<int, int> cache_lru(3);
+    cache_lru.put(7, 777);
+    cache_lru.put(8, 888);
+    cache_lru.put(9, 999);
+    EXPECT_EQ(3U, cache_lru.size());
+    EXPECT_TRUE(cache_lru.exists(7));
+    EXPECT_EQ(777, cache_lru.get(7));
+
+    EXPECT_TRUE(cache_lru.drop(7));
+
+    EXPECT_EQ(2U, cache_lru.size());
+    EXPECT_FALSE(cache_lru.exists(7));
+    EXPECT_THROW(cache_lru.get(7).value(), std::range_error);
+
+    EXPECT_FALSE(cache_lru.drop(7));
+}
+
+TEST(CacheTest1, KeepsAllValuesWithinCapacity) {
+    kiwix::lru_cache<int, int> cache_lru(TEST2_CACHE_CAPACITY);
+
+    for (uint i = 0; i < NUM_OF_TEST2_RECORDS; ++i) {
+        cache_lru.put(i, i);
+    }
+
+    for (uint i = 0; i < NUM_OF_TEST2_RECORDS - TEST2_CACHE_CAPACITY; ++i) {
+        EXPECT_FALSE(cache_lru.exists(i));
+    }
+
+    for (uint i = NUM_OF_TEST2_RECORDS - TEST2_CACHE_CAPACITY; i < NUM_OF_TEST2_RECORDS; ++i) {
+        EXPECT_TRUE(cache_lru.exists(i));
+        EXPECT_EQ((int)i, cache_lru.get(i));
+    }
+
+    size_t size = cache_lru.size();
+    EXPECT_EQ(TEST2_CACHE_CAPACITY, size);
+}
+
+TEST(ConcurrentCacheTest, handleException) {
+    kiwix::ConcurrentCache<int, int> cache(1);
+    auto val = cache.getOrPut(7, []() { return 777; });
+    EXPECT_EQ(val, 777);
+    EXPECT_THROW(cache.getOrPut(8, []() { throw std::runtime_error("oups"); return 0; }), std::runtime_error);
+    val = cache.getOrPut(8, []() { return 888; });
+    EXPECT_EQ(val, 888);
+}
+

--- a/test/meson.build
+++ b/test/meson.build
@@ -10,7 +10,8 @@ tests = [
     'manager',
     'name_mapper',
     'opds_catalog',
-    'server_helper'
+    'server_helper',
+    'lrucache'
 ]
 
 if build_machine.system() != 'windows'

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -1590,6 +1590,8 @@ bool isSubSnippet(std::string subSnippet, const std::string& superSnippet)
   return true;
 }
 
+#define  RAYCHARLESZIMID "6f1d19d0-633f-087b-fb55-7ac324ff9baf"
+
 TEST_F(TaskbarlessServerTest, searchResults)
 {
   struct TestData
@@ -1601,7 +1603,7 @@ TEST_F(TaskbarlessServerTest, searchResults)
       bool selected;
     };
 
-    std::string pattern;
+    std::string query;
     int start;
     size_t resultsPerPage;
     size_t totalResultCount;
@@ -1609,9 +1611,9 @@ TEST_F(TaskbarlessServerTest, searchResults)
     std::vector<std::string> results;
     std::vector<PaginationEntry> pagination;
 
-    static std::string makeUrl(const std::string pattern, int start, size_t resultsPerPage)
+    static std::string makeUrl(const std::string& query, int start, size_t resultsPerPage)
     {
-      std::string url = "/ROOT/search?pattern=" + pattern + "&books.id=6f1d19d0-633f-087b-fb55-7ac324ff9baf";
+      std::string url = "/ROOT/search?" + query;
 
       if ( start >= 0 ) {
         url += "&start=" + to_string(start);
@@ -1624,15 +1626,23 @@ TEST_F(TaskbarlessServerTest, searchResults)
       return url;
     }
 
+    std::string getPattern() const
+    {
+      const std::string p = "pattern=";
+      const size_t i = query.find(p);
+      std::string r = query.substr(i + p.size());
+      return r.substr(0, r.find("&"));
+    }
+
     std::string url() const
     {
-      return makeUrl(pattern, start, resultsPerPage);
+      return makeUrl(query, start, resultsPerPage);
     }
 
     std::string expectedHeader() const
     {
       if ( totalResultCount == 0 ) {
-        return "\n        No results were found for <b>\"" + pattern + "\"</b>";
+        return "\n        No results were found for <b>\"" + getPattern() + "\"</b>";
       }
 
       std::string header = R"(  Results
@@ -1649,7 +1659,7 @@ TEST_F(TaskbarlessServerTest, searchResults)
       header = replace(header, "FIRSTRESULT", to_string(firstResultIndex));
       header = replace(header, "LASTRESULT",  to_string(lastResultIndex));
       header = replace(header, "RESULTCOUNT", to_string(totalResultCount));
-      header = replace(header, "PATTERN",     pattern);
+      header = replace(header, "PATTERN",     getPattern());
       return header;
     }
 
@@ -1677,7 +1687,7 @@ TEST_F(TaskbarlessServerTest, searchResults)
       std::ostringstream oss;
       oss << "\n        <ul>\n";
       for ( const auto& p : pagination ) {
-        const auto url = makeUrl(pattern, p.start, resultsPerPage);
+        const auto url = makeUrl(query, p.start, resultsPerPage);
         oss << "            <li>\n";
         oss << "              <a ";
         if ( p.selected ) {
@@ -1695,7 +1705,7 @@ TEST_F(TaskbarlessServerTest, searchResults)
     std::string expectedHtml() const
     {
       return makeSearchResultsHtml(
-               pattern,
+               getPattern(),
                expectedHeader(),
                expectedResultsString(),
                expectedFooter()
@@ -1768,7 +1778,7 @@ TEST_F(TaskbarlessServerTest, searchResults)
 
   const TestData testData[] = {
     {
-      /* pattern */          "velomanyunkan",
+      /* query */          "pattern=velomanyunkan&books.id=" RAYCHARLESZIMID,
       /* start */            -1,
       /* resultsPerPage */   0,
       /* totalResultCount */ 0,
@@ -1778,7 +1788,7 @@ TEST_F(TaskbarlessServerTest, searchResults)
     },
 
     {
-      /* pattern */          "razaf",
+      /* query */          "pattern=razaf&books.id=" RAYCHARLESZIMID,
       /* start */            -1,
       /* resultsPerPage */   0,
       /* totalResultCount */ 1,
@@ -1797,7 +1807,7 @@ R"SEARCHRESULT(
     },
 
     {
-      /* pattern */          "yellow",
+      /* query */          "pattern=yellow&books.id=" RAYCHARLESZIMID,
       /* start */            -1,
       /* resultsPerPage */   0,
       /* totalResultCount */ 2,
@@ -1825,7 +1835,7 @@ R"SEARCHRESULT(
     },
 
     {
-      /* pattern */          "jazz",
+      /* query */          "pattern=jazz&books.id=" RAYCHARLESZIMID,
       /* start */            -1,
       /* resultsPerPage */   100,
       /* totalResultCount */ 44,
@@ -1835,7 +1845,7 @@ R"SEARCHRESULT(
     },
 
     {
-      /* pattern */          "jazz",
+      /* query */          "pattern=jazz&books.id=" RAYCHARLESZIMID,
       /* start */            -1,
       /* resultsPerPage */   5,
       /* totalResultCount */ 44,
@@ -1859,7 +1869,7 @@ R"SEARCHRESULT(
     },
 
     {
-      /* pattern */          "jazz",
+      /* query */          "pattern=jazz&books.id=" RAYCHARLESZIMID,
       /* start */            5,
       /* resultsPerPage */   5,
       /* totalResultCount */ 44,
@@ -1884,7 +1894,7 @@ R"SEARCHRESULT(
     },
 
     {
-      /* pattern */          "jazz",
+      /* query */          "pattern=jazz&books.id=" RAYCHARLESZIMID,
       /* start */            10,
       /* resultsPerPage */   5,
       /* totalResultCount */ 44,
@@ -1910,7 +1920,7 @@ R"SEARCHRESULT(
     },
 
     {
-      /* pattern */          "jazz",
+      /* query */          "pattern=jazz&books.id=" RAYCHARLESZIMID,
       /* start */            15,
       /* resultsPerPage */   5,
       /* totalResultCount */ 44,
@@ -1937,7 +1947,7 @@ R"SEARCHRESULT(
     },
 
     {
-      /* pattern */          "jazz",
+      /* query */            "pattern=jazz&books.id=" RAYCHARLESZIMID,
       /* start */            20,
       /* resultsPerPage */   5,
       /* totalResultCount */ 44,
@@ -1964,7 +1974,7 @@ R"SEARCHRESULT(
     },
 
     {
-      /* pattern */          "jazz",
+      /* query */          "pattern=jazz&books.id=" RAYCHARLESZIMID,
       /* start */            25,
       /* resultsPerPage */   5,
       /* totalResultCount */ 44,
@@ -1991,7 +2001,7 @@ R"SEARCHRESULT(
     },
 
     {
-      /* pattern */          "jazz",
+      /* query */          "pattern=jazz&books.id=" RAYCHARLESZIMID,
       /* start */            30,
       /* resultsPerPage */   5,
       /* totalResultCount */ 44,
@@ -2017,7 +2027,7 @@ R"SEARCHRESULT(
     },
 
     {
-      /* pattern */          "jazz",
+      /* query */          "pattern=jazz&books.id=" RAYCHARLESZIMID,
       /* start */            35,
       /* resultsPerPage */   5,
       /* totalResultCount */ 44,
@@ -2042,7 +2052,7 @@ R"SEARCHRESULT(
     },
 
     {
-      /* pattern */          "jazz",
+      /* query */          "pattern=jazz&books.id=" RAYCHARLESZIMID,
       /* start */            40,
       /* resultsPerPage */   5,
       /* totalResultCount */ 44,
@@ -2065,7 +2075,7 @@ R"SEARCHRESULT(
     },
 
     {
-      /* pattern */          "jazz",
+      /* query */          "pattern=jazz&books.id=" RAYCHARLESZIMID,
       /* start */            21,
       /* resultsPerPage */   3,
       /* totalResultCount */ 44,
@@ -2094,7 +2104,7 @@ R"SEARCHRESULT(
     // This test-point only documents how the current implementation
     // works, not how it should work!
     {
-      /* pattern */          "jazz",
+      /* query */          "pattern=jazz&books.id=" RAYCHARLESZIMID,
       /* start */            45,
       /* resultsPerPage */   5,
       /* totalResultCount */ 44,

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -156,6 +156,7 @@ protected:
   const int PORT = 8001;
   const ZimFileServer::FilePathCollection ZIMFILES {
     "./test/zimfile.zim",
+    "./test/example.zim",
     "./test/poor.zim",
     "./test/corner_cases.zim"
   };
@@ -1591,6 +1592,7 @@ bool isSubSnippet(std::string subSnippet, const std::string& superSnippet)
 }
 
 #define  RAYCHARLESZIMID "6f1d19d0-633f-087b-fb55-7ac324ff9baf"
+#define  EXAMPLEZIMID    "5dc0b3af-5df2-0925-f0ca-d2bf75e78af6"
 
 TEST_F(TaskbarlessServerTest, searchResults)
 {
@@ -2119,6 +2121,37 @@ R"SEARCHRESULT(
         { "9", 40, false  },
       }
     },
+
+    {
+      /* query */          "pattern=travel"
+                           "&books.id=" RAYCHARLESZIMID
+                           "&books.id=" EXAMPLEZIMID,
+      /* start */            0,
+      /* resultsPerPage */   10,
+      /* totalResultCount */ 2,
+      /* firstResultIndex */ 1,
+      /* results */          {
+R"SEARCHRESULT(
+            <a href="/ROOT/zimfile/A/If_You_Go_Away">
+              If You Go Away
+            </a>
+              <cite>...<b>Travel</b> On" (1965) "If You Go Away" (1966) "Walk Away" (1967) Damita Jo reached #10 on the Adult Contemporary chart and #68 on the Billboard Hot 100 in 1966 for her version of the song. Terry Jacks recorded a version of the song which was released as a single in 1974 and reached #29 on the Adult Contemporary chart, #68 on the Billboard Hot 100, and went to #8 in the UK. The complex melody is partly derivative of classical music - the poignant "But if you stay..." passage comes from Franz Liszt's......</cite>
+              <div class="book-title">from Ray Charles</div>
+              <div class="informations">204 words</div>
+)SEARCHRESULT",
+
+R"SEARCHRESULT(
+            <a href="/ROOT/example/Wikibooks.html">
+              Wikibooks
+            </a>
+              <cite>...<b>Travel</b> guide Wikidata Knowledge database Commons Media repository Meta Coordination MediaWiki MediaWiki software Phabricator MediaWiki bug tracker Wikimedia Labs MediaWiki development The Wikimedia Foundation is a non-profit organization that depends on your voluntarism and donations to operate. If you find Wikibooks or other projects hosted by the Wikimedia Foundation useful, please volunteer or make a donation. Your donations primarily helps to purchase server equipment, launch new projects......</cite>
+              <div class="book-title">from Wikibooks</div>
+              <div class="informations">538 words</div>
+)SEARCHRESULT"
+      },
+      /* pagination */       {}
+    },
+
   };
 
   for ( const auto& t : testData ) {

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -1611,7 +1611,7 @@ TEST_F(TaskbarlessServerTest, searchResults)
 
     static std::string makeUrl(const std::string pattern, int start, size_t resultsPerPage)
     {
-      std::string url = "/ROOT/search?pattern=" + pattern + "&content=zimfile";
+      std::string url = "/ROOT/search?pattern=" + pattern + "&books.id=6f1d19d0-633f-087b-fb55-7ac324ff9baf";
 
       if ( start >= 0 ) {
         url += "&start=" + to_string(start);

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -919,7 +919,7 @@ TEST_F(ServerTest, 400WithBodyTesting)
       The requested URL "/ROOT/search?content=non-existing-book&pattern=asdfqwerty" is not a valid request.
     </p>
     <p>
-      The requested book doesn't exist.
+      No such book: non-existing-book
     </p>
 )"  },
     { /* url */ "/ROOT/search?content=non-existing-book&pattern=a\"<script foo>",
@@ -929,7 +929,7 @@ TEST_F(ServerTest, 400WithBodyTesting)
       The requested URL "/ROOT/search?content=non-existing-book&pattern=a"&lt;script foo&gt;" is not a valid request.
     </p>
     <p>
-      The requested book doesn't exist.
+      No such book: non-existing-book
     </p>
 )"  },
     // There is a flaw in our way to handle query string, we cannot differenciate


### PR DESCRIPTION
Based on #724 

- Better cache system
- Be able to specify a list of zim files to search in.
- Correctly protect search from multithread race condition (may be the root cause of #760)
- Maximal number of books on which we do a multizim search can be configured

The filtering of books to use in the search is made using new querystring parameter:
- `books.id` to specify book's id to use (may be provided several times to select several books)
- `books.name` to specify book's name to use (may be provided several times to select several books).
- `content`, same as `books.name`. Keep for compatibility. `content` can be provided only once
- `books.filter.foo` to do a search on the books using the `foo` criteria. Available criterias are the same as to search books in the opds stream

This PR now integrate #730 as both PR must be merge together to have something coherent.