### PR TITLE
Unit test for diacritics insensitive suggestions

### DIFF
--- a/test/server.cpp
+++ b/test/server.cpp
@@ -1392,6 +1392,23 @@ R"EXPECTEDRESPONSE([
 ]
 )EXPECTEDRESPONSE"
     },
+    { /* url: */ "/ROOT/suggest?content=zimfile&term=öld%20suñ",
+R"EXPECTEDRESPONSE([
+  {
+    "value" : "That Lucky Old Sun",
+    "label" : "That Lucky &lt;b&gt;Old&lt;/b&gt; &lt;b&gt;Sun&lt;/b&gt;",
+    "kind" : "path"
+      , "path" : "A/That_Lucky_Old_Sun"
+  },
+  {
+    "value" : "öld suñ ",
+    "label" : "containing &apos;öld suñ&apos;...",
+    "kind" : "pattern"
+    //EOLWHITESPACEMARKER
+  }
+]
+)EXPECTEDRESPONSE"
+    },
     { /* url: */ "/ROOT/suggest?content=zimfile&term=abracadabra",
 R"EXPECTEDRESPONSE([
   {


### PR DESCRIPTION
Fixes #758

A new unit test was added that only checks that diacritics present in the query are ignored. There is no unit test for diacritics present in the titles (this is complicated by the current unit-test data where no diacritics is present).