### PR TITLE
Automatic discovery of i18n resources

### DIFF
--- a/scripts/kiwix-compile-i18n
+++ b/scripts/kiwix-compile-i18n
@@ -86,22 +86,12 @@ extern const size_t langCount = $LANG_COUNT;
 '''
 
 class Resource:
-    def __init__(self, base_dirs, filename):
+    def __init__(self, filename):
         filename = filename.strip()
         self.filename = filename
         self.lang_code = lang_code(filename)
-        found = False
-        for base_dir in base_dirs:
-            try:
-                with open(os.path.join(base_dir, filename), 'r') as f:
-                    self.data = f.read()
-                found = True
-                break
-            except FileNotFoundError:
-                continue
-        if not found:
-            raise Exception("Impossible to find {}".format(filename))
-
+        with open(filename, 'r') as f:
+            self.data = f.read()
 
     def get_string_table_name(self):
         return "string_table_for_" + self.lang_code
@@ -147,14 +137,11 @@ if __name__ == "__main__":
     parser.add_argument('--cxxfile',
                         required=True,
                         help='The Cpp file name to generate')
-    parser.add_argument('i18n_resource_file',
+    parser.add_argument('i18n_resource_files', nargs='+',
                         help='The list of resources to compile.')
     args = parser.parse_args()
 
-    base_dir = os.path.dirname(os.path.realpath(args.i18n_resource_file))
-    with open(args.i18n_resource_file, 'r') as f:
-        resources = [Resource([base_dir], filename)
-                        for filename in f.readlines()]
+    resources = [Resource(filename) for filename in args.i18n_resource_files]
 
     with open(args.cxxfile, 'w') as f:
         f.write(gen_c_file(resources))

--- a/scripts/kiwix-compile-i18n.1
+++ b/scripts/kiwix-compile-i18n.1
@@ -2,10 +2,10 @@
 .SH NAME
 kiwix-compile-i18n \- helper to compile Kiwix i18n (internationalization) data
 .SH SYNOPSIS
-\fBkiwix\-compile\-i18n\fR [\-h] \-\-cxxfile CXXFILE i18n_resource_file\fR
+\fBkiwix\-compile\-i18n\fR [\-h] \-\-cxxfile CXXFILE i18n_resource_files ...\fR
 .SH DESCRIPTION
 .TP
-i18n_resource_file
+i18n_resource_files ...
 The list of i18n resources to compile.
 .TP
 \fB\-h\fR, \fB\-\-help\fR

--- a/static/i18n_resources_list.txt
+++ b/static/i18n_resources_list.txt
@@ -1,2 +1,0 @@
-i18n/en.json
-i18n/hy.json

--- a/static/meson.build
+++ b/static/meson.build
@@ -24,17 +24,29 @@ lib_resources = custom_target('resources',
     depends: preprocessed_resources
 )
 
-i18n_resource_files = run_command(find_program('python3'),
-                    '-c',
-                    'import sys; f=open(sys.argv[1]); print(f.read())',
-                    files('i18n_resources_list.txt')
-                 ).stdout().strip().split('\n')
+i18n_resource_listing_script = '''import glob
+import os
+import sys
+qqq = sys.argv[1]
+d = os.path.dirname(qqq)
+r = glob.glob(d + "/*.json")
+r.remove(qqq)
+for f in r: print(f)
+'''
+
+i18n_resource_listing_cmd = [
+                                find_program('python3'),
+                                '-c',
+                                i18n_resource_listing_script,
+                                files('i18n/qqq.json')
+                            ]
+
+i18n_resource_files = run_command(i18n_resource_listing_cmd).stdout().strip().split('\n')
 
 i18n_resources = custom_target('i18n_resources',
-    input: 'i18n_resources_list.txt',
+    input: i18n_resource_files,
     output: ['libkiwix-i18n-resources.cpp'],
     command:[i18n_compiler,
              '--cxxfile', '@OUTPUT0@',
              '@INPUT@'],
-    depend_files: i18n_resource_files
 )


### PR DESCRIPTION
Excluding qqq.json any .json file under static/i18n is now considered to be a i18n resource. This eliminates the need to update the
i18n_resources_list.txt file every time a new language json file is added. Thus Translatewiki PRs will not require extra work.