### PR TITLE
Backslash handling in suggestions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Setup python 3.10
-        uses: actions/setup-python@v2
+      - name: Setup python 3.9
+        uses: actions/setup-python@v1
         with:
-          python-version: '3.10'
+          python-version: '3.9'
       - name: Install packages
         run: |
           brew update
-          brew install gcovr pkg-config ninja
+          brew install gcovr pkg-config ninja || brew link --overwrite python
       - name: Install python modules
         run: pip3 install meson==0.49.2 pytest
       - name: Install deps

--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -711,18 +711,7 @@ std::unique_ptr<Response> InternalServer::handle_suggest(const RequestContext& r
   auto srs = search.getResults(start, count);
 
   for(auto& suggestion: srs) {
-    MustacheData result;
-    result.set("label", suggestion.getTitle());
-
-    if (suggestion.hasSnippet()) {
-      result.set("label", suggestion.getSnippet());
-    }
-
-    result.set("value", suggestion.getTitle());
-    result.set("kind", "path");
-    result.set("path", suggestion.getPath());
-    result.set("first", results.is_empty_list());
-    results.push_back(result);
+    results.add(suggestion);
   }
 
 

--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -711,11 +711,7 @@ std::unique_ptr<Response> InternalServer::handle_suggest(const RequestContext& r
     results.addFTSearchSuggestion(request.get_user_language(), queryString);
   }
 
-  auto data = get_default_data();
-  data.set("suggestions", results);
-
-  auto response = ContentResponse::build(*this, RESOURCE::templates::suggestion_json, data, "application/json; charset=utf-8");
-  return std::move(response);
+  return ContentResponse::build(*this, results.getJSON(), "application/json; charset=utf-8");
 }
 
 std::unique_ptr<Response> InternalServer::handle_viewer_settings(const RequestContext& request)

--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -138,15 +138,6 @@ std::string renderUrl(const std::string& root, const std::string& urlTemplate)
   return url;
 }
 
