### PR TITLE
Include iostream header in include/version.h

### DIFF
--- a/include/version.h
+++ b/include/version.h
@@ -22,6 +22,7 @@
 
 #include <string>
 #include <vector>
+#include <iostream>
 
 namespace kiwix
 {


### PR DESCRIPTION
This is needed for kiwix-tools compilation.
Part 2 of https://github.com/kiwix/kiwix-tools/pull/564