### PR TITLE
Fixed external links in the viewer iframe

### DIFF
--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -1088,6 +1088,7 @@ const std::string CONTENT_CSP_HEADER =
 
     "sandbox allow-scripts "
             "allow-same-origin "
+            "allow-top-navigation-by-user-activation "
             "allow-modals "
             "allow-popups "
             "allow-forms "

--- a/static/skin/viewer.js
+++ b/static/skin/viewer.js
@@ -257,7 +257,7 @@ function isExternalUrl(url) {
       || url.startsWith("https:");
 }
 
-function onClickEvent(e) {
+function handleLinkClick(e) {
   const iframeDocument = contentIframe.contentDocument;
   const target = matchingAncestorElement(e.target, iframeDocument, "a");
   if (target !== null && "href" in target) {
@@ -266,6 +266,8 @@ function onClickEvent(e) {
       if ( viewerSettings.linkBlockingEnabled ) {
         return blockLink(target);
       }
+    } else {
+      target.setAttribute("target", "content_iframe");
     }
   }
 }
@@ -301,7 +303,7 @@ this.Element && function(ElementPrototype) {
 }(Element.prototype);
 
 function setup_external_link_blocker() {
-  setupEventHandler(contentIframe.contentDocument, 'a', 'click', onClickEvent);
+  setupEventHandler(contentIframe.contentDocument, 'a', 'click', handleLinkClick);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/static/viewer.html
+++ b/static/viewer.html
@@ -69,6 +69,7 @@
     </div>
 
     <iframe id="content_iframe"
+            name="content_iframe"
             referrerpolicy="no-referrer"
             onload="on_content_load()"
             src="./skin/blank.html?KIWIXCACHEID" title="ZIM content" width="100%"

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -73,7 +73,7 @@ const ResourceCollection resources200Compressible{
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/taskbar.css" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/taskbar.css?cacheid=bbdaf425" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/viewer.js" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=b9a574d4" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=b548ad94" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Poppins.ttf" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/fonts/Poppins.ttf?cacheid=af705837" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Roboto.ttf" },
@@ -312,7 +312,7 @@ R"EXPECTEDRESULT(    <link type="text/css" href="./skin/taskbar.css?cacheid=bbda
     <link type="text/css" href="./skin/css/autoComplete.css?cacheid=08951e06" rel="Stylesheet" />
     <script type="module" src="./skin/i18n.js?cacheid=2cf0f8c5" defer></script>
     <script type="text/javascript" src="./skin/languages.js?cacheid=b00b12db" defer></script>
-    <script type="text/javascript" src="./skin/viewer.js?cacheid=b9a574d4" defer></script>
+    <script type="text/javascript" src="./skin/viewer.js?cacheid=b548ad94" defer></script>
     <script type="text/javascript" src="./skin/autoComplete.min.js?cacheid=1191aaaf"></script>
       const blankPageUrl = root + "/skin/blank.html?cacheid=6b1fa032";
             <img src="./skin/langSelector.svg?cacheid=00b59961">


### PR DESCRIPTION
Fixes #943

Before this fix clicking an external link in the viewer iframe had no effect (other than an error being reported in the browser dev tools console) because the attempt to navigate the top browser context was suppressed due to sandboxing.

One downside with this solution is that it again opens the possibility of losing the viewer toolbar if an internal link in a ZIM file has its `target` attribute set to `_top` (however, such links can be detected and corrected by the viewer). I cannot think of other downsides.