### PR TITLE
Safe href in suggestion links for the iframe-based viewer

### DIFF
--- a/static/skin/viewer.js
+++ b/static/skin/viewer.js
@@ -342,7 +342,14 @@ function setupSuggestions() {
           } else {
             searchLink = `${root}/search?content=${encodeURIComponent(currentBook)}&pattern=${encodeURIComponent(htmlDecode(data.value.value))}`;
           }
-          item.innerHTML = `<a class="suggest" href="javascript:gotoUrl('${searchLink}')">${htmlDecode(data.value.label)}</a>`;
+          const jsAction = `gotoUrl('${searchLink}')`;
+          // Values of the href attribute are assumed by the browser to be
+          // fully URI-encoded (no matter what the scheme is). Therefore, in
+          // order to prevent the browser from decoding the URI-encoded parts
+          // of searchLink we have to URI-encode a second time.
+          // (see https://stackoverflow.com/questions/33721510)
+          const jsActionURIEncoded = encodeURIComponent(jsAction);
+          item.innerHTML = `<a class="suggest" href="javascript:${jsActionURIEncoded}">${htmlDecode(data.value.label)}</a>`;
         },
         highlight: "autoComplete_highlight",
         selected: "autoComplete_selected"

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -69,7 +69,7 @@ const ResourceCollection resources200Compressible{
   { DYNAMIC_CONTENT, "/ROOT/skin/taskbar.css" },
   { STATIC_CONTENT,  "/ROOT/skin/taskbar.css?cacheid=216d6b5d" },
   { DYNAMIC_CONTENT, "/ROOT/skin/viewer.js" },
-  { STATIC_CONTENT,  "/ROOT/skin/viewer.js?cacheid=51e745c2" },
+  { STATIC_CONTENT,  "/ROOT/skin/viewer.js?cacheid=0933a233" },
   { DYNAMIC_CONTENT, "/ROOT/skin/fonts/Poppins.ttf" },
   { STATIC_CONTENT,  "/ROOT/skin/fonts/Poppins.ttf?cacheid=af705837" },
   { DYNAMIC_CONTENT, "/ROOT/skin/fonts/Roboto.ttf" },
@@ -291,7 +291,7 @@ R"EXPECTEDRESULT(                                <img src="../skin/download.png?
       /* url */ "/ROOT/viewer",
 R"EXPECTEDRESULT(    <link type="text/css" href="./skin/taskbar.css?cacheid=216d6b5d" rel="Stylesheet" />
     <link type="text/css" href="./skin/css/autoComplete.css?cacheid=08951e06" rel="Stylesheet" />
-    <script type="text/javascript" src="./skin/viewer.js?cacheid=51e745c2" defer></script>
+    <script type="text/javascript" src="./skin/viewer.js?cacheid=0933a233" defer></script>
     <script type="text/javascript" src="./skin/autoComplete.min.js?cacheid=1191aaaf"></script>
       const blankPageUrl = root + "/skin/blank.html?cacheid=6b1fa032";
             <label for="kiwix_button_show_toggle"><img src="./skin/caret.png?cacheid=22b942b4" alt=""></label>


### PR DESCRIPTION
Addresses kiwix/kiwix-tools#587 with respect to suggestions in the iframe-based viewer.

The value of the `href` attributed is assumed to always be a URI-encoded string that has to be decoded. This is true for URLs with  `javascript:` scheme too.

The following example demonstrates the problem

```HTML
<!DOCTYPE html>
<html>
  <head>
    <script>
      function foo() { alert('A%26B'); }
    </script>
  </head>
  <body>
    <a href="javascript:alert('A%26B)">Inline javascript.</a>
    <a href="javascript:foo()">Out-of-line javascript</a>
  </body>
</html>
```

Invoking inline javascript via the first link displays URL-decoded text ("A&B"). Running out-of-line javascript via the second link display the text as is ("A%26B").

This means that suggestion links in the iframe-based viewer that work via javascript need a second level of URL-encoding.