### PR TITLE
Enable Chromium to display PDFs in the viewer iframe

### DIFF
--- a/src/server/response.cpp
+++ b/src/server/response.cpp
@@ -412,6 +412,12 @@ ContentResponse::ContentResponse(const std::string& root, bool verbose, const st
   m_mimeType(mimetype)
 {
   add_header(MHD_HTTP_HEADER_CONTENT_TYPE, m_mimeType);
+  if ( !startsWith(m_mimeType, "application/pdf") ) {
+    add_header("Content-Security-Policy",
+               "default-src 'self' data: blob: about: chrome-extension: 'unsafe-inline' 'unsafe-eval'; "
+               "sandbox allow-scripts allow-same-origin allow-modals allow-popups allow-forms allow-downloads;");
+    add_header("Referrer-Policy", "no-referrer");
+  }
 }
 
 std::unique_ptr<ContentResponse> ContentResponse::build(

--- a/static/viewer.html
+++ b/static/viewer.html
@@ -2,6 +2,10 @@
 <html>
   <head>
     <meta charset="UTF-8">
+    <meta http-equiv="Content-Security-Policy"
+          content="default-src 'self' data: 'unsafe-inline' 'unsafe-eval';
+                   frame-src 'self' moz-extension: chrome-extension:;
+                   object-src 'none';">
     <title>ZIM Viewer</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link type="text/css" href="./skin/taskbar.css?KIWIXCACHEID" rel="Stylesheet" />
@@ -65,8 +69,7 @@
     </div>
 
     <iframe id="content_iframe"
-            referrerpolicy="same-origin"
-            sandbox="allow-same-origin allow-scripts"
+            referrerpolicy="no-referrer"
             onload="on_content_load()"
             src="./skin/blank.html?KIWIXCACHEID" title="ZIM content" width="100%"
             style="border:0px">


### PR DESCRIPTION
Fixes #916

The fix doesn't work for Chromium versions under 91. Frankly I haven't verified that it works for Chromium 91+ because I only have 90.