### PR TITLE
Fix documentation typos

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@ import os
 
 project = 'libkiwix'
 copyright = '2022, libkiwix-team'
-author = 'libzim-team'
+author = 'libkiwix-team'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to libzim's documentation!
+Welcome to libkiwix's documentation!
 ==================================
 
 .. toctree::

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -7,11 +7,9 @@ Introduction
 libkiwix is written in C++. To use the library, you need the include files of libkiwix have
 to link against libzim.
 
-Errors are handled with exceptions. When something goes wrong, libzim throws an error,
+Errors are handled with exceptions. When something goes wrong, libkiwix throws an error,
 which is always derived from std::exception.
 
 All classes are defined in the namespace kiwix.
 
 libkiwix is a set of tools to manage zim files and provide some common functionnality.
-While libkiwix has some wrappers around libzim classes, they are deprecated and will be removed
-in the future.


### PR DESCRIPTION
Replace wrong  mentions of libzim with libkiwix
Remove libkiwix deprecated functions mention in usage.rst - they are removed now (when https://github.com/kiwix/libkiwix/pull/789 is merged)
Fix #788 