### PR TITLE
User language control in the server

### DIFF
--- a/src/server/i18n.cpp
+++ b/src/server/i18n.cpp
@@ -111,4 +111,21 @@ std::string ParameterizedMessage::getText(const std::string& lang) const
   return i18n::expandParameterizedString(lang, msgId, params);
 }
 
+UserLangPreferences parseUserLanguagePreferences(const std::string& s)
+{
+  // TODO: implement properly
+  const UserLangPreferences defaultPref{{"en", 1}};
+
+  if ( s.empty() )
+    return defaultPref;
+
+  for ( const char c :  s ) {
+    if ( ! std::isalpha(c) ) {
+      return defaultPref;
+    }
+  }
+
+  return {{s, 1}};
+}
+
 } // namespace kiwix

--- a/src/server/i18n.cpp
+++ b/src/server/i18n.cpp
@@ -128,4 +128,10 @@ UserLangPreferences parseUserLanguagePreferences(const std::string& s)
   return {{s, 1}};
 }
 
+std::string selectMostSuitableLanguage(const UserLangPreferences& prefs)
+{
+  // TOOD: implement properly
+  return prefs[0].lang;
+}
+
 } // namespace kiwix

--- a/src/server/i18n.h
+++ b/src/server/i18n.h
@@ -99,6 +99,8 @@ typedef std::vector<LangPreference> UserLangPreferences;
 
 UserLangPreferences parseUserLanguagePreferences(const std::string& s);
 
+std::string selectMostSuitableLanguage(const UserLangPreferences& prefs);
+
 } // namespace kiwix
 
 #endif // KIWIX_SERVER_I18N

--- a/src/server/i18n.h
+++ b/src/server/i18n.h
@@ -89,6 +89,16 @@ private: // data
   const Parameters  params;
 };
 
+struct LangPreference
+{
+  const std::string lang;
+  const float preference;
+};
+
+typedef std::vector<LangPreference> UserLangPreferences;
+
+UserLangPreferences parseUserLanguagePreferences(const std::string& s);
+
 } // namespace kiwix
 
 #endif // KIWIX_SERVER_I18N

--- a/src/server/request_context.cpp
+++ b/src/server/request_context.cpp
@@ -25,6 +25,7 @@
 #include <sstream>
 #include <cstdio>
 #include <atomic>
+#include <cctype>
 
 #include "tools/stringTools.h"
 
@@ -61,6 +62,22 @@ fullURL2LocalURL(const std::string& full_url, const std::string& rootLocation)
   } else {
     return "";
   }
+}
+
+std::string parseAcceptLanguageHeader(const std::string& s)
+{
+  // TODO: implement properly
+
+  if ( s.empty() )
+    return "en";
+
+  for ( const char c :  s ) {
+    if ( ! std::isalpha(c) ) {
+      return "en";
+    }
+  }
+
+  return s;
 }
 
 } // unnamed namespace
@@ -204,7 +221,7 @@ std::string RequestContext::get_user_language() const
   } catch(const std::out_of_range&) {}
 
   try {
-    return get_header("Accept-Language");
+    return parseAcceptLanguageHeader(get_header("Accept-Language"));
   } catch(const std::out_of_range&) {}
 
   return "en";

--- a/src/server/request_context.cpp
+++ b/src/server/request_context.cpp
@@ -64,20 +64,29 @@ fullURL2LocalURL(const std::string& full_url, const std::string& rootLocation)
   }
 }
 
-std::string parseAcceptLanguageHeader(const std::string& s)
+struct LangPreference
+{
+  const std::string lang;
+  const float preference;
+};
+
+typedef std::vector<LangPreference> UserLangPreferences;
+
+UserLangPreferences parseUserLanguagePreferences(const std::string& s)
 {
   // TODO: implement properly
+  const UserLangPreferences defaultPref{{"en", 1}};
 
   if ( s.empty() )
-    return "en";
+    return defaultPref;
 
   for ( const char c :  s ) {
     if ( ! std::isalpha(c) ) {
-      return "en";
+      return defaultPref;
     }
   }
 
-  return s;
+  return {{s, 1}};
 }
 
 } // unnamed namespace
