### PR TITLE
Bump-up GitHub action workflows to latest version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup python 3.9
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v3
         with:
           python-version: '3.9'
       - name: Install packages

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -13,7 +13,7 @@ jobs:
           - ubuntu-focal
           - ubuntu-bionic
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Determine which PPA we should upload to
       - name: PPA
@@ -66,7 +66,7 @@ jobs:
           args: --no-sign
           ppa: ${{ steps.ppa.outputs.ppa }}
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: Packages for ${{ matrix.distro }}
           path: output


### PR DESCRIPTION
This is necessary to avoid warnings in the CI, these warning been caused by old actions version relying on Node.js 12 (which is now unsupported).