### PR TITLE
Really enable Chromium to display PDFs in the viewer iframe

### DIFF
--- a/src/server/response.cpp
+++ b/src/server/response.cpp
@@ -412,12 +412,6 @@ ContentResponse::ContentResponse(const std::string& root, bool verbose, const st
   m_mimeType(mimetype)
 {
   add_header(MHD_HTTP_HEADER_CONTENT_TYPE, m_mimeType);
-  if ( !startsWith(m_mimeType, "application/pdf") ) {
-    add_header("Content-Security-Policy",
-               "default-src 'self' data: blob: about: chrome-extension: 'unsafe-inline' 'unsafe-eval'; "
-               "sandbox allow-scripts allow-same-origin allow-modals allow-popups allow-forms allow-downloads;");
-    add_header("Referrer-Policy", "no-referrer");
-  }
 }
 
 std::unique_ptr<ContentResponse> ContentResponse::build(

--- a/static/viewer.html
+++ b/static/viewer.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="Content-Security-Policy"
           content="default-src 'self' data: 'unsafe-inline' 'unsafe-eval';
-                   frame-src 'self' moz-extension: chrome-extension:;
+                   frame-src 'self';
                    object-src 'none';">
     <title>ZIM Viewer</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
Fixes #916

The previous "fix" (merged PR #92 ) was buggy. It not only didn't work in Chromium v90, but in more recent versions too.

I verified that this fix works in Firefox (v111) and Chromium (v90):

- Attempts by the ZIM content to break out of the viewer iframe are blocked.
- PDFs are displayed in the viewer.

Also (unrelated to the bug being addressed) removed `moz-extension:` and `chrome-extension:` from list of valid sources in content security policy as they are not justified for `kiwix-serve` (as [noted](https://github.com/kiwix/libkiwix/pull/924#discussion_r1152134334) in @Jaifroid's review of #924) 