### PR TITLE
Minor UI language selection improvements

### DIFF
--- a/static/skin/index.css
+++ b/static/skin/index.css
@@ -182,6 +182,7 @@ body {
 #uiLanguageSelectorButton {
   margin: 0 12px 0 0;
   float: right;
+  cursor: pointer;
 }
 
 .book__list {

--- a/static/skin/taskbar.css
+++ b/static/skin/taskbar.css
@@ -200,6 +200,7 @@ a.suggest, a.suggest:visited, a.suggest:hover, a.suggest:active {
 #uiLanguageSelectorButton {
   margin: 0px 12px 6px 12px;
   float: right;
+  cursor: pointer;
 }
 
 @media(min-width:420px) {

--- a/static/templates/index.html
+++ b/static/templates/index.html
@@ -53,7 +53,10 @@
              aria-label="Library OPDS Feed"
              title="Library OPDS Feed">
       </a>
-      <a onclick="window.modalUILanguageSelector.show()">
+      <a onclick="window.modalUILanguageSelector.show()"
+         alt="Select UI language"
+         aria-label="Select UI language"
+         title="Select UI language">
         <svg xmlns="http://www.w3.org/2000/svg"
              id="uiLanguageSelectorButton"
              width="30"

--- a/static/viewer.html
+++ b/static/viewer.html
@@ -30,7 +30,11 @@
     <div class="kiwix" style="display:none" id="kiwixtoolbarwrapper">
       <div id="kiwixtoolbar" class="ui-widget-header">
         <div class="kiwix_centered">
-          <a id="uiLanguageSelectorButton" onclick="window.modalUILanguageSelector.show()">
+          <a id="uiLanguageSelectorButton"
+             onclick="window.modalUILanguageSelector.show()"
+             alt="Select UI language"
+             aria-label="Select UI language"
+             title="Select UI language">
             <svg xmlns="http://www.w3.org/2000/svg"
                  width="30"
                  height="30"

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -61,7 +61,7 @@ const ResourceCollection resources200Compressible{
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/i18n.js" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/i18n.js?cacheid=2cf0f8c5" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/index.css" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/index.css?cacheid=be514520" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/index.css?cacheid=4974c58b" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/index.js" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/index.js?cacheid=cafa3d61" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/iso6391To3.js" },
@@ -71,7 +71,7 @@ const ResourceCollection resources200Compressible{
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/mustache.min.js" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/mustache.min.js?cacheid=bd23c4fb" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/taskbar.css" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/taskbar.css?cacheid=8fc2cc83" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/taskbar.css?cacheid=fee406f3" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/viewer.js" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=b9a574d4" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Poppins.ttf" },
@@ -270,7 +270,7 @@ TEST_F(ServerTest, CacheIdsOfStaticResources)
   const std::vector<UrlAndExpectedResult> testData{
     {
       /* url */ "/ROOT%23%3F/",
-R"EXPECTEDRESULT(      href="/ROOT%23%3F/skin/index.css?cacheid=be514520"
+R"EXPECTEDRESULT(      href="/ROOT%23%3F/skin/index.css?cacheid=4974c58b"
     <link rel="apple-touch-icon" sizes="180x180" href="/ROOT%23%3F/skin/favicon/apple-touch-icon.png?cacheid=f86f8df3">
     <link rel="icon" type="image/png" sizes="32x32" href="/ROOT%23%3F/skin/favicon/favicon-32x32.png?cacheid=79ded625">
     <link rel="icon" type="image/png" sizes="16x16" href="/ROOT%23%3F/skin/favicon/favicon-16x16.png?cacheid=a986fedc">
@@ -303,7 +303,7 @@ R"EXPECTEDRESULT(                                <img src="${root}/skin/download
     },
     {
       /* url */ "/ROOT%23%3F/viewer",
-R"EXPECTEDRESULT(    <link type="text/css" href="./skin/taskbar.css?cacheid=8fc2cc83" rel="Stylesheet" />
+R"EXPECTEDRESULT(    <link type="text/css" href="./skin/taskbar.css?cacheid=fee406f3" rel="Stylesheet" />
     <link type="text/css" href="./skin/css/autoComplete.css?cacheid=08951e06" rel="Stylesheet" />
     <script type="module" src="./skin/i18n.js?cacheid=2cf0f8c5" defer></script>
     <script type="text/javascript" src="./skin/languages.js?cacheid=b00b12db" defer></script>


### PR DESCRIPTION
Fixes #900

Added cursor type and hints to the UI language selection button. The hints are always in English since seeing a hint in an unfamiliar language doesn't help and English is the current lingua franca.