### PR TITLE
OPDS dumper cleanup

### DIFF
--- a/src/opds_dumper.cpp
+++ b/src/opds_dumper.cpp
@@ -99,10 +99,12 @@ kainjow::mustache::object getSingleBookData(const Book& book)
 std::string getSingleBookEntryXML(const Book& book, const std::string& rootLocation, const std::string& endpointRoot, bool partial)
 {
   auto data = getSingleBookData(book);
-  data["dump_partial_entries"] = MustacheData(partial);
   data["endpoint_root"] = endpointRoot;
   data["root"] = rootLocation;
-  return render_template(RESOURCE::templates::catalog_v2_entry_xml, data);
+  const auto xmlTemplate = partial
+                         ? RESOURCE::templates::catalog_v2_partial_entry_xml
+                         : RESOURCE::templates::catalog_v2_entry_xml;
+  return render_template(xmlTemplate, data);
 }
 
 BooksData getBooksData(const Library* library, const std::vector<std::string>& bookIds, const std::string& rootLocation, const std::string& endpointRoot, bool partial)

--- a/static/resources_list.txt
+++ b/static/resources_list.txt
@@ -27,6 +27,7 @@ templates/catalog_entries.xml
 templates/catalog_v2_root.xml
 templates/catalog_v2_entries.xml
 templates/catalog_v2_entry.xml
+templates/catalog_v2_partial_entry.xml
 templates/catalog_v2_categories.xml
 templates/catalog_v2_languages.xml
 templates/url_of_search_results_css

--- a/static/templates/catalog_v2_entry.xml
+++ b/static/templates/catalog_v2_entry.xml
@@ -2,11 +2,7 @@
     <id>urn:uuid:{{id}}</id>
     <title>{{title}}</title>
     <updated>{{updated}}</updated>
-{{#dump_partial_entries}}
-    <link rel="alternate"
-          href="{{endpoint_root}}/entry/{{{id}}}"
-          type="application/atom+xml;type=entry;profile=opds-catalog"/>
-{{/dump_partial_entries}}{{^dump_partial_entries}}    <summary>{{description}}</summary>
+    <summary>{{description}}</summary>
     <language>{{language}}</language>
     <name>{{name}}</name>
     <flavour>{{flavour}}</flavour>
@@ -28,5 +24,4 @@
     {{#url}}
     <link rel="http://opds-spec.org/acquisition/open-access" type="application/x-zim" href="{{{url}}}" length="{{{size}}}" />
     {{/url}}
-{{/dump_partial_entries}}
   </entry>

--- a/static/templates/catalog_v2_entry.xml
+++ b/static/templates/catalog_v2_entry.xml
@@ -1,5 +1,4 @@
-{{#with_xml_header}}<?xml version="1.0" encoding="UTF-8"?>
-{{/with_xml_header}}  <entry>
+  <entry>
     <id>urn:uuid:{{id}}</id>
     <title>{{title}}</title>
     <updated>{{updated}}</updated>

--- a/static/templates/catalog_v2_partial_entry.xml
+++ b/static/templates/catalog_v2_partial_entry.xml
@@ -1,0 +1,8 @@
+  <entry>
+    <id>urn:uuid:{{id}}</id>
+    <title>{{title}}</title>
+    <updated>{{updated}}</updated>
+    <link rel="alternate"
+          href="{{endpoint_root}}/entry/{{{id}}}"
+          type="application/atom+xml;type=entry;profile=opds-catalog"/>
+  </entry>


### PR DESCRIPTION
OPDS dumper cleanup (as a preparatory step for fixing #828)

This cleanup should also result in a slightly faster OPDS feed generation when only partial entries are requested. 