### PR TITLE
New logic for generating HTTP-redirects

### DIFF
--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -1043,9 +1043,14 @@ std::unique_ptr<Response> InternalServer::handle_content(const RequestContext& r
 
   try {
     auto entry = getEntryFromPath(*archive, urlStr);
-    if (entry.isRedirect() || urlStr.empty()) {
-      // If urlStr is empty, we want to mainPage.
-      // We must do a redirection to the real page.
+    if (entry.isRedirect() || urlStr != entry.getPath()) {
+      // In the condition above, the second case (an entry with a different
+      // URL was returned) can occur in the following situations:
+      // 1. urlStr is empty or equal to "/" and the ZIM file doesn't contain
+      //    such an entry, in which case the main entry is returned instead.
+      // 2. The ZIM file uses old namespace scheme, and the resource at urlStr
+      //    is not present but can be found under one of the 'A', 'I', 'J' or
+      //    '-' namespaces, in which case that resource is returned instead.
       return build_redirect(bookName, getFinalItem(*archive, entry));
     }
     auto response = ItemResponse::build(*this, request, entry.getItem());


### PR DESCRIPTION
Fixes #826 (with some side-effects).

Before this fix the root URL for a book was assumed to resolve to the main page. This was not true for ZIM files containing an entry at an empty path or with a path equal to "/", leading to #826. The logic behind this behaviour is found in `kiwix::getEntryFromPath()`.

The fix to that issue by this PR is a little more general and will result in an HTTP redirect in any case where `kiwix::getEntryFromPath(zim, path)` returns an entry with a real path different from the requested one. In particular, this will affect the behaviour on ZIM files with the old namespace scheme, where the requested resource - if not found - is also looked up in the 'A', 'I', 'J', and/or '-' namespaces. Now instead of returning the contents of that other resource an HTTP redirect response will be sent.