### PR TITLE
Fix macOS CI python dependency install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
       - name: Install packages
         run: |
           brew update
+          brew unlink python3
+          # upgrade from python@3.11.2_1 to python@3.11.3 fails to overwrite those
+          rm -f /usr/local/bin/2to3 /usr/local/bin/2to3-3.11 /usr/local/bin/idle3 /usr/local/bin/idle3.11 /usr/local/bin/pydoc3 /usr/local/bin/pydoc3.11 /usr/local/bin/python3 /usr/local/bin/python3-config /usr/local/bin/python3.11 /usr/local/bin/python3.11-config
           brew install pkg-config ninja meson
 
       - name: Install dependencies


### PR DESCRIPTION
meson and ninja both depends on python3 which received an update.
This python3 update fails to install when linking.

This temp fix removes those files. Hopefully a future update will remove the need for this hack

I couldn't find any cleaner way to get passed this…