### PR TITLE
A pseudosafe iframe

### DIFF
--- a/static/viewer.html
+++ b/static/viewer.html
@@ -69,6 +69,7 @@
 
     <iframe id="content_iframe"
             referrerpolicy="same-origin"
+            sandbox="allow-same-origin allow-scripts"
             onload="on_content_load()"
             src="./skin/blank.html?KIWIXCACHEID" title="ZIM content" width="100%"
             style="border:0px">


### PR DESCRIPTION
"Fixes" kiwix/kiwix-tools#604.

This prevents scripts running inside an iframe from inadvertently manipulating the top browsing context. However a malicious script could still remove the sandboxing imposed on it (because the combination of "allow-same-origin" and "allow-scripts" is vulnerable).