### PR TITLE
Changed minimal version of C++ standard to C++17

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('libkiwix', 'cpp',
   version : '12.0.0',
   license : 'GPLv3+',
-  default_options : ['c_std=c11', 'cpp_std=c++11', 'werror=true'])
+  default_options : ['c_std=c11', 'cpp_std=c++17', 'werror=true'])
 
 compiler = meson.get_compiler('cpp')
 


### PR DESCRIPTION
Changed minimal version of C++ standard to C++14. Google Test since version 1.13.0 requires C++14.

Closes #877.