### PR TITLE
PDF-friendly book home button in the viewer

### DIFF
--- a/test/server.cpp
+++ b/test/server.cpp
@@ -73,7 +73,7 @@ const ResourceCollection resources200Compressible{
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/taskbar.css" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/taskbar.css?cacheid=bbdaf425" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/viewer.js" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=b9a574d4" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=725c95a2" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Poppins.ttf" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/fonts/Poppins.ttf?cacheid=af705837" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Roboto.ttf" },
@@ -312,7 +312,7 @@ R"EXPECTEDRESULT(    <link type="text/css" href="./skin/taskbar.css?cacheid=bbda
     <link type="text/css" href="./skin/css/autoComplete.css?cacheid=08951e06" rel="Stylesheet" />
     <script type="module" src="./skin/i18n.js?cacheid=2cf0f8c5" defer></script>
     <script type="text/javascript" src="./skin/languages.js?cacheid=648526e1" defer></script>
-    <script type="text/javascript" src="./skin/viewer.js?cacheid=b9a574d4" defer></script>
+    <script type="text/javascript" src="./skin/viewer.js?cacheid=725c95a2" defer></script>
     <script type="text/javascript" src="./skin/autoComplete.min.js?cacheid=1191aaaf"></script>
       const blankPageUrl = root + "/skin/blank.html?cacheid=6b1fa032";
             <img src="./skin/langSelector.svg?cacheid=00b59961">


### PR DESCRIPTION
Fixes #912

In firefox, when PDF content is displayed in the viewer, changing the viewer URL in the address bar had no effect. The most prominent manifestation of this bug was the broken book home button but the same issue was present even if the fragment component of the viewer URL was edited manually. The bug was a result of

1. an optimization preventing any actions if the new content URL is the same as the old content URL (this was needed to break the infinite loop of mutual updates of the top-window and content window/iframe URLs when any one of them changes).

2. sandboxing of the iframe and inability to access the content URL in iframe because of cross-origin restrictions when the content is a PDF displayed by the builtin viewer.

Now that issue is fixed. A slight remaining defect is that the addressbar URL is still not updated when a PDF file is loaded/displayed in the viewer.