-std::string makeFulltextSearchSuggestion(const std::string& lang, const std::string& queryString)
-{
-  return i18n::expandParameterizedString(lang, "suggest-full-text-search",
-               {
-                  {"SEARCH_TERMS", queryString}
-               }
-         );
-}
-
 ParameterizedMessage noSuchBookErrorMsg(const std::string& bookName)
 {
   return ParameterizedMessage("no-such-book", { {"BOOK_NAME", bookName} });
@@ -717,13 +708,7 @@ std::unique_ptr<Response> InternalServer::handle_suggest(const RequestContext& r
 
   /* Propose the fulltext search if possible */
   if (archive->hasFulltextIndex()) {
-    MustacheData result;
-    const auto lang = request.get_user_language();
-    result.set("label", makeFulltextSearchSuggestion(lang, queryString));
-    result.set("value", queryString + " ");
-    result.set("kind", "pattern");
-    result.set("first", results.is_empty_list());
-    results.push_back(result);
+    results.addFTSearchSuggestion(request.get_user_language(), queryString);
   }
 
   auto data = get_default_data();

--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -702,8 +702,6 @@ std::unique_ptr<Response> InternalServer::handle_suggest(const RequestContext& r
 
   Suggestions results;
 
-  bool first = true;
-
   /* Get the suggestions */
   auto searcher = suggestionSearcherCache.getOrPut(bookId,
     [=](){ return make_shared<LockableSuggestionSearcher>(*archive); }
@@ -723,8 +721,7 @@ std::unique_ptr<Response> InternalServer::handle_suggest(const RequestContext& r
     result.set("value", suggestion.getTitle());
     result.set("kind", "path");
     result.set("path", suggestion.getPath());
-    result.set("first", first);
-    first = false;
+    result.set("first", results.is_empty_list());
     results.push_back(result);
   }
 
@@ -736,7 +733,7 @@ std::unique_ptr<Response> InternalServer::handle_suggest(const RequestContext& r
     result.set("label", makeFulltextSearchSuggestion(lang, queryString));
     result.set("value", queryString + " ");
     result.set("kind", "pattern");
-    result.set("first", first);
+    result.set("first", results.is_empty_list());
     results.push_back(result);
   }
 

--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -700,7 +700,7 @@ std::unique_ptr<Response> InternalServer::handle_suggest(const RequestContext& r
     printf("Searching suggestions for: \"%s\"\n", queryString.c_str());
   }
 
-  MustacheData results{MustacheData::type::list};
+  Suggestions results;
 
   bool first = true;
 

--- a/src/tools/otherTools.cpp
+++ b/src/tools/otherTools.cpp
@@ -32,6 +32,7 @@
 #endif
 
 #include "tools/stringTools.h"
+#include "server/i18n.h"
 
 #include <map>
 #include <sstream>
@@ -328,6 +329,21 @@ std::string kiwix::render_template(const std::string& template_str, kainjow::mus
   return ss.str();
 }
 
+namespace
+{
+
+std::string makeFulltextSearchSuggestion(const std::string& lang,
+                                         const std::string& queryString)
+{
+  return kiwix::i18n::expandParameterizedString(lang, "suggest-full-text-search",
+               {
+                  {"SEARCH_TERMS", queryString}
+               }
+         );
+}
+
+} // unnamed namespace
+
 kiwix::Suggestions::Suggestions()
   : kainjow::mustache::data(kainjow::mustache::data::type::list)
 {
@@ -345,6 +361,17 @@ void kiwix::Suggestions::add(const zim::SuggestionItem& suggestion)
   result.set("value", suggestion.getTitle());
   result.set("kind", "path");
   result.set("path", suggestion.getPath());
+  result.set("first", this->is_empty_list());
+  this->push_back(result);
+}
+
+void kiwix::Suggestions::addFTSearchSuggestion(const std::string& uiLang,
+                                               const std::string& queryString)
+{
+  kainjow::mustache::data result;
+  result.set("label", makeFulltextSearchSuggestion(uiLang, queryString));
+  result.set("value", queryString + " ");
+  result.set("kind", "pattern");
   result.set("first", this->is_empty_list());
   this->push_back(result);
 }

--- a/src/tools/otherTools.cpp
+++ b/src/tools/otherTools.cpp
@@ -333,6 +333,19 @@ std::string kiwix::render_template(const std::string& template_str, kainjow::mus
 namespace
 {
 
+std::string escapeBackslashes(const std::string& s)
+{
+  std::string es;
+  es.reserve(s.size());
+  for (char c : s) {
+    if ( c == '\\' ) {
+      es.push_back('\\');
+    }
+    es.push_back(c);
+  }
+  return es;
+}
+
 std::string makeFulltextSearchSuggestion(const std::string& lang,
                                          const std::string& queryString)
 {
@@ -358,10 +371,10 @@ void kiwix::Suggestions::add(const zim::SuggestionItem& suggestion)
                           ? suggestion.getSnippet()
                           : suggestion.getTitle();
 
-  result.set("label", label);
-  result.set("value", suggestion.getTitle());
+  result.set("label", escapeBackslashes(label));
+  result.set("value", escapeBackslashes(suggestion.getTitle()));
   result.set("kind", "path");
-  result.set("path", suggestion.getPath());
+  result.set("path", escapeBackslashes(suggestion.getPath()));
   result.set("first", m_data.is_empty_list());
   m_data.push_back(result);
 }
@@ -370,8 +383,9 @@ void kiwix::Suggestions::addFTSearchSuggestion(const std::string& uiLang,
                                                const std::string& queryString)
 {
   kainjow::mustache::data result;
-  result.set("label", makeFulltextSearchSuggestion(uiLang, queryString));
-  result.set("value", queryString + " ");
+  const std::string label = makeFulltextSearchSuggestion(uiLang, queryString);
+  result.set("label", escapeBackslashes(label));
+  result.set("value", escapeBackslashes(queryString + " "));
   result.set("kind", "pattern");
   result.set("first", m_data.is_empty_list());
   m_data.push_back(result);

--- a/src/tools/otherTools.cpp
+++ b/src/tools/otherTools.cpp
@@ -353,12 +353,12 @@ kiwix::Suggestions::Suggestions()
 void kiwix::Suggestions::add(const zim::SuggestionItem& suggestion)
 {
   kainjow::mustache::data result;
-  result.set("label", suggestion.getTitle());
 
-  if (suggestion.hasSnippet()) {
-    result.set("label", suggestion.getSnippet());
-  }
+  const std::string label = suggestion.hasSnippet()
+                          ? suggestion.getSnippet()
+                          : suggestion.getTitle();
 
+  result.set("label", label);
   result.set("value", suggestion.getTitle());
   result.set("kind", "path");
   result.set("path", suggestion.getPath());

--- a/src/tools/otherTools.cpp
+++ b/src/tools/otherTools.cpp
@@ -33,6 +33,7 @@
 
 #include "tools/stringTools.h"
 #include "server/i18n.h"
+#include "libkiwix-resources.h"
 
 #include <map>
 #include <sstream>
@@ -374,4 +375,12 @@ void kiwix::Suggestions::addFTSearchSuggestion(const std::string& uiLang,
   result.set("kind", "pattern");
   result.set("first", this->is_empty_list());
   this->push_back(result);
+}
+
+std::string kiwix::Suggestions::getJSON() const
+{
+  kainjow::mustache::data data;
+  data.set("suggestions", *this);
+
+  return render_template(RESOURCE::templates::suggestion_json, data);
 }

--- a/src/tools/otherTools.cpp
+++ b/src/tools/otherTools.cpp
@@ -38,6 +38,7 @@
 #include <pugixml.hpp>
 
 #include <zim/uuid.h>
+#include <zim/suggestion_iterator.h>
 
 
 static std::map<std::string, std::string> codeisomapping {
@@ -330,4 +331,20 @@ std::string kiwix::render_template(const std::string& template_str, kainjow::mus
 kiwix::Suggestions::Suggestions()
   : kainjow::mustache::data(kainjow::mustache::data::type::list)
 {
+}
+
+void kiwix::Suggestions::add(const zim::SuggestionItem& suggestion)
+{
+  kainjow::mustache::data result;
+  result.set("label", suggestion.getTitle());
+
+  if (suggestion.hasSnippet()) {
+    result.set("label", suggestion.getSnippet());
+  }
+
+  result.set("value", suggestion.getTitle());
+  result.set("kind", "path");
+  result.set("path", suggestion.getPath());
+  result.set("first", this->is_empty_list());
+  this->push_back(result);
 }

--- a/src/tools/otherTools.cpp
+++ b/src/tools/otherTools.cpp
@@ -346,7 +346,7 @@ std::string makeFulltextSearchSuggestion(const std::string& lang,
 } // unnamed namespace
 
 kiwix::Suggestions::Suggestions()
-  : kainjow::mustache::data(kainjow::mustache::data::type::list)
+  : m_data(kainjow::mustache::data::type::list)
 {
 }
 
@@ -362,8 +362,8 @@ void kiwix::Suggestions::add(const zim::SuggestionItem& suggestion)
   result.set("value", suggestion.getTitle());
   result.set("kind", "path");
   result.set("path", suggestion.getPath());
-  result.set("first", this->is_empty_list());
-  this->push_back(result);
+  result.set("first", m_data.is_empty_list());
+  m_data.push_back(result);
 }
 
 void kiwix::Suggestions::addFTSearchSuggestion(const std::string& uiLang,
@@ -373,14 +373,14 @@ void kiwix::Suggestions::addFTSearchSuggestion(const std::string& uiLang,
   result.set("label", makeFulltextSearchSuggestion(uiLang, queryString));
   result.set("value", queryString + " ");
   result.set("kind", "pattern");
-  result.set("first", this->is_empty_list());
-  this->push_back(result);
+  result.set("first", m_data.is_empty_list());
+  m_data.push_back(result);
 }
 
 std::string kiwix::Suggestions::getJSON() const
 {
   kainjow::mustache::data data;
-  data.set("suggestions", *this);
+  data.set("suggestions", m_data);
 
   return render_template(RESOURCE::templates::suggestion_json, data);
 }

--- a/src/tools/otherTools.cpp
+++ b/src/tools/otherTools.cpp
@@ -326,3 +326,8 @@ std::string kiwix::render_template(const std::string& template_str, kainjow::mus
   tmpl.render(data, [&ss](const std::string& str) { ss << str; });
   return ss.str();
 }
+
+kiwix::Suggestions::Suggestions()
+  : kainjow::mustache::data(kainjow::mustache::data::type::list)
+{
+}

--- a/src/tools/otherTools.h
+++ b/src/tools/otherTools.h
@@ -78,6 +78,9 @@ namespace kiwix
     Suggestions();
 
     void add(const zim::SuggestionItem& suggestion);
+
+    void addFTSearchSuggestion(const std::string& uiLang,
+                               const std::string& query);
   };
 }
 

--- a/src/tools/otherTools.h
+++ b/src/tools/otherTools.h
@@ -33,6 +33,10 @@ namespace pugi {
   class xml_node;
 }
 
+namespace zim {
+  class SuggestionItem;
+}
+
 namespace kiwix
 {
   std::string nodeToString(const pugi::xml_node& node);
@@ -72,6 +76,8 @@ namespace kiwix
   {
   public:
     Suggestions();
+
+    void add(const zim::SuggestionItem& suggestion);
   };
 }
 

--- a/src/tools/otherTools.h
+++ b/src/tools/otherTools.h
@@ -81,6 +81,8 @@ namespace kiwix
 
     void addFTSearchSuggestion(const std::string& uiLang,
                                const std::string& query);
+
+    std::string getJSON() const;
   };
 }
 

--- a/src/tools/otherTools.h
+++ b/src/tools/otherTools.h
@@ -67,6 +67,12 @@ namespace kiwix
 
     return defaultValue;
   }
+
+  class Suggestions : public kainjow::mustache::data
+  {
+  public:
+    Suggestions();
+  };
 }
 
 #endif

--- a/src/tools/otherTools.h
+++ b/src/tools/otherTools.h
@@ -72,7 +72,7 @@ namespace kiwix
     return defaultValue;
   }
 
-  class Suggestions : public kainjow::mustache::data
+  class Suggestions
   {
   public:
     Suggestions();
@@ -83,6 +83,9 @@ namespace kiwix
                                const std::string& query);
 
     std::string getJSON() const;
+
+  private:
+    kainjow::mustache::data m_data;
   };
 }
 

--- a/test/meson.build
+++ b/test/meson.build
@@ -4,6 +4,7 @@ tests = [
     'tagParsing',
     'stringTools',
     'pathTools',
+    'otherTools',
     'kiwixserve',
     'book',
     'manager',

--- a/test/otherTools.cpp
+++ b/test/otherTools.cpp
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) 2022 Veloman Yunkan
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * is provided AS IS, WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, and
+ * NON-INFRINGEMENT.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ */
+
+#include "gtest/gtest.h"
+#include "../src/tools/otherTools.h"
+#include "zim/suggestion_iterator.h"
+
+#include <regex>
+
+namespace
+{
+
+// Output generated via mustache templates sometimes contains end-of-line
+// whitespace. This complicates representing the expected output of a unit-test
+// as C++ raw strings in editors that are configured to delete EOL whitespace.
+// A workaround is to put special markers (//EOLWHITESPACEMARKER) at the end
+// of such lines in the expected output string and remove them at runtime.
+// This is exactly what this function is for.
+std::string removeEOLWhitespaceMarkers(const std::string& s)
+{
+  const std::regex pattern("//EOLWHITESPACEMARKER");
+  return std::regex_replace(s, pattern, "");
+}
+
+} // unnamed namespace
+
+#define CHECK_SUGGESTIONS(actual, expected) \
+        EXPECT_EQ(actual, removeEOLWhitespaceMarkers(expected))
+
+TEST(Suggestions, basicTest)
+{
+  kiwix::Suggestions s;
+  CHECK_SUGGESTIONS(s.getJSON(),
+R"EXPECTEDJSON([
+  //EOLWHITESPACEMARKER
+]
+)EXPECTEDJSON"
+  );
+
+  s.add(zim::SuggestionItem("Title", "/PATH", "Snippet"));
+
+  CHECK_SUGGESTIONS(s.getJSON(),
+R"EXPECTEDJSON([
+  {
+    "value" : "Title",
+    "label" : "Snippet",
+    "kind" : "path"
+      , "path" : "/PATH"
+  }
+]
+)EXPECTEDJSON"
+  );
+
+  s.add(zim::SuggestionItem("Title Without Snippet", "/P/a/t/h"));
+  s.addFTSearchSuggestion("en", "kiwi");
+
+  CHECK_SUGGESTIONS(s.getJSON(),
+R"EXPECTEDJSON([
+  {
+    "value" : "Title",
+    "label" : "Snippet",
+    "kind" : "path"
+      , "path" : "/PATH"
+  },
+  {
+    "value" : "Title Without Snippet",
+    "label" : "Title Without Snippet",
+    "kind" : "path"
+      , "path" : "/P/a/t/h"
+  },
+  {
+    "value" : "kiwi ",
+    "label" : "containing &apos;kiwi&apos;...",
+    "kind" : "pattern"
+    //EOLWHITESPACEMARKER
+  }
+]
+)EXPECTEDJSON"
+  );
+}
+
+TEST(Suggestions, specialCharHandling)
+{
+  // HTML special symbols (<, >, &, ", and ') must be HTML-escaped
+  // Backslash symbols (\) must be duplicated.
+  const std::string SPECIAL_CHARS(R"(\<>&'")");
+  {
+    kiwix::Suggestions s;
+    s.add(zim::SuggestionItem("Title with "   + SPECIAL_CHARS,
+                              "Path with "    + SPECIAL_CHARS,
+                              "Snippet with " + SPECIAL_CHARS));
+
+    CHECK_SUGGESTIONS(s.getJSON(),
+R"EXPECTEDJSON([
+  {
+    "value" : "Title with \\&lt;&gt;&amp;&apos;&quot;",
+    "label" : "Snippet with \\&lt;&gt;&amp;&apos;&quot;",
+    "kind" : "path"
+      , "path" : "Path with \\&lt;&gt;&amp;&apos;&quot;"
+  }
+]
+)EXPECTEDJSON"
+    );
+  }
+
+  {
+    kiwix::Suggestions s;
+    s.add(zim::SuggestionItem("Snippetless title with " + SPECIAL_CHARS,
+                              "Path with " + SPECIAL_CHARS));
+
+    CHECK_SUGGESTIONS(s.getJSON(),
+R"EXPECTEDJSON([
+  {
+    "value" : "Snippetless title with \\&lt;&gt;&amp;&apos;&quot;",
+    "label" : "Snippetless title with \\&lt;&gt;&amp;&apos;&quot;",
+    "kind" : "path"
+      , "path" : "Path with \\&lt;&gt;&amp;&apos;&quot;"
+  }
+]
+)EXPECTEDJSON"
+    );
+  }
+
+  {
+    kiwix::Suggestions s;
+    s.addFTSearchSuggestion("eng", "text with " + SPECIAL_CHARS);
+
+    CHECK_SUGGESTIONS(s.getJSON(),
+R"EXPECTEDJSON([
+  {
+    "value" : "text with \\&lt;&gt;&amp;&apos;&quot; ",
+    "label" : "containing &apos;text with \\&lt;&gt;&amp;&apos;&quot;&apos;...",
+    "kind" : "pattern"
+    //EOLWHITESPACEMARKER
+  }
+]
+)EXPECTEDJSON"
+    );
+  }
+}
+
+TEST(Suggestions, fulltextSearchSuggestionIsTranslated)
+{
+  kiwix::Suggestions s;
+  s.addFTSearchSuggestion("it", "kiwi");
+
+  CHECK_SUGGESTIONS(s.getJSON(),
+R"EXPECTEDJSON([
+  {
+    "value" : "kiwi ",
+    "label" : "contenente &apos;kiwi&apos;...",
+    "kind" : "pattern"
+    //EOLWHITESPACEMARKER
+  }
+]
+)EXPECTEDJSON"
+  );
+}

