### PR TITLE
Exit download modal on pressing escape key.

### DIFF
--- a/static/skin/index.js
+++ b/static/skin/index.js
@@ -439,6 +439,12 @@
 
     window.addEventListener('scroll', loadSubset);
 
+    window.addEventListener('keydown', function (event) {
+        if (event.key === "Escape" ) {
+            closeModal();
+        }
+    });
+
     window.onload = async () => {
         iso = new Isotope( '.book__list', {
             itemSelector: '.book',

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -184,7 +184,7 @@ R"EXPECTEDRESULT(      src="/ROOT/skin/jquery-ui/external/jquery/jquery.js?cache
           src: url("/ROOT/skin/fonts/Roboto.ttf?cacheid=84d10248") format("truetype");
     <script src="/ROOT/skin/isotope.pkgd.min.js?cacheid=2e48d392" defer></script>
     <script src="/ROOT/skin/iso6391To3.js?cacheid=ecde2bb3"></script>
-    <script type="text/javascript" src="/ROOT/skin/index.js?cacheid=ce2c8253" defer></script>
+    <script type="text/javascript" src="/ROOT/skin/index.js?cacheid=a0307d03" defer></script>
 )EXPECTEDRESULT"
     },
     {


### PR DESCRIPTION
Adds an event listener to call closeModal() when Escape key is pressed.
Fixes #799 