### PR TITLE
Remove pinning of Sphinx<4

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,2 @@
 breathe
 exhale
-sphinx<4


### PR DESCRIPTION
Fix #735 

It seems the issue is a dependencies version problem. (See https://github.com/readthedocs/readthedocs.org/issues/9038)
This issue is fixed with Sphinx 4.0.2 but we were forcing sphinx to be <4 (probably for the same kind of problem)
We could force `Jinja2<3.0` as proposed in readthedocs issue.
However, I've decided to remove the `Sphinx<4` to compile doc with up to date dependencies. But I'm open to counter-argument to force `Jinja2<3.0`