### PR TITLE
Correctly define the variable `urlNotFoundMsg` and `invalidUrlMsg`.

### DIFF
--- a/src/server/response.cpp
+++ b/src/server/response.cpp
@@ -109,8 +109,8 @@ std::unique_ptr<ContentResponse> Response::build_404(const InternalServer& serve
   return response;
 }
 
-extern const UrlNotFoundMsg urlNotFoundMsg;
-extern const InvalidUrlMsg invalidUrlMsg;
+const UrlNotFoundMsg urlNotFoundMsg;
+const InvalidUrlMsg invalidUrlMsg;
 
 std::unique_ptr<ContentResponse> ContentResponseBlueprint::generateResponseObject() const
 {


### PR DESCRIPTION
As we must declare the two variables as `extern` in response.h,
we must define it somewhere (and `response.cpp` is a good place).

Keeping the `extern` seems to compile (and link) correctly on linux (I don't know why) but it fails on Windows (https://ci.appveyor.com/project/Kiwix/kiwix-build/builds/43086731)