### PR TITLE
Specify utf8 encoding when opening i18n resource file.

### DIFF
--- a/scripts/kiwix-compile-i18n
+++ b/scripts/kiwix-compile-i18n
@@ -90,7 +90,7 @@ class Resource:
         filename = filename.strip()
         self.filename = filename
         self.lang_code = lang_code(filename)
-        with open(filename, 'r') as f:
+        with open(filename, 'r', encoding='utf-8') as f:
             self.data = f.read()
 
     def get_string_table_name(self):


### PR DESCRIPTION
Else, on windows, we will try to open files with "local" encoding (cp1252)

See https://ci.appveyor.com/project/Kiwix/kiwix-build/builds/43573745