@@ -241,7 +250,8 @@ std::string RequestContext::determine_user_language() const
   } catch(const std::out_of_range&) {}
 
   try {
-    return parseAcceptLanguageHeader(get_header("Accept-Language"));
+    const std::string acceptLanguage = get_header("Accept-Language");
+    return parseUserLanguagePreferences(acceptLanguage)[0].lang;
   } catch(const std::out_of_range&) {}
 
   return "en";

--- a/src/server/request_context.cpp
+++ b/src/server/request_context.cpp
@@ -227,7 +227,8 @@ std::string RequestContext::determine_user_language() const
 
   try {
     const std::string acceptLanguage = get_header("Accept-Language");
-    return parseUserLanguagePreferences(acceptLanguage)[0].lang;
+    const auto userLangPrefs = parseUserLanguagePreferences(acceptLanguage);
+    return selectMostSuitableLanguage(userLangPrefs);
   } catch(const std::out_of_range&) {}
 
   return "en";

--- a/src/server/request_context.cpp
+++ b/src/server/request_context.cpp
@@ -28,6 +28,7 @@
 #include <cctype>
 
 #include "tools/stringTools.h"
+#include "i18n.h"
 
 namespace kiwix {
 
@@ -62,31 +63,6 @@ fullURL2LocalURL(const std::string& full_url, const std::string& rootLocation)
   } else {
     return "";
   }
-}
-
-struct LangPreference
-{
-  const std::string lang;
-  const float preference;
-};
-
-typedef std::vector<LangPreference> UserLangPreferences;
-
-UserLangPreferences parseUserLanguagePreferences(const std::string& s)
-{
-  // TODO: implement properly
-  const UserLangPreferences defaultPref{{"en", 1}};
-
-  if ( s.empty() )
-    return defaultPref;
-
-  for ( const char c :  s ) {
-    if ( ! std::isalpha(c) ) {
-      return defaultPref;
-    }
-  }
-
-  return {{s, 1}};
 }
 
 } // unnamed namespace

--- a/src/server/request_context.h
+++ b/src/server/request_context.h
@@ -130,10 +130,15 @@ class RequestContext {
     ByteRange byteRange_;
     std::map<std::string, std::string> headers;
     std::map<std::string, std::vector<std::string>> arguments;
+    std::map<std::string, std::string> cookies;
     std::string queryString;
+    std::string userlang;
 
   private: // functions
+    std::string determine_user_language() const;
+
     static MHD_Result fill_header(void *, enum MHD_ValueKind, const char*, const char*);
+    static MHD_Result fill_cookie(void *, enum MHD_ValueKind, const char*, const char*);
     static MHD_Result fill_argument(void *, enum MHD_ValueKind, const char*, const char*);
 };
 

--- a/src/server/response.cpp
+++ b/src/server/response.cpp
@@ -387,6 +387,9 @@ MHD_Result Response::send(const RequestContext& request, MHD_Connection* connect
     MHD_add_response_header(response, p.first.c_str(), p.second.c_str());
   }
 
+  const std::string cookie = "userlang=" + request.get_user_language();
+  MHD_add_response_header(response, MHD_HTTP_HEADER_SET_COOKIE, cookie.c_str());
+
   if (m_returnCode == MHD_HTTP_OK && m_byteRange.kind() == ByteRange::RESOLVED_PARTIAL_CONTENT)
     m_returnCode = MHD_HTTP_PARTIAL_CONTENT;
 

--- a/test/otherTools.cpp
+++ b/test/otherTools.cpp
@@ -20,6 +20,7 @@
 #include "gtest/gtest.h"
 #include "../src/tools/otherTools.h"
 #include "zim/suggestion_iterator.h"
+#include "../src/server/i18n.h"
 
 #include <regex>
 
@@ -170,5 +171,65 @@ R"EXPECTEDJSON([
   }
 ]
 )EXPECTEDJSON"
