### PR TITLE
Illustration URL uses the book UUID

### DIFF
--- a/src/server/internalServer_catalog_v2.cpp
+++ b/src/server/internalServer_catalog_v2.cpp
@@ -154,8 +154,7 @@ std::unique_ptr<Response> InternalServer::handle_catalog_v2_languages(const Requ
 std::unique_ptr<Response> InternalServer::handle_catalog_v2_illustration(const RequestContext& request)
 {
   try {
-    const auto bookName  = request.get_url_part(3);
-    const auto bookId = mp_nameMapper->getIdForName(bookName);
+    const auto bookId  = request.get_url_part(3);
     auto book = mp_library->getBookByIdThreadSafe(bookId);
     auto size = request.get_argument<unsigned int>("size");
     auto illustration = book.getIllustration(size);

--- a/static/templates/catalog_v2_entry.xml
+++ b/static/templates/catalog_v2_entry.xml
@@ -16,7 +16,7 @@
     <articleCount>{{article_count}}</articleCount>
     <mediaCount>{{media_count}}</mediaCount>
     {{#icons}}<link rel="http://opds-spec.org/image/thumbnail"
-          href="{{root}}/catalog/v2/illustration/{{{content_id}}}/?size={{icon_size}}"
+          href="{{root}}/catalog/v2/illustration/{{{id}}}/?size={{icon_size}}"
           type="{{icon_mimetype}};width={{icon_size}};height={{icon_size}};scale=1"/>
     {{/icons}}<link type="text/html" href="{{root}}/{{{content_id}}}" />
     <author>

--- a/test/library_server.cpp
+++ b/test/library_server.cpp
@@ -108,7 +108,7 @@ std::string maskVariableOPDSFeedData(std::string s)
     "    <articleCount>284</articleCount>\n"                            \
     "    <mediaCount>2</mediaCount>\n"                                  \
     "    <link rel=\"http://opds-spec.org/image/thumbnail\"\n"          \
-    "          href=\"/ROOT/catalog/v2/illustration/zimfile/?size=48\"\n" \
+    "          href=\"/ROOT/catalog/v2/illustration/raycharles/?size=48\"\n" \
     "          type=\"image/png;width=48;height=48;scale=1\"/>\n"               \
     "    <link type=\"text/html\" href=\"/ROOT/zimfile\" />\n"               \
     "    <author>\n"                                                    \

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -72,7 +72,7 @@ const ResourceCollection resources200Uncompressible{
   { WITH_ETAG, "/ROOT/raw/zimfile/meta/Creator" },
   { WITH_ETAG, "/ROOT/raw/zimfile/meta/Publisher" },
 
-  { NO_ETAG, "/ROOT/catalog/v2/illustration/zimfile?size=48" },
+  { NO_ETAG, "/ROOT/catalog/v2/illustration/6f1d19d0-633f-087b-fb55-7ac324ff9baf?size=48" },
 
   { WITH_ETAG, "/ROOT/zimfile/I/m/Ray_Charles_classic_piano_pose.jpg" },
 
@@ -253,7 +253,8 @@ const char* urls404[] = {
   "/ROOT/catalog",
   "/ROOT/catalog/non-existent-item",
   "/ROOT/catalogBLABLABLA/root.xml",
-  "/ROOT/catalog/v2/illustration/zimfile?size=96",
+  "/ROOT/catalog/v2/illustration/zimfile?size=48",
+  "/ROOT/catalog/v2/illustration/6f1d19d0-633f-087b-fb55-7ac324ff9baf?size=96",
   "/ROOT/meta",
   "/ROOT/meta?content=zimfile",
   "/ROOT/meta?content=zimfile&name=non-existent-item",


### PR DESCRIPTION
Fixes #755

If the server is initialized with a library.xml file, then the id specified in the XML file is used (rather than the UUID recorded in the
ZIM file).

Note that in test/data/library.xml the book ids are fake and different from the real ZIM IDs; that file was created for testing of the /catalog endpoint which doesn't access ZIM content, so the the same ZIM file zimfile.zim was added to library.xml three times as
three different books (with unique human-friendly ids). This explains the diff in test/library_server.cpp.