### PR TITLE
Make the Searcher owning the stored Reader

### DIFF
--- a/include/searcher.h
+++ b/include/searcher.h
@@ -76,10 +76,10 @@ class Searcher
    * @return true if the reader has been added.
    *         false if the reader cannot be added (no embedded fulltext index present)
    */
-  bool add_reader(Reader* reader);
+  bool add_reader(std::shared_ptr<Reader> reader);
 
 
-  Reader* get_reader(int index);
+  std::shared_ptr<Reader> get_reader(int index);
 
   /**
    * Start a search on the zim associated to the Searcher.
@@ -161,7 +161,7 @@ class Searcher
                      const unsigned int maxResultCount,
                      const bool verbose = false);
 
-  std::vector<Reader*> readers;
+  std::vector<std::shared_ptr<Reader>> readers;
   std::unique_ptr<SearcherInternal> internal;
   std::unique_ptr<SuggestionInternal> suggestionInternal;
   std::string searchPattern;

--- a/src/search_renderer.cpp
+++ b/src/search_renderer.cpp
@@ -40,11 +40,12 @@ namespace kiwix
 /* Constructor */
 SearchRenderer::SearchRenderer(Searcher* searcher, NameMapper* mapper)
     : SearchRenderer(
-        searcher->getSearchResultSet(),
-        mapper,
-        nullptr,
-        searcher->getEstimatedResultCount(),
-        searcher->getResultStart())
+        /* srs */ searcher->getSearchResultSet(),
+        /* mapper */ mapper,
+        /* library */ nullptr,
+        /* start */ searcher->getResultStart(),
+        /* estimatedResultCount */ searcher->getEstimatedResultCount()
+        )
 {}
 
 SearchRenderer::SearchRenderer(zim::SearchResultSet srs, NameMapper* mapper,

--- a/src/searcher.cpp
+++ b/src/searcher.cpp
@@ -89,13 +89,13 @@ Searcher::~Searcher()
 {
 }
 
-bool Searcher::add_reader(Reader* reader)
+bool Searcher::add_reader(std::shared_ptr<Reader> reader)
 {
   if (!reader->hasFulltextIndex()) {
       return false;
   }
 
-  for ( const Reader* const existing_reader : readers ) {
+  for ( auto existing_reader : readers ) {
     if ( existing_reader->getZimArchive()->getUuid() == reader->getZimArchive()->getUuid() )
       return false;
   }
@@ -105,7 +105,7 @@ bool Searcher::add_reader(Reader* reader)
 }
 
 
-Reader* Searcher::get_reader(int readerIndex)
+std::shared_ptr<Reader> Searcher::get_reader(int readerIndex)
 {
   return readers.at(readerIndex);
 }


### PR DESCRIPTION
If we keep a reference to a `Reader` it is better to (share) owning
the reference. Else the reader may be deleted after we create the searcher.

This is especially the case now we are creating the `Reader` at demand
and we don't store it in the library's cache.