--- a/test/otherTools.cpp
+++ b/test/otherTools.cpp
@@ -99,20 +99,20 @@ TEST(Suggestions, specialCharHandling)
 {
   // HTML special symbols (<, >, &, ", and ') must be HTML-escaped
   // Backslash symbols (\) must be duplicated.
-  const std::string SPECIAL_CHARS(R"(\<>&'")");
+  const std::string SYMBOLS(R"(\<>&'"~!@#$%^*()_+`-=[]{}|:;,.?)");
   {
     kiwix::Suggestions s;
-    s.add(zim::SuggestionItem("Title with "   + SPECIAL_CHARS,
-                              "Path with "    + SPECIAL_CHARS,
-                              "Snippet with " + SPECIAL_CHARS));
+    s.add(zim::SuggestionItem("Title with "   + SYMBOLS,
+                              "Path with "    + SYMBOLS,
+                              "Snippet with " + SYMBOLS));
 
     CHECK_SUGGESTIONS(s.getJSON(),
 R"EXPECTEDJSON([
   {
-    "value" : "Title with \\&lt;&gt;&amp;&apos;&quot;",
-    "label" : "Snippet with \\&lt;&gt;&amp;&apos;&quot;",
+    "value" : "Title with \\&lt;&gt;&amp;&apos;&quot;~!@#$%^*()_+`-=[]{}|:;,.?",
+    "label" : "Snippet with \\&lt;&gt;&amp;&apos;&quot;~!@#$%^*()_+`-=[]{}|:;,.?",
     "kind" : "path"
-      , "path" : "Path with \\&lt;&gt;&amp;&apos;&quot;"
+      , "path" : "Path with \\&lt;&gt;&amp;&apos;&quot;~!@#$%^*()_+`-=[]{}|:;,.?"
   }
 ]
 )EXPECTEDJSON"
@@ -121,16 +121,16 @@ R"EXPECTEDJSON([
 
   {
     kiwix::Suggestions s;
-    s.add(zim::SuggestionItem("Snippetless title with " + SPECIAL_CHARS,
-                              "Path with " + SPECIAL_CHARS));
+    s.add(zim::SuggestionItem("Snippetless title with " + SYMBOLS,
+                              "Path with " + SYMBOLS));
 
     CHECK_SUGGESTIONS(s.getJSON(),
 R"EXPECTEDJSON([
   {
-    "value" : "Snippetless title with \\&lt;&gt;&amp;&apos;&quot;",
-    "label" : "Snippetless title with \\&lt;&gt;&amp;&apos;&quot;",
+    "value" : "Snippetless title with \\&lt;&gt;&amp;&apos;&quot;~!@#$%^*()_+`-=[]{}|:;,.?",
+    "label" : "Snippetless title with \\&lt;&gt;&amp;&apos;&quot;~!@#$%^*()_+`-=[]{}|:;,.?",
     "kind" : "path"
-      , "path" : "Path with \\&lt;&gt;&amp;&apos;&quot;"
+      , "path" : "Path with \\&lt;&gt;&amp;&apos;&quot;~!@#$%^*()_+`-=[]{}|:;,.?"
   }
 ]
 )EXPECTEDJSON"
@@ -139,13 +139,13 @@ R"EXPECTEDJSON([
 
   {
     kiwix::Suggestions s;
-    s.addFTSearchSuggestion("eng", "text with " + SPECIAL_CHARS);
+    s.addFTSearchSuggestion("eng", "text with " + SYMBOLS);
 
     CHECK_SUGGESTIONS(s.getJSON(),
 R"EXPECTEDJSON([
   {
-    "value" : "text with \\&lt;&gt;&amp;&apos;&quot; ",
-    "label" : "containing &apos;text with \\&lt;&gt;&amp;&apos;&quot;&apos;...",
+    "value" : "text with \\&lt;&gt;&amp;&apos;&quot;~!@#$%^*()_+`-=[]{}|:;,.? ",
+    "label" : "containing &apos;text with \\&lt;&gt;&amp;&apos;&quot;~!@#$%^*()_+`-=[]{}|:;,.?&apos;...",
     "kind" : "pattern"
     //EOLWHITESPACEMARKER
   }


### PR DESCRIPTION
Fixes #842.
Depends on openzim/libzim#740.

The fix of #842 is quite small (as illustrated by the commit titled "Fixed handling of backslashes in suggestions") however properly testing it was problematic for the lack of necessary data in the available test ZIM files. The solution to that challenge was to extract the functionality into a separate utility that could be unit-tested. That's what is mostly done in this PR.