+  );
+}
+
+std::string toString(const kiwix::LangPreference& x)
+{
+  std::ostringstream oss;
+  oss << "{" << x.lang << ", " << x.preference << "}";
+  return oss.str();
+}
+
+std::string toString(const kiwix::UserLangPreferences& prefs) {
+  std::ostringstream oss;
+  for ( const auto& x : prefs )
+    oss << toString(x);
+  return oss.str();
+}
+
+TEST(I18n, parseUserLanguagePreferences)
+{
+  EXPECT_EQ(toString(kiwix::parseUserLanguagePreferences("")),
+      ""
+  );
+  EXPECT_EQ(toString(kiwix::parseUserLanguagePreferences("*")),
+      "{*, 1}"
+  );
+  EXPECT_EQ(toString(kiwix::parseUserLanguagePreferences("fr")),
+      "{fr, 1}"
+  );
+  EXPECT_EQ(toString(kiwix::parseUserLanguagePreferences("fr-CH")),
+      "{fr-CH, 1}"
+  );
+  EXPECT_EQ(toString(kiwix::parseUserLanguagePreferences("fr, en-US")),
+      "{fr, 1}{en-US, 1}"
+  );
+  EXPECT_EQ(toString(kiwix::parseUserLanguagePreferences("ru;q=0.5")),
+      "{ru, 0.5}"
+  );
+  EXPECT_EQ(toString(kiwix::parseUserLanguagePreferences("fr-CH,ru;q=0.5")),
+      "{fr-CH, 1}{ru, 0.5}"
+  );
+  EXPECT_EQ(toString(kiwix::parseUserLanguagePreferences("ru;q=0.5, *;q=0.1")),
+      "{ru, 0.5}{*, 0.1}"
+  );
+
+  // rejected input
+  EXPECT_EQ(toString(kiwix::parseUserLanguagePreferences("ru;")),
+      ""
+  );
+  EXPECT_EQ(toString(kiwix::parseUserLanguagePreferences("ru;q")),
+      ""
+  );
+  EXPECT_EQ(toString(kiwix::parseUserLanguagePreferences("ru;q=")),
+      ""
+  );
+  EXPECT_EQ(toString(kiwix::parseUserLanguagePreferences("ru;0.8")),
+      ""
+  );
+
+  EXPECT_EQ(toString(kiwix::parseUserLanguagePreferences("fr,ru;0.8,en;q=0.5")),
+      "{fr, 1}{en, 0.5}"
   );
 }

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -976,6 +976,7 @@ TEST_F(ServerTest, UserLanguageControl)
 {
   struct TestData
   {
+    const std::string description;
     const std::string url;
     const std::string acceptLanguageHeader;
     const char* const requestCookie; // Cookie: header of the request
@@ -985,6 +986,7 @@ TEST_F(ServerTest, UserLanguageControl)
     operator TestContext() const
     {
       TestContext ctx{
+          {"description", description},
           {"url", url},
           {"acceptLanguageHeader", acceptLanguageHeader},
       };
@@ -1001,6 +1003,7 @@ TEST_F(ServerTest, UserLanguageControl)
 
   const TestData testData[] = {
     {
+      "Default user language is English",
       /*url*/ "/ROOT/content/zimfile/invalid-article",
       /*Accept-Language:*/ "",
       /*Request Cookie:*/       NO_COOKIE,
@@ -1008,6 +1011,7 @@ TEST_F(ServerTest, UserLanguageControl)
       /* expected <h1> */ "Not Found"
     },
     {
+      "userlang URL query parameter is respected",
       /*url*/ "/ROOT/content/zimfile/invalid-article?userlang=en",
       /*Accept-Language:*/ "",
       /*Request Cookie:*/       NO_COOKIE,
@@ -1015,6 +1019,7 @@ TEST_F(ServerTest, UserLanguageControl)
       /* expected <h1> */ "Not Found"
     },
     {
+      "userlang URL query parameter is respected",
       /*url*/ "/ROOT/content/zimfile/invalid-article?userlang=test",
       /*Accept-Language:*/ "",
       /*Request Cookie:*/       NO_COOKIE,
@@ -1022,6 +1027,7 @@ TEST_F(ServerTest, UserLanguageControl)
       /* expected <h1> */ "[I18N TESTING] Content not found, but at least the server is alive"
     },
     {
+      "'Accept-Language: *' is handled",
       /*url*/ "/ROOT/content/zimfile/invalid-article",
       /*Accept-Language:*/ "*",
       /*Request Cookie:*/       NO_COOKIE,
@@ -1029,6 +1035,7 @@ TEST_F(ServerTest, UserLanguageControl)
       /* expected <h1> */ "Not Found"
     },
     {
+      "Accept-Language: header is respected",
       /*url*/ "/ROOT/content/zimfile/invalid-article",
       /*Accept-Language:*/ "test",
       /*Request Cookie:*/       NO_COOKIE,
@@ -1036,7 +1043,7 @@ TEST_F(ServerTest, UserLanguageControl)
       /* expected <h1> */ "[I18N TESTING] Content not found, but at least the server is alive"
     },
     {
-      // userlang query parameter takes precedence over Accept-Language
+      "userlang query parameter takes precedence over Accept-Language",
       /*url*/ "/ROOT/content/zimfile/invalid-article?userlang=en",
       /*Accept-Language:*/ "test",
       /*Request Cookie:*/       NO_COOKIE,
@@ -1044,7 +1051,7 @@ TEST_F(ServerTest, UserLanguageControl)
       /* expected <h1> */ "Not Found"
     },
     {
-      // The value of the Accept-Language header is not currently parsed.
+      "The value of the Accept-Language header is not currently parsed.",
       // In case of a comma separated list of languages (optionally weighted
       // with quality values) the default (en) language is used instead.
       /*url*/ "/ROOT/content/zimfile/invalid-article",

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -1113,8 +1113,8 @@ TEST_F(ServerTest, UserLanguageControl)
       /*url*/ "/ROOT/content/zimfile/invalid-article",
       /*Accept-Language:*/ "test;q=0.9, en;q=0.2",
       /*Request Cookie:*/       NO_COOKIE,
-      /*Response Set-Cookie:*/  "userlang=en",
-      /* expected <h1> */ "Not Found"
+      /*Response Set-Cookie:*/  "userlang=test",
+      /* expected <h1> */ "[I18N TESTING] Content not found, but at least the server is alive"
     },
   };
 

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -998,42 +998,41 @@ TEST_F(ServerTest, UserLanguageControl)
   };
 
   const char* const NO_COOKIE = nullptr;
-  const char* const NO_SET_COOKIE = nullptr;
 
   const TestData testData[] = {
     {
       /*url*/ "/ROOT/content/zimfile/invalid-article",
       /*Accept-Language:*/ "",
       /*Request Cookie:*/       NO_COOKIE,
-      /*Response Set-Cookie:*/  NO_SET_COOKIE,
+      /*Response Set-Cookie:*/  "userlang=en",
       /* expected <h1> */ "Not Found"
     },
     {
       /*url*/ "/ROOT/content/zimfile/invalid-article?userlang=en",
       /*Accept-Language:*/ "",
       /*Request Cookie:*/       NO_COOKIE,
-      /*Response Set-Cookie:*/  NO_SET_COOKIE,
+      /*Response Set-Cookie:*/  "userlang=en",
       /* expected <h1> */ "Not Found"
     },
     {
       /*url*/ "/ROOT/content/zimfile/invalid-article?userlang=test",
       /*Accept-Language:*/ "",
       /*Request Cookie:*/       NO_COOKIE,
-      /*Response Set-Cookie:*/  NO_SET_COOKIE,
+      /*Response Set-Cookie:*/  "userlang=test",
       /* expected <h1> */ "[I18N TESTING] Content not found, but at least the server is alive"
     },
     {
       /*url*/ "/ROOT/content/zimfile/invalid-article",
       /*Accept-Language:*/ "*",
       /*Request Cookie:*/       NO_COOKIE,
-      /*Response Set-Cookie:*/  NO_SET_COOKIE,
+      /*Response Set-Cookie:*/  "userlang=en",
       /* expected <h1> */ "Not Found"
     },
     {
       /*url*/ "/ROOT/content/zimfile/invalid-article",
       /*Accept-Language:*/ "test",
       /*Request Cookie:*/       NO_COOKIE,
-      /*Response Set-Cookie:*/  NO_SET_COOKIE,
+      /*Response Set-Cookie:*/  "userlang=test",
       /* expected <h1> */ "[I18N TESTING] Content not found, but at least the server is alive"
     },
     {
@@ -1041,7 +1040,7 @@ TEST_F(ServerTest, UserLanguageControl)
       /*url*/ "/ROOT/content/zimfile/invalid-article?userlang=en",
       /*Accept-Language:*/ "test",
       /*Request Cookie:*/       NO_COOKIE,
-      /*Response Set-Cookie:*/  NO_SET_COOKIE,
+      /*Response Set-Cookie:*/  "userlang=en",
       /* expected <h1> */ "Not Found"
     },
     {
@@ -1051,7 +1050,7 @@ TEST_F(ServerTest, UserLanguageControl)
       /*url*/ "/ROOT/content/zimfile/invalid-article",
       /*Accept-Language:*/ "test;q=0.9, en;q=0.2",
       /*Request Cookie:*/       NO_COOKIE,
-      /*Response Set-Cookie:*/  NO_SET_COOKIE,
+      /*Response Set-Cookie:*/  "userlang=en",
       /* expected <h1> */ "Not Found"
     },
   };

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -1043,10 +1043,66 @@ TEST_F(ServerTest, UserLanguageControl)
       /* expected <h1> */ "[I18N TESTING] Content not found, but at least the server is alive"
     },
     {
+      "userlang cookie is respected",
+      /*url*/ "/ROOT/content/zimfile/invalid-article",
+      /*Accept-Language:*/ "",
+      /*Request Cookie:*/       "userlang=test",
+      /*Response Set-Cookie:*/  "userlang=test",
+      /* expected <h1> */ "[I18N TESTING] Content not found, but at least the server is alive"
+    },
+    {
+      "userlang cookie is correctly parsed",
+      /*url*/ "/ROOT/content/zimfile/invalid-article",
+      /*Accept-Language:*/ "",
+      /*Request Cookie:*/       "anothercookie=123; userlang=test",
+      /*Response Set-Cookie:*/  "userlang=test",
+      /* expected <h1> */ "[I18N TESTING] Content not found, but at least the server is alive"
+    },
+    {
+      "userlang cookie is correctly parsed",
+      /*url*/ "/ROOT/content/zimfile/invalid-article",
+      /*Accept-Language:*/ "",
+      /*Request Cookie:*/       "userlang=test; anothercookie=abc",
+      /*Response Set-Cookie:*/  "userlang=test",
+      /* expected <h1> */ "[I18N TESTING] Content not found, but at least the server is alive"
+    },
+    {
+      "userlang cookie is correctly parsed",
+      /*url*/ "/ROOT/content/zimfile/invalid-article",
+      /*Accept-Language:*/ "",
+      /*Request Cookie:*/       "cookie1=abc; userlang=test; cookie2=xyz",
+      /*Response Set-Cookie:*/  "userlang=test",
+      /* expected <h1> */ "[I18N TESTING] Content not found, but at least the server is alive"
+    },
+    {
+      "Multiple userlang cookies are not a problem",
+      /*url*/ "/ROOT/content/zimfile/invalid-article",
+      /*Accept-Language:*/ "",
+      /*Request Cookie:*/       "cookie1=abc; userlang=en; userlang=test; cookie2=xyz",
+      /*Response Set-Cookie:*/  "userlang=test",
+      /* expected <h1> */ "[I18N TESTING] Content not found, but at least the server is alive"
+    },
+    {
       "userlang query parameter takes precedence over Accept-Language",
       /*url*/ "/ROOT/content/zimfile/invalid-article?userlang=en",
       /*Accept-Language:*/ "test",
       /*Request Cookie:*/       NO_COOKIE,
+      /*Response Set-Cookie:*/  "userlang=en",
+      /* expected <h1> */ "Not Found"
+    },
+    {
+      "userlang query parameter takes precedence over its cookie counterpart",
+      /*url*/ "/ROOT/content/zimfile/invalid-article?userlang=en",
+      /*Accept-Language:*/ "",
+      /*Request Cookie:*/       "userlang=test",
+      /*Response Set-Cookie:*/  "userlang=en",
+      /* expected <h1> */ "Not Found"
+    },
+    {
+      "userlang in cookies takes precedence over Accept-Language",
+      /*url*/ "/ROOT/content/zimfile/invalid-article",
+      /*Accept-Language:*/ "test",
+      /*Request Cookie:*/       "userlang=en",
       /*Response Set-Cookie:*/  "userlang=en",
       /* expected <h1> */ "Not Found"
     },


### PR DESCRIPTION
Fixes #750

Depends on #848

kiwix server determines the user language from three sources (in that order, earlier source takes precedence):
- `userlang` URL query parameter
- `userlang` cookie
- `Accept-Language` header

In all cases, the server sets the `userlang` cookie in its response using thus determined language.

If `Accept-Language` is used and multiple language options are specified with weights, then the most suitable language is selected by scoring available translation languages - the score value is computed as the product of weight value and the number of translated strings for that language.