### PR TITLE
New way of building 404 error HTML responses

### DIFF
--- a/src/opds_dumper.cpp
+++ b/src/opds_dumper.cpp
@@ -73,9 +73,6 @@ IllustrationInfo getBookIllustrationInfo(const Book& book)
 kainjow::mustache::object getSingleBookData(const Book& book)
 {
     const auto bookDate = book.getDate() + "T00:00:00Z";
-    const MustacheData bookUrl = book.getUrl().empty()
-                               ? MustacheData(false)
-                               : MustacheData(book.getUrl());
     return kainjow::mustache::object{
       {"id", book.getId()},
       {"name", book.getName()},
@@ -92,7 +89,7 @@ kainjow::mustache::object getSingleBookData(const Book& book)
       {"media_count", to_string(book.getMediaCount())},
       {"author_name", book.getCreator()},
       {"publisher_name", book.getPublisher()},
-      {"url", bookUrl},
+      {"url", onlyAsNonEmptyMustacheValue(book.getUrl())},
       {"size", to_string(book.getSize())},
       {"icons", getBookIllustrationInfo(book)},
     };
@@ -194,7 +191,7 @@ string OPDSDumper::dumpOPDSFeed(const std::vector<std::string>& bookIds, const s
      {"date", gen_date_str()},
      {"root", rootLocation},
      {"feed_id", gen_uuid(libraryId + "/catalog/search?"+query)},
-     {"filter", query.empty() ? MustacheData(false) : MustacheData(query)},
+     {"filter", onlyAsNonEmptyMustacheValue(query)},
      {"totalResults", to_string(m_totalResults)},
      {"startIndex", to_string(m_startIndex)},
      {"itemsPerPage", to_string(m_count)},
@@ -214,7 +211,7 @@ string OPDSDumper::dumpOPDSFeedV2(const std::vector<std::string>& bookIds, const
      {"date", gen_date_str()},
      {"endpoint_root", endpointRoot},
      {"feed_id", gen_uuid(libraryId + endpoint + "?" + query)},
-     {"filter", query.empty() ? MustacheData(false) : MustacheData(query)},
+     {"filter", onlyAsNonEmptyMustacheValue(query)},
      {"query", query.empty() ? "" : "?" + urlEncode(query)},
      {"totalResults", to_string(m_totalResults)},
      {"startIndex", to_string(m_startIndex)},

--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -676,7 +676,7 @@ std::unique_ptr<Response> InternalServer::handle_catalog(const RequestContext& r
     host = request.get_header("Host");
     url  = request.get_url_part(1);
   } catch (const std::out_of_range&) {
-    return make404Response(*this, request)
+    return HTTP404HtmlResponse(*this, request)
            + urlNotFoundMsg;
   }
 
@@ -685,7 +685,7 @@ std::unique_ptr<Response> InternalServer::handle_catalog(const RequestContext& r
   }
 
   if (url != "searchdescription.xml" && url != "root.xml" && url != "search") {
-    return make404Response(*this, request)
+    return HTTP404HtmlResponse(*this, request)
            + urlNotFoundMsg;
   }
 

--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -387,26 +387,6 @@ SuggestionsList_t getSuggestions(SuggestionSearcherCache& cache, const zim::Arch
   return suggestions;
 }
 
-namespace
-{
-
-class UrlNotFoundMsg {};
-
-const UrlNotFoundMsg urlNotFoundMsg;
-
-ContentResponseBlueprint&& operator+(ContentResponseBlueprint&& crb,
-                                     UrlNotFoundMsg /*unused*/)
-{
-  const std::string requestUrl = crb.m_request.get_full_url();
-  kainjow::mustache::mustache msgTmpl(R"(The requested URL "{{url}}" was not found on this server.)");
-  const auto urlNotFoundMsgText = msgTmpl.render({"url", requestUrl});
-  crb.m_data["details"].push_back({"p", urlNotFoundMsgText});
-  return std::move(crb);
-}
-
-
-} // unnamed namespace
-
 std::unique_ptr<Response> InternalServer::handle_suggest(const RequestContext& request)
 {
   if (m_verbose.load()) {

--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -877,7 +877,9 @@ std::unique_ptr<Response> InternalServer::handle_raw(const RequestContext& reque
 
   if (archive == nullptr) {
     const std::string error_details = "No such book: " + bookName;
-    return Response::build_404(*this, request.get_full_url(), error_details);
+    return HTTP404HtmlResponse(*this, request)
+           + urlNotFoundMsg
+           + error_details;
   }
 
   // Remove the beggining of the path:

--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -657,7 +657,8 @@ std::unique_ptr<Response> InternalServer::handle_catalog(const RequestContext& r
     host = request.get_header("Host");
     url  = request.get_url_part(1);
   } catch (const std::out_of_range&) {
-    return Response::build_404(*this, request.get_full_url());
+    return make404Response(*this, request)
+           + make404ResponseData(request.get_full_url());
   }
 
   if (url == "v2") {

--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -519,9 +519,8 @@ std::unique_ptr<Response> InternalServer::handle_search(const RequestContext& re
     data.set("pattern", encodeDiples(patternString));
     data.set("root", m_root);
     auto response = ContentResponse::build(*this, RESOURCE::templates::no_search_result_html, data, "text/html; charset=utf-8");
-    response->set_taskbar(bookName, archive ? getArchiveTitle(*archive) : "");
     response->set_code(MHD_HTTP_NOT_FOUND);
-    return std::move(response);
+    return withTaskbarInfo(bookName, archive.get(), std::move(response));
   }
 
   std::shared_ptr<zim::Searcher> searcher;
@@ -591,9 +590,7 @@ std::unique_ptr<Response> InternalServer::handle_search(const RequestContext& re
     renderer.setSearchProtocolPrefix(m_root + "/search?");
     renderer.setPageLength(pageLength);
     auto response = ContentResponse::build(*this, renderer.getHtml(), "text/html; charset=utf-8");
-    response->set_taskbar(bookName, archive ? getArchiveTitle(*archive) : "");
-
-    return std::move(response);
+    return withTaskbarInfo(bookName, archive.get(), std::move(response));
   } catch (const std::exception& e) {
     std::cerr << e.what() << std::endl;
     return Response::build_500(*this, e.what());

--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -278,8 +278,10 @@ MHD_Result InternalServer::handlerCallback(struct MHD_Connection* connection,
 std::unique_ptr<Response> InternalServer::handle_request(const RequestContext& request)
 {
   try {
-    if (! request.is_valid_url())
-      return Response::build_404(*this, request.get_full_url());
+    if (! request.is_valid_url()) {
+      return HTTP404HtmlResponse(*this, request)
+             + urlNotFoundMsg;
+    }
 
     const ETag etag = get_matching_if_none_match_etag(request);
     if ( etag )
@@ -476,7 +478,8 @@ std::unique_ptr<Response> InternalServer::handle_skin(const RequestContext& requ
     response->set_cacheable();
     return std::move(response);
   } catch (const ResourceNotFound& e) {
-    return Response::build_404(*this, request.get_full_url());
+    return HTTP404HtmlResponse(*this, request)
+           + urlNotFoundMsg;
   }
 }
 
@@ -636,8 +639,10 @@ std::unique_ptr<Response> InternalServer::handle_captured_external(const Request
     source = kiwix::urlDecode(request.get_argument("source"));
   } catch (const std::out_of_range& e) {}
 
-  if (source.empty())
-    return Response::build_404(*this, request.get_full_url());
+  if (source.empty()) {
+    return HTTP404HtmlResponse(*this, request)
+           + urlNotFoundMsg;
+  }
 
   auto data = get_default_data();
   data.set("source", source);
@@ -855,7 +860,8 @@ std::unique_ptr<Response> InternalServer::handle_raw(const RequestContext& reque
      bookName = request.get_url_part(1);
      kind = request.get_url_part(2);
   } catch (const std::out_of_range& e) {
-    return Response::build_404(*this, request.get_full_url());
+    return HTTP404HtmlResponse(*this, request)
+           + urlNotFoundMsg;
   }
 
   if (kind != "meta" && kind!= "content") {

--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -627,9 +627,9 @@ std::unique_ptr<Response> InternalServer::handle_random(const RequestContext& re
   }
 
   if (archive == nullptr) {
-    const std::string error_details = noSuchBookErrorMsg(bookName);
-    auto response = Response::build_404(*this, "", error_details);
-    return withTaskbarInfo(bookName, nullptr, std::move(response));
+    return HTTP404HtmlResponse(*this, request)
+           + noSuchBookErrorMsg(bookName)
+           + TaskbarInfo(bookName);
   }
 
   try {

--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -816,7 +816,7 @@ std::unique_ptr<Response> InternalServer::handle_content(const RequestContext& r
     }
     auto response = ItemResponse::build(*this, request, entry.getItem());
     try {
-      dynamic_cast<ContentResponse&>(*response).set_taskbar(bookName, getArchiveTitle(*archive));
+      dynamic_cast<ContentResponse&>(*response).set_taskbar(bookName, archive.get());
     } catch (std::bad_cast& e) {}
 
     if (m_verbose.load()) {

--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -389,6 +389,16 @@ SuggestionsList_t getSuggestions(SuggestionSearcherCache& cache, const zim::Arch
   return suggestions;
 }
 
+namespace
+{
+
+std::string noSuchBookErrorMsg(const std::string& bookName)
+{
+  return "No such book: " + bookName;
+}
+
+} // unnamed namespace
+
 std::unique_ptr<Response> InternalServer::handle_suggest(const RequestContext& request)
 {
   if (m_verbose.load()) {
@@ -406,7 +416,7 @@ std::unique_ptr<Response> InternalServer::handle_suggest(const RequestContext& r
   }
 
   if (archive == nullptr) {
-    const std::string error_details = "No such book: " + bookName;
+    const std::string error_details = noSuchBookErrorMsg(bookName);
     auto response = Response::build_404(*this, "", error_details);
     return withTaskbarInfo(bookName, nullptr, std::move(response));
   }
@@ -617,7 +627,7 @@ std::unique_ptr<Response> InternalServer::handle_random(const RequestContext& re
   }
 
   if (archive == nullptr) {
-    const std::string error_details = "No such book: " + bookName;
+    const std::string error_details = noSuchBookErrorMsg(bookName);
     auto response = Response::build_404(*this, "", error_details);
     return withTaskbarInfo(bookName, nullptr, std::move(response));
   }
@@ -876,10 +886,9 @@ std::unique_ptr<Response> InternalServer::handle_raw(const RequestContext& reque
   } catch (const std::out_of_range& e) {}
 
   if (archive == nullptr) {
-    const std::string error_details = "No such book: " + bookName;
     return HTTP404HtmlResponse(*this, request)
            + urlNotFoundMsg
-           + error_details;
+           + noSuchBookErrorMsg(bookName);
   }
 
   // Remove the beggining of the path:

--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -416,9 +416,9 @@ std::unique_ptr<Response> InternalServer::handle_suggest(const RequestContext& r
   }
 
   if (archive == nullptr) {
-    const std::string error_details = noSuchBookErrorMsg(bookName);
-    auto response = Response::build_404(*this, "", error_details);
-    return withTaskbarInfo(bookName, nullptr, std::move(response));
+    return HTTP404HtmlResponse(*this, request)
+           + noSuchBookErrorMsg(bookName)
+           + TaskbarInfo(bookName);
   }
 
   const auto queryString = request.get_optional_param("term", std::string());

--- a/src/server/internalServer_catalog_v2.cpp
+++ b/src/server/internalServer_catalog_v2.cpp
@@ -43,7 +43,7 @@ std::unique_ptr<Response> InternalServer::handle_catalog_v2(const RequestContext
   try {
     url  = request.get_url_part(2);
   } catch (const std::out_of_range&) {
-    return Response::build_404(*this, request.get_full_url(), "", "");
+    return Response::build_404(*this, request.get_full_url());
   }
 
   if (url == "root.xml") {
@@ -69,7 +69,7 @@ std::unique_ptr<Response> InternalServer::handle_catalog_v2(const RequestContext
   } else if (url == "illustration") {
     return handle_catalog_v2_illustration(request);
   } else {
-    return Response::build_404(*this, request.get_full_url(), "", "");
+    return Response::build_404(*this, request.get_full_url());
   }
 }
 
@@ -110,7 +110,7 @@ std::unique_ptr<Response> InternalServer::handle_catalog_v2_complete_entry(const
   try {
     mp_library->getBookById(entryId);
   } catch (const std::out_of_range&) {
-    return Response::build_404(*this, request.get_full_url(), "", "");
+    return Response::build_404(*this, request.get_full_url());
   }
 
   OPDSDumper opdsDumper(mp_library);
@@ -158,7 +158,7 @@ std::unique_ptr<Response> InternalServer::handle_catalog_v2_illustration(const R
     auto illustration = book.getIllustration(size);
     return ContentResponse::build(*this, illustration->getData(), illustration->mimeType);
   } catch(...) {
-    return Response::build_404(*this, request.get_full_url(), "", "");
+    return Response::build_404(*this, request.get_full_url());
   }
 }
 

--- a/src/server/internalServer_catalog_v2.cpp
+++ b/src/server/internalServer_catalog_v2.cpp
@@ -43,7 +43,8 @@ std::unique_ptr<Response> InternalServer::handle_catalog_v2(const RequestContext
   try {
     url  = request.get_url_part(2);
   } catch (const std::out_of_range&) {
-    return Response::build_404(*this, request.get_full_url());
+    return HTTP404HtmlResponse(*this, request)
+           + urlNotFoundMsg;
   }
 
   if (url == "root.xml") {
@@ -69,7 +70,8 @@ std::unique_ptr<Response> InternalServer::handle_catalog_v2(const RequestContext
   } else if (url == "illustration") {
     return handle_catalog_v2_illustration(request);
   } else {
-    return Response::build_404(*this, request.get_full_url());
+    return HTTP404HtmlResponse(*this, request)
+           + urlNotFoundMsg;
   }
 }
 
@@ -110,7 +112,8 @@ std::unique_ptr<Response> InternalServer::handle_catalog_v2_complete_entry(const
   try {
     mp_library->getBookById(entryId);
   } catch (const std::out_of_range&) {
-    return Response::build_404(*this, request.get_full_url());
+    return HTTP404HtmlResponse(*this, request)
+           + urlNotFoundMsg;
   }
 
   OPDSDumper opdsDumper(mp_library);
@@ -158,7 +161,8 @@ std::unique_ptr<Response> InternalServer::handle_catalog_v2_illustration(const R
     auto illustration = book.getIllustration(size);
     return ContentResponse::build(*this, illustration->getData(), illustration->mimeType);
   } catch(...) {
-    return Response::build_404(*this, request.get_full_url());
+    return HTTP404HtmlResponse(*this, request)
+           + urlNotFoundMsg;
   }
 }
 

--- a/src/server/response.cpp
+++ b/src/server/response.cpp
@@ -86,13 +86,13 @@ std::unique_ptr<Response> Response::build_304(const InternalServer& server, cons
 
 std::unique_ptr<ContentResponse> Response::build_404(const InternalServer& server, const std::string& url, const std::string& details)
 {
-  MustacheData results;
+  MustacheData data;
   if ( !url.empty() ) {
-    results.set("url", url);
+    data.set("url", url);
   }
-  results.set("details", details);
+  data.set("details", details);
 
-  auto response = ContentResponse::build(server, RESOURCE::templates::_404_html, results, "text/html");
+  auto response = ContentResponse::build(server, RESOURCE::templates::_404_html, data, "text/html");
   response->set_code(MHD_HTTP_NOT_FOUND);
 
   return response;

--- a/src/server/response.cpp
+++ b/src/server/response.cpp
@@ -25,6 +25,7 @@
 #include "tools/regexTools.h"
 #include "tools/stringTools.h"
 #include "tools/otherTools.h"
+#include "tools/archiveTools.h"
 
 #include "string.h"
 #include <mustache.hpp>
@@ -381,6 +382,15 @@ std::unique_ptr<ContentResponse> ContentResponse::build(
 {
   auto content = render_template(template_str, data);
   return ContentResponse::build(server, content, mimetype, isHomePage);
+}
+
+std::unique_ptr<ContentResponse> withTaskbarInfo(
+  const std::string& bookName,
+  const zim::Archive* archive,
+  std::unique_ptr<ContentResponse> r)
+{
+  r->set_taskbar(bookName, archive ? getArchiveTitle(*archive) : "");
+  return r;
 }
 
 ItemResponse::ItemResponse(bool verbose, const zim::Item& item, const std::string& mimetype, const ByteRange& byterange) :

--- a/src/server/response.cpp
+++ b/src/server/response.cpp
@@ -83,7 +83,7 @@ std::unique_ptr<Response> Response::build_304(const InternalServer& server, cons
   return response;
 }
 
-std::unique_ptr<Response> Response::build_404(const InternalServer& server, const std::string& url, const std::string& bookName, const std::string& bookTitle, const std::string& details)
+std::unique_ptr<ContentResponse> Response::build_404(const InternalServer& server, const std::string& url, const std::string& bookName, const std::string& bookTitle, const std::string& details)
 {
   MustacheData results;
   if ( !url.empty() ) {
@@ -95,7 +95,7 @@ std::unique_ptr<Response> Response::build_404(const InternalServer& server, cons
   response->set_code(MHD_HTTP_NOT_FOUND);
   response->set_taskbar(bookName, bookTitle);
 
-  return std::move(response);
+  return response;
 }
 
 std::unique_ptr<Response> Response::build_416(const InternalServer& server, size_t resourceLength)

--- a/src/server/response.cpp
+++ b/src/server/response.cpp
@@ -84,7 +84,7 @@ std::unique_ptr<Response> Response::build_304(const InternalServer& server, cons
   return response;
 }
 
-std::unique_ptr<ContentResponse> Response::build_404(const InternalServer& server, const std::string& url, const std::string& bookName, const std::string& bookTitle, const std::string& details)
+std::unique_ptr<ContentResponse> Response::build_404(const InternalServer& server, const std::string& url, const std::string& details)
 {
   MustacheData results;
   if ( !url.empty() ) {
@@ -94,7 +94,6 @@ std::unique_ptr<ContentResponse> Response::build_404(const InternalServer& serve
 
   auto response = ContentResponse::build(server, RESOURCE::templates::_404_html, results, "text/html");
   response->set_code(MHD_HTTP_NOT_FOUND);
-  response->set_taskbar(bookName, bookTitle);
 
   return response;
 }

--- a/src/server/response.cpp
+++ b/src/server/response.cpp
@@ -92,11 +92,17 @@ std::unique_ptr<ContentResponse> Response::build_404(const InternalServer& serve
   }
   data.set("details", details);
 
+  return build_404(server, data);
+}
+
+std::unique_ptr<ContentResponse> Response::build_404(const InternalServer& server, const kainjow::mustache::data& data)
+{
   auto response = ContentResponse::build(server, RESOURCE::templates::_404_html, data, "text/html");
   response->set_code(MHD_HTTP_NOT_FOUND);
 
   return response;
 }
+
 
 std::unique_ptr<Response> Response::build_416(const InternalServer& server, size_t resourceLength)
 {

--- a/src/server/response.cpp
+++ b/src/server/response.cpp
@@ -115,7 +115,9 @@ std::unique_ptr<ContentResponse> ContentResponseBlueprint::generateResponseObjec
 {
   auto r = ContentResponse::build(m_server, m_template, m_data, m_mimeType);
   r->set_code(m_httpStatusCode);
-  return r;
+  return m_taskbarInfo
+       ? withTaskbarInfo(m_taskbarInfo->bookName, m_taskbarInfo->archive, std::move(r))
+       : std::move(r);
 }
 
 HTTP404HtmlResponse::HTTP404HtmlResponse(const InternalServer& server,
@@ -143,18 +145,10 @@ HTTP404HtmlResponse& HTTP404HtmlResponse::operator+(const std::string& msg)
   return *this;
 }
 
-HTTP404HtmlResponse& HTTP404HtmlResponse::operator+(const TaskbarInfo& taskbarInfo)
+ContentResponseBlueprint& ContentResponseBlueprint::operator+(const TaskbarInfo& taskbarInfo)
 {
-  this->taskbarInfo.reset(new TaskbarInfo(taskbarInfo));
+  this->m_taskbarInfo.reset(new TaskbarInfo(taskbarInfo));
   return *this;
-}
-
-std::unique_ptr<ContentResponse> HTTP404HtmlResponse::generateResponseObject() const
-{
-  auto r = ContentResponseBlueprint::generateResponseObject();
-  return taskbarInfo
-       ? withTaskbarInfo(taskbarInfo->bookName, taskbarInfo->archive, std::move(r))
-       : std::move(r);
 }
 
 std::unique_ptr<Response> Response::build_416(const InternalServer& server, size_t resourceLength)

--- a/src/server/response.cpp
+++ b/src/server/response.cpp
@@ -112,11 +112,14 @@ std::unique_ptr<ContentResponse> Response::build_404(const InternalServer& serve
 ContentResponseBlueprint make404Response(const InternalServer& server,
                                          const RequestContext& request)
 {
-  return ContentResponseBlueprint(&server,
-                                  &request,
-                                  MHD_HTTP_NOT_FOUND,
-                                  "text/html",
-                                  RESOURCE::templates::_404_html);
+  auto crb = ContentResponseBlueprint(&server,
+                                      &request,
+                                      MHD_HTTP_NOT_FOUND,
+                                      "text/html",
+                                      RESOURCE::templates::_404_html);
+
+  kainjow::mustache::list emptyList;
+  return crb + kainjow::mustache::object{{"details", emptyList}};
 }
 
 std::unique_ptr<Response> Response::build_416(const InternalServer& server, size_t resourceLength)

--- a/src/server/response.cpp
+++ b/src/server/response.cpp
@@ -333,10 +333,10 @@ MHD_Result Response::send(const RequestContext& request, MHD_Connection* connect
   return ret;
 }
 
-void ContentResponse::set_taskbar(const std::string& bookName, const std::string& bookTitle)
+void ContentResponse::set_taskbar(const std::string& bookName, const zim::Archive* archive)
 {
   m_bookName = bookName;
-  m_bookTitle = bookTitle;
+  m_bookTitle = archive ? getArchiveTitle(*archive) : "";
 }
 
 
@@ -389,7 +389,7 @@ std::unique_ptr<ContentResponse> withTaskbarInfo(
   const zim::Archive* archive,
   std::unique_ptr<ContentResponse> r)
 {
-  r->set_taskbar(bookName, archive ? getArchiveTitle(*archive) : "");
+  r->set_taskbar(bookName, archive);
   return r;
 }
 

--- a/src/server/response.cpp
+++ b/src/server/response.cpp
@@ -109,17 +109,16 @@ std::unique_ptr<ContentResponse> Response::build_404(const InternalServer& serve
   return response;
 }
 
-ContentResponseBlueprint make404Response(const InternalServer& server,
+HTTP404HtmlResponse::HTTP404HtmlResponse(const InternalServer& server,
                                          const RequestContext& request)
+  : ContentResponseBlueprint(&server,
+                             &request,
+                             MHD_HTTP_NOT_FOUND,
+                             "text/html",
+                             RESOURCE::templates::_404_html)
 {
-  auto crb = ContentResponseBlueprint(&server,
-                                      &request,
-                                      MHD_HTTP_NOT_FOUND,
-                                      "text/html",
-                                      RESOURCE::templates::_404_html);
-
   kainjow::mustache::list emptyList;
-  return crb + kainjow::mustache::object{{"details", emptyList}};
+  this->m_data = kainjow::mustache::object{{"details", emptyList}};
 }
 
 std::unique_ptr<Response> Response::build_416(const InternalServer& server, size_t resourceLength)

--- a/src/server/response.cpp
+++ b/src/server/response.cpp
@@ -136,6 +136,20 @@ HTTP404HtmlResponse& HTTP404HtmlResponse::operator+(const std::string& msg)
   return *this;
 }
 
+HTTP404HtmlResponse& HTTP404HtmlResponse::operator+(const TaskbarInfo& taskbarInfo)
+{
+  this->taskbarInfo.reset(new TaskbarInfo(taskbarInfo));
+  return *this;
+}
+
+std::unique_ptr<ContentResponse> HTTP404HtmlResponse::generateResponseObject() const
+{
+  auto r = ContentResponseBlueprint::generateResponseObject();
+  return taskbarInfo
+       ? withTaskbarInfo(taskbarInfo->bookName, taskbarInfo->archive, std::move(r))
+       : std::move(r);
+}
+
 std::unique_ptr<Response> Response::build_416(const InternalServer& server, size_t resourceLength)
 {
   auto response = Response::build(server);

--- a/src/server/response.cpp
+++ b/src/server/response.cpp
@@ -109,6 +109,8 @@ std::unique_ptr<ContentResponse> Response::build_404(const InternalServer& serve
   return response;
 }
 
+extern const UrlNotFoundMsg urlNotFoundMsg;
+
 HTTP404HtmlResponse::HTTP404HtmlResponse(const InternalServer& server,
                                          const RequestContext& request)
   : ContentResponseBlueprint(&server,
@@ -119,6 +121,15 @@ HTTP404HtmlResponse::HTTP404HtmlResponse(const InternalServer& server,
 {
   kainjow::mustache::list emptyList;
   this->m_data = kainjow::mustache::object{{"details", emptyList}};
+}
+
+HTTP404HtmlResponse& HTTP404HtmlResponse::operator+(UrlNotFoundMsg /*unused*/)
+{
+  const std::string requestUrl = m_request.get_full_url();
+  kainjow::mustache::mustache msgTmpl(R"(The requested URL "{{url}}" was not found on this server.)");
+  const auto urlNotFoundMsgText = msgTmpl.render({"url", requestUrl});
+  m_data["details"].push_back({"p", urlNotFoundMsgText});
+  return *this;
 }
 
 std::unique_ptr<Response> Response::build_416(const InternalServer& server, size_t resourceLength)

--- a/src/server/response.cpp
+++ b/src/server/response.cpp
@@ -111,6 +111,13 @@ std::unique_ptr<ContentResponse> Response::build_404(const InternalServer& serve
 
 extern const UrlNotFoundMsg urlNotFoundMsg;
 
+std::unique_ptr<ContentResponse> ContentResponseBlueprint::generateResponseObject() const
+{
+  auto r = ContentResponse::build(m_server, m_template, m_data, m_mimeType);
+  r->set_code(m_httpStatusCode);
+  return r;
+}
+
 HTTP404HtmlResponse::HTTP404HtmlResponse(const InternalServer& server,
                                          const RequestContext& request)
   : ContentResponseBlueprint(&server,

--- a/src/server/response.cpp
+++ b/src/server/response.cpp
@@ -109,6 +109,15 @@ std::unique_ptr<ContentResponse> Response::build_404(const InternalServer& serve
   return response;
 }
 
+ContentResponseBlueprint make404Response(const InternalServer& server,
+                                         const RequestContext& request)
+{
+  return ContentResponseBlueprint(&server,
+                                  &request,
+                                  MHD_HTTP_NOT_FOUND,
+                                  "text/html",
+                                  RESOURCE::templates::_404_html);
+}
 
 std::unique_ptr<Response> Response::build_416(const InternalServer& server, size_t resourceLength)
 {

--- a/src/server/response.cpp
+++ b/src/server/response.cpp
@@ -86,13 +86,15 @@ std::unique_ptr<Response> Response::build_304(const InternalServer& server, cons
 
 std::unique_ptr<ContentResponse> Response::build_404(const InternalServer& server, const std::string& url, const std::string& details)
 {
-  MustacheData data;
+  kainjow::mustache::list pList;
   if ( !url.empty() ) {
-    data.set("url", url);
+    kainjow::mustache::mustache msgTmpl(R"(The requested URL "{{url}}" was not found on this server.)");
+    const auto urlNotFoundMsg = msgTmpl.render({"url", url});
+    pList.push_back({"p", urlNotFoundMsg});
   }
-  data.set("details", details);
+  pList.push_back({"p", details});
 
-  return build_404(server, data);
+  return build_404(server, {"details", pList});
 }
 
 std::unique_ptr<ContentResponse> Response::build_404(const InternalServer& server, const kainjow::mustache::data& data)

--- a/src/server/response.cpp
+++ b/src/server/response.cpp
@@ -84,7 +84,7 @@ std::unique_ptr<Response> Response::build_304(const InternalServer& server, cons
   return response;
 }
 
-std::unique_ptr<ContentResponse> Response::build_404(const InternalServer& server, const std::string& url, const std::string& details)
+kainjow::mustache::data make404ResponseData(const std::string& url, const std::string& details)
 {
   kainjow::mustache::list pList;
   if ( !url.empty() ) {
@@ -93,8 +93,12 @@ std::unique_ptr<ContentResponse> Response::build_404(const InternalServer& serve
     pList.push_back({"p", urlNotFoundMsg});
   }
   pList.push_back({"p", details});
+  return {"details", pList};
+}
 
-  return build_404(server, {"details", pList});
+std::unique_ptr<ContentResponse> Response::build_404(const InternalServer& server, const std::string& url, const std::string& details)
+{
+  return build_404(server, make404ResponseData(url, details));
 }
 
 std::unique_ptr<ContentResponse> Response::build_404(const InternalServer& server, const kainjow::mustache::data& data)

--- a/src/server/response.cpp
+++ b/src/server/response.cpp
@@ -127,8 +127,12 @@ HTTP404HtmlResponse& HTTP404HtmlResponse::operator+(UrlNotFoundMsg /*unused*/)
 {
   const std::string requestUrl = m_request.get_full_url();
   kainjow::mustache::mustache msgTmpl(R"(The requested URL "{{url}}" was not found on this server.)");
-  const auto urlNotFoundMsgText = msgTmpl.render({"url", requestUrl});
-  m_data["details"].push_back({"p", urlNotFoundMsgText});
+  return *this + msgTmpl.render({"url", requestUrl});
+}
+
+HTTP404HtmlResponse& HTTP404HtmlResponse::operator+(const std::string& msg)
+{
+  m_data["details"].push_back({"p", msg});
   return *this;
 }
 

--- a/src/server/response.h
+++ b/src/server/response.h
@@ -38,7 +38,7 @@ namespace kiwix {
 class InternalServer;
 class RequestContext;
 
-class EntryResponse;
+class ContentResponse;
 
 class Response {
   public:
@@ -47,7 +47,7 @@ class Response {
 
     static std::unique_ptr<Response> build(const InternalServer& server);
     static std::unique_ptr<Response> build_304(const InternalServer& server, const ETag& etag);
-    static std::unique_ptr<Response> build_404(const InternalServer& server, const std::string& url, const std::string& bookName, const std::string& bookTitle, const std::string& details="");
+    static std::unique_ptr<ContentResponse> build_404(const InternalServer& server, const std::string& url, const std::string& bookName, const std::string& bookTitle, const std::string& details="");
     static std::unique_ptr<Response> build_416(const InternalServer& server, size_t resourceLength);
     static std::unique_ptr<Response> build_500(const InternalServer& server, const std::string& msg);
     static std::unique_ptr<Response> build_redirect(const InternalServer& server, const std::string& redirectUrl);

--- a/src/server/response.h
+++ b/src/server/response.h
@@ -51,6 +51,7 @@ class Response {
 
     static std::unique_ptr<Response> build(const InternalServer& server);
     static std::unique_ptr<Response> build_304(const InternalServer& server, const ETag& etag);
+    static std::unique_ptr<ContentResponse> build_404(const InternalServer& server, const kainjow::mustache::data& data);
     static std::unique_ptr<ContentResponse> build_404(const InternalServer& server, const std::string& url, const std::string& details="");
     static std::unique_ptr<Response> build_416(const InternalServer& server, size_t resourceLength);
     static std::unique_ptr<Response> build_500(const InternalServer& server, const std::string& msg);

--- a/src/server/response.h
+++ b/src/server/response.h
@@ -166,7 +166,7 @@ public: // functions
     return operator std::unique_ptr<ContentResponse>();
   }
 
-private: // data
+public: //data
   const InternalServer& m_server;
   const RequestContext& m_request;
   const int m_httpStatusCode;

--- a/src/server/response.h
+++ b/src/server/response.h
@@ -175,12 +175,11 @@ public: //data
   kainjow::mustache::data m_data;
 };
 
-ContentResponseBlueprint make404Response(const InternalServer& server,
-                                         const RequestContext& request);
-
-kainjow::mustache::data make404ResponseData(const std::string& url,
-                                            const std::string& details = "");
-
+struct HTTP404HtmlResponse : ContentResponseBlueprint
+{
+  HTTP404HtmlResponse(const InternalServer& server,
+                      const RequestContext& request);
+};
 
 class ItemResponse : public Response {
   public:

--- a/src/server/response.h
+++ b/src/server/response.h
@@ -51,7 +51,7 @@ class Response {
 
     static std::unique_ptr<Response> build(const InternalServer& server);
     static std::unique_ptr<Response> build_304(const InternalServer& server, const ETag& etag);
-    static std::unique_ptr<ContentResponse> build_404(const InternalServer& server, const std::string& url, const std::string& bookName, const std::string& bookTitle, const std::string& details="");
+    static std::unique_ptr<ContentResponse> build_404(const InternalServer& server, const std::string& url, const std::string& details="");
     static std::unique_ptr<Response> build_416(const InternalServer& server, size_t resourceLength);
     static std::unique_ptr<Response> build_500(const InternalServer& server, const std::string& msg);
     static std::unique_ptr<Response> build_redirect(const InternalServer& server, const std::string& redirectUrl);

--- a/src/server/response.h
+++ b/src/server/response.h
@@ -175,10 +175,16 @@ public: //data
   kainjow::mustache::data m_data;
 };
 
+class UrlNotFoundMsg {};
+
+extern const UrlNotFoundMsg urlNotFoundMsg;
+
 struct HTTP404HtmlResponse : ContentResponseBlueprint
 {
   HTTP404HtmlResponse(const InternalServer& server,
                       const RequestContext& request);
+
+  HTTP404HtmlResponse& operator+(UrlNotFoundMsg /*unused*/);
 };
 
 class ItemResponse : public Response {

--- a/src/server/response.h
+++ b/src/server/response.h
@@ -33,6 +33,10 @@ extern "C" {
 #include "microhttpd_wrapper.h"
 }
 
+namespace zim {
+class Archive;
+} // namespace zim
+
 namespace kiwix {
 
 class InternalServer;
@@ -123,6 +127,10 @@ class ContentResponse : public Response {
     std::string m_bookName;
     std::string m_bookTitle;
  };
+
+std::unique_ptr<ContentResponse> withTaskbarInfo(const std::string& bookName,
+                                                 const zim::Archive* archive,
+                                                 std::unique_ptr<ContentResponse> r);
 
 class ItemResponse : public Response {
   public:

--- a/src/server/response.h
+++ b/src/server/response.h
@@ -129,6 +129,17 @@ class ContentResponse : public Response {
     std::string m_bookTitle;
  };
 
+struct TaskbarInfo
+{
+  const std::string bookName;
+  const zim::Archive* const archive;
+
+  TaskbarInfo(const std::string& bookName, const zim::Archive* a = nullptr)
+    : bookName(bookName)
+    , archive(a)
+  {}
+};
+
 std::unique_ptr<ContentResponse> withTaskbarInfo(const std::string& bookName,
                                                  const zim::Archive* archive,
                                                  std::unique_ptr<ContentResponse> r);
@@ -166,6 +177,9 @@ public: // functions
     return operator std::unique_ptr<ContentResponse>();
   }
 
+
+  ContentResponseBlueprint& operator+(const TaskbarInfo& taskbarInfo);
+
 protected: // functions
   virtual std::unique_ptr<ContentResponse> generateResponseObject() const;
 
@@ -176,35 +190,21 @@ public: //data
   const std::string m_mimeType;
   const std::string m_template;
   kainjow::mustache::data m_data;
+  std::unique_ptr<TaskbarInfo> m_taskbarInfo;
 };
 
 class UrlNotFoundMsg {};
 
 extern const UrlNotFoundMsg urlNotFoundMsg;
 
-struct TaskbarInfo
-{
-  const std::string bookName;
-  const zim::Archive* const archive;
-
-  TaskbarInfo(const std::string& bookName, const zim::Archive* a = nullptr)
-    : bookName(bookName)
-    , archive(a)
-  {}
-};
-
 struct HTTP404HtmlResponse : ContentResponseBlueprint
 {
   HTTP404HtmlResponse(const InternalServer& server,
                       const RequestContext& request);
 
+  using ContentResponseBlueprint::operator+;
   HTTP404HtmlResponse& operator+(UrlNotFoundMsg /*unused*/);
   HTTP404HtmlResponse& operator+(const std::string& errorDetails);
-  HTTP404HtmlResponse& operator+(const TaskbarInfo& taskbarInfo);
-
-  std::unique_ptr<ContentResponse> generateResponseObject() const override;
-
-  std::unique_ptr<TaskbarInfo> taskbarInfo;
 };
 
 class ItemResponse : public Response {

--- a/src/server/response.h
+++ b/src/server/response.h
@@ -161,17 +161,13 @@ public: // functions
     return generateResponseObject();
   }
 
-  virtual std::unique_ptr<ContentResponse> generateResponseObject() const
-  {
-    auto r = ContentResponse::build(m_server, m_template, m_data, m_mimeType);
-    r->set_code(m_httpStatusCode);
-    return r;
-  }
-
   operator std::unique_ptr<Response>() const
   {
     return operator std::unique_ptr<ContentResponse>();
   }
+
+protected: // functions
+  virtual std::unique_ptr<ContentResponse> generateResponseObject() const;
 
 public: //data
   const InternalServer& m_server;

--- a/src/server/response.h
+++ b/src/server/response.h
@@ -185,6 +185,7 @@ struct HTTP404HtmlResponse : ContentResponseBlueprint
                       const RequestContext& request);
 
   HTTP404HtmlResponse& operator+(UrlNotFoundMsg /*unused*/);
+  HTTP404HtmlResponse& operator+(const std::string& errorDetails);
 };
 
 class ItemResponse : public Response {

--- a/src/server/response.h
+++ b/src/server/response.h
@@ -148,6 +148,8 @@ public: // functions
     , m_template(templateStr)
   {}
 
+  virtual ~ContentResponseBlueprint() = default;
+
   ContentResponseBlueprint& operator+(kainjow::mustache::data&& data)
   {
     this->m_data = std::move(data);
@@ -155,6 +157,11 @@ public: // functions
   }
 
   operator std::unique_ptr<ContentResponse>() const
+  {
+    return generateResponseObject();
+  }
+
+  virtual std::unique_ptr<ContentResponse> generateResponseObject() const
   {
     auto r = ContentResponse::build(m_server, m_template, m_data, m_mimeType);
     r->set_code(m_httpStatusCode);
@@ -179,6 +186,17 @@ class UrlNotFoundMsg {};
 
 extern const UrlNotFoundMsg urlNotFoundMsg;
 
+struct TaskbarInfo
+{
+  const std::string bookName;
+  const zim::Archive* const archive;
+
+  TaskbarInfo(const std::string& bookName, const zim::Archive* a = nullptr)
+    : bookName(bookName)
+    , archive(a)
+  {}
+};
+
 struct HTTP404HtmlResponse : ContentResponseBlueprint
 {
   HTTP404HtmlResponse(const InternalServer& server,
@@ -186,6 +204,11 @@ struct HTTP404HtmlResponse : ContentResponseBlueprint
 
   HTTP404HtmlResponse& operator+(UrlNotFoundMsg /*unused*/);
   HTTP404HtmlResponse& operator+(const std::string& errorDetails);
+  HTTP404HtmlResponse& operator+(const TaskbarInfo& taskbarInfo);
+
+  std::unique_ptr<ContentResponse> generateResponseObject() const override;
+
+  std::unique_ptr<TaskbarInfo> taskbarInfo;
 };
 
 class ItemResponse : public Response {

--- a/src/server/response.h
+++ b/src/server/response.h
@@ -104,7 +104,7 @@ class ContentResponse : public Response {
       const std::string& mimetype,
       bool isHomePage = false);
 
-    void set_taskbar(const std::string& bookName, const std::string& bookTitle);
+    void set_taskbar(const std::string& bookName, const zim::Archive* archive);
 
   private:
     MHD_Response* create_mhd_response(const RequestContext& request);

--- a/src/tools/otherTools.cpp
+++ b/src/tools/otherTools.cpp
@@ -370,6 +370,13 @@ std::string kiwix::gen_uuid(const std::string& s)
   return kiwix::to_string(zim::Uuid::generate(s));
 }
 
+kainjow::mustache::data kiwix::onlyAsNonEmptyMustacheValue(const std::string& s)
+{
+  return s.empty()
+       ? kainjow::mustache::data(false)
+       : kainjow::mustache::data(s);
+}
+
 std::string kiwix::render_template(const std::string& template_str, kainjow::mustache::data data)
 {
   kainjow::mustache::mustache tmpl(template_str);

--- a/src/tools/otherTools.h
+++ b/src/tools/otherTools.h
@@ -48,6 +48,10 @@ namespace kiwix
   std::string gen_date_str();
   std::string gen_uuid(const std::string& s);
 
+  // if s is empty then returns kainjow::mustache::data(false)
+  // otherwise kainjow::mustache::data(value)
+  kainjow::mustache::data onlyAsNonEmptyMustacheValue(const std::string& s);
+
   std::string render_template(const std::string& template_str, kainjow::mustache::data data);
 }
 

--- a/static/templates/404.html
+++ b/static/templates/404.html
@@ -6,15 +6,10 @@
   </head>
   <body>
     <h1>Not Found</h1>
-    {{#url}}
+{{#details}}
     <p>
-      The requested URL "{{url}}" was not found on this server.
+      {{{p}}}
     </p>
-    {{/url}}
-    {{#details}}
-    <p>
-      {{{details}}}
-    </p>
-    {{/details}}
+{{/details}}
   </body>
 </html>

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -638,8 +638,6 @@ TEST_F(ServerTest, 404WithBodyTesting)
 )"  },
 
     { /* url */ "/ROOT/raw/zimfile/meta/invalid-metadata",
-      book_name=="zimfile" &&
-      book_title=="Ray Charles" &&
       expected_body==R"(
     <h1>Not Found</h1>
     <p>
@@ -651,8 +649,6 @@ TEST_F(ServerTest, 404WithBodyTesting)
 )"  },
 
     { /* url */ "/ROOT/raw/zimfile/content/invalid-article",
-      book_name=="zimfile" &&
-      book_title=="Ray Charles" &&
       expected_body==R"(
     <h1>Not Found</h1>
     <p>

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -549,9 +549,6 @@ TEST_F(ServerTest, 404WithBodyTesting)
     <p>
       The requested URL "/ROOT/catalog/" was not found on this server.
     </p>
-    <p>
-      //EOLWHITESPACEMARKER
-    </p>
 )"  },
 
     { /* url */ "/ROOT/catalog/invalid_endpoint",
@@ -559,9 +556,6 @@ TEST_F(ServerTest, 404WithBodyTesting)
     <h1>Not Found</h1>
     <p>
       The requested URL "/ROOT/catalog/invalid_endpoint" was not found on this server.
-    </p>
-    <p>
-      //EOLWHITESPACEMARKER
     </p>
 )"  },
 

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -530,7 +530,6 @@ TEST_F(ServerTest, 404WithBodyTesting)
     { /* url */ "/ROOT/random?content=non-existent-book",
       expected_body==R"(
     <h1>Not Found</h1>
-    //EOLWHITESPACEMARKER
     <p>
       No such book: non-existent-book
     </p>
@@ -539,7 +538,6 @@ TEST_F(ServerTest, 404WithBodyTesting)
     { /* url */ "/ROOT/suggest?content=no-such-book&term=whatever",
       expected_body==R"(
     <h1>Not Found</h1>
-    //EOLWHITESPACEMARKER
     <p>
       No such book: no-such-book
     </p>


### PR DESCRIPTION
This is the next step on our path to internationalizing kiwix-serve (and making #679 a smaller PR).

The main goal of this PR was to introduce a new eDSL like way of building error responses. Here it is done only for 404 HTML error responses. A couple of further generalizations still remain in #679 because those enhancements were a little too dependent (factually but not conceptually) on the changes related to the internationalization of kiwix-serve.