### PR TITLE
Do not use deprecated constructor for Reader.

### DIFF
--- a/src/library.cpp
+++ b/src/library.cpp
@@ -282,7 +282,7 @@ std::shared_ptr<Reader> Library::getReaderById(const std::string& id)
 {
   auto archive = getArchiveById(id);
   if(archive) {
-    return std::make_shared<Reader>(archive);
+    return std::shared_ptr<Reader>(new Reader(archive, true));
   } else {
     return nullptr;
   }

--- a/test/lrucache.cpp
+++ b/test/lrucache.cpp
@@ -81,15 +81,15 @@ TEST(CacheTest, DropValue) {
 TEST(CacheTest1, KeepsAllValuesWithinCapacity) {
     kiwix::lru_cache<int, int> cache_lru(TEST2_CACHE_CAPACITY);
 
-    for (uint i = 0; i < NUM_OF_TEST2_RECORDS; ++i) {
+    for (unsigned int i = 0; i < NUM_OF_TEST2_RECORDS; ++i) {
         cache_lru.put(i, i);
     }
 
-    for (uint i = 0; i < NUM_OF_TEST2_RECORDS - TEST2_CACHE_CAPACITY; ++i) {
+    for (unsigned int i = 0; i < NUM_OF_TEST2_RECORDS - TEST2_CACHE_CAPACITY; ++i) {
         EXPECT_FALSE(cache_lru.exists(i));
     }
 
-    for (uint i = NUM_OF_TEST2_RECORDS - TEST2_CACHE_CAPACITY; i < NUM_OF_TEST2_RECORDS; ++i) {
+    for (unsigned int i = NUM_OF_TEST2_RECORDS - TEST2_CACHE_CAPACITY; i < NUM_OF_TEST2_RECORDS; ++i) {
         EXPECT_TRUE(cache_lru.exists(i));
         EXPECT_EQ((int)i, cache_lru.get(i));
     }


### PR DESCRIPTION
We have a specific private non deprecated constructor especially for that,
let's use it.