### PR TITLE
Fixed search results for kiwix-desktop

### DIFF
--- a/src/search_renderer.cpp
+++ b/src/search_renderer.cpp
@@ -166,7 +166,7 @@ kainjow::mustache::data buildPagination(
 
 std::string SearchRenderer::renderTemplate(const std::string& tmpl_str)
 {
-  const std::string absPathPrefix = protocolPrefix + "content/";
+  const std::string absPathPrefix = protocolPrefix;
   // Build the results list
   kainjow::mustache::data items{kainjow::mustache::data::type::list};
   for (auto it = m_srs.begin(); it != m_srs.end(); it++) {
@@ -206,7 +206,7 @@ std::string SearchRenderer::renderTemplate(const std::string& tmpl_str)
 
 
   kainjow::mustache::data allData;
-  allData.set("protocolPrefix", protocolPrefix);
+  allData.set("searchProtocolPrefix", searchProtocolPrefix);
   allData.set("results", results);
   allData.set("pagination", pagination);
   allData.set("query", query);

--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -830,7 +830,7 @@ std::unique_ptr<Response> InternalServer::handle_search(const RequestContext& re
                             search->getEstimatedMatches());
     renderer.setSearchPattern(searchInfo.pattern);
     renderer.setSearchBookQuery(searchInfo.bookFilterQuery);
-    renderer.setProtocolPrefix(m_root + "/");
+    renderer.setProtocolPrefix(m_root + "/content/");
     renderer.setSearchProtocolPrefix(m_root + "/search");
     renderer.setPageLength(pageLength);
     if (request.get_requested_format() == "xml") {

--- a/static/templates/search_result.xml
+++ b/static/templates/search_result.xml
@@ -9,7 +9,7 @@
     <opensearch:totalResults>{{results.count}}</opensearch:totalResults>
     <opensearch:startIndex>{{results.start}}</opensearch:startIndex>
     <opensearch:itemsPerPage>{{pagination.itemsPerPage}}</opensearch:itemsPerPage>
-    <atom:link rel="search" type="application/opensearchdescription+xml" href="{{protocolPrefix}}search/searchdescription.xml"/>
+    <atom:link rel="search" type="application/opensearchdescription+xml" href="{{searchProtocolPrefix}}/searchdescription.xml"/>
     <opensearch:Query role="request"
       searchTerms="{{query.pattern}}"{{#query.lang}}
       language="{{query.lang}}"{{/query.lang}}


### PR DESCRIPTION
Fixes kiwix/kiwix-desktop#889

Introduction of the `/content` endpoint (#806) broke the links in the search results in kiwix-desktop, turning them into **zim://content/**_ZIM-FILE-UUID_**.zim/**_PATH/TO/ARTICLE_.

This PR restores the correct structure **zim://**_ZIM-FILE-UUID_**.zim/**_PATH/TO/ARTICLE_ for links in search results generated in kiwix-desktop context.