### PR TITLE
Do not auto discover i18n files.

### DIFF
--- a/static/generate_i18n_resources_list.py
+++ b/static/generate_i18n_resources_list.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 Matthieu Gautier <mgautier@kymeria.fr>
+#
+# This file is part of libkiwix.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+from pathlib import Path
+
+script_path = Path(__file__)
+
+resource_file = script_path.parent / "i18n_resources_list.txt"
+translation_dir = script_path.parent / "i18n"
+
+json_files = translation_dir.glob("*.json")
+with open(resource_file, 'w', encoding="utf-8") as f:
+    for json in sorted(translation_dir.glob("*.json")):
+        if json.name == "qqq.json":
+            continue
+        f.write(str(json.relative_to(script_path.parent)) + '\n')

--- a/static/i18n_resources_list.txt
+++ b/static/i18n_resources_list.txt
@@ -1,0 +1,2 @@
+i18n/en.json
+i18n/hy.json

--- a/static/i18n_resources_list.txt
+++ b/static/i18n_resources_list.txt
@@ -1,2 +1,15 @@
+i18n/bn.json
 i18n/en.json
+i18n/fr.json
+i18n/he.json
 i18n/hy.json
+i18n/it.json
+i18n/ja.json
+i18n/ko.json
+i18n/mk.json
+i18n/ru.json
+i18n/sc.json
+i18n/sk.json
+i18n/sv.json
+i18n/tr.json
+i18n/zh-hant.json

--- a/static/meson.build
+++ b/static/meson.build
@@ -24,24 +24,17 @@ lib_resources = custom_target('resources',
     depends: preprocessed_resources
 )
 
-i18n_resource_listing_script = '''import glob
-import os
-import sys
-qqq = sys.argv[1]
-d = os.path.dirname(qqq)
-r = glob.glob(d + "/*.json")
-r.remove(qqq)
-for f in r: print(f)
-'''
-
-i18n_resource_listing_cmd = [
-                                find_program('python3'),
-                                '-c',
-                                i18n_resource_listing_script,
-                                files('i18n/qqq.json')
-                            ]
-
-i18n_resource_files = run_command(i18n_resource_listing_cmd).stdout().strip().split('\n')
+# This could be replaced with
+# ```
+# fs = import('fs')
+# i18n_resource_files = fs.read('i18n_resources_list.txt').strip().split('\n')
+# ```
+# once we move to meson >= 0.57.0
+i18n_resource_files = run_command(find_program('python3'),
+                                    '-c',
+                                    'import sys; f=open(sys.argv[1]); print(f.read())',
+                                    files('i18n_resources_list.txt')
+                                 ).stdout().strip().split('\n')
 
 i18n_resources = custom_target('i18n_resources',
     input: i18n_resource_files,


### PR DESCRIPTION
Revert to the plain old 'i18n_resources_list.txt' file.

Auto discovering of i18n file has a main flaw (and a small bug):
- The main flaw is that rerun the configure will not detect new
  translation files. It means that if we use cache in our CI,
  new translation will not be included. (https://github.com/kiwix/libkiwix/pull/763#issuecomment-1121585502)
- The bug is that on Windows, meson fails with a error about a non existent
  `` (empty) file name. I suppose it is because python replace
  `\n` by `\r\n` on Windows, and the the `.strip().split('\n')` keeps empty
  lines (see https://ci.appveyor.com/project/Kiwix/kiwix-build/builds/43549451)

The small bug could be fixed, but the main flaw make the whole better if
we use a script to generate the listing.

This commit is somehow a half revert of 2eff5b5