### PR TITLE
Suggestion link points to /content endpoint

### DIFF
--- a/static/skin/viewer.js
+++ b/static/skin/viewer.js
@@ -350,7 +350,7 @@ function setupSuggestions() {
           let url;
           if (data.value.kind == "path") {
             const path = encodeURIComponent(htmlDecode(data.value.path));
-            url = `/${uriEncodedBookName}/${path}`;
+            url = `/content/${uriEncodedBookName}/${path}`;
           } else {
             const pattern = encodeURIComponent(htmlDecode(data.value.value));
             url = `/search?content=${uriEncodedBookName}&pattern=${pattern}`;

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -69,7 +69,7 @@ const ResourceCollection resources200Compressible{
   { DYNAMIC_CONTENT, "/ROOT/skin/taskbar.css" },
   { STATIC_CONTENT,  "/ROOT/skin/taskbar.css?cacheid=216d6b5d" },
   { DYNAMIC_CONTENT, "/ROOT/skin/viewer.js" },
-  { STATIC_CONTENT,  "/ROOT/skin/viewer.js?cacheid=23966598" },
+  { STATIC_CONTENT,  "/ROOT/skin/viewer.js?cacheid=ab5374c5" },
   { DYNAMIC_CONTENT, "/ROOT/skin/fonts/Poppins.ttf" },
   { STATIC_CONTENT,  "/ROOT/skin/fonts/Poppins.ttf?cacheid=af705837" },
   { DYNAMIC_CONTENT, "/ROOT/skin/fonts/Roboto.ttf" },
@@ -291,7 +291,7 @@ R"EXPECTEDRESULT(                                <img src="../skin/download.png?
       /* url */ "/ROOT/viewer",
 R"EXPECTEDRESULT(    <link type="text/css" href="./skin/taskbar.css?cacheid=216d6b5d" rel="Stylesheet" />
     <link type="text/css" href="./skin/css/autoComplete.css?cacheid=08951e06" rel="Stylesheet" />
-    <script type="text/javascript" src="./skin/viewer.js?cacheid=23966598" defer></script>
+    <script type="text/javascript" src="./skin/viewer.js?cacheid=ab5374c5" defer></script>
     <script type="text/javascript" src="./skin/autoComplete.min.js?cacheid=1191aaaf"></script>
       const blankPageUrl = root + "/skin/blank.html?cacheid=6b1fa032";
             <label for="kiwix_button_show_toggle"><img src="./skin/caret.png?cacheid=22b942b4" alt=""></label>


### PR DESCRIPTION
Should fix kiwix/kiwix-tools#589 (but a similar issue for a search result link will persist)

Directly pointing the suggestion link to a `/content/...` URL avoids an unnecessary redirection by the server (and an associated bug related to redirection of URLs with URI-encoded special symbols in them that - in the current implementation - go into the target URL in decoded form).