### PR TITLE
Fixed external links in the viewer iframe (via postMessage)

### DIFF
--- a/static/skin/viewer.js
+++ b/static/skin/viewer.js
@@ -312,8 +312,8 @@ let viewerSetupComplete = false;
 function on_content_load() {
   if ( viewerSetupComplete ) {
     handle_content_url_change();
-    setup_external_link_blocker();
   }
+  setup_external_link_blocker();
 }
 
 function htmlDecode(input) {

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -73,7 +73,7 @@ const ResourceCollection resources200Compressible{
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/taskbar.css" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/taskbar.css?cacheid=bbdaf425" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/viewer.js" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=d575e81a" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=d407a38a" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Poppins.ttf" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/fonts/Poppins.ttf?cacheid=af705837" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Roboto.ttf" },
@@ -312,7 +312,7 @@ R"EXPECTEDRESULT(    <link type="text/css" href="./skin/taskbar.css?cacheid=bbda
     <link type="text/css" href="./skin/css/autoComplete.css?cacheid=08951e06" rel="Stylesheet" />
     <script type="module" src="./skin/i18n.js?cacheid=2cf0f8c5" defer></script>
     <script type="text/javascript" src="./skin/languages.js?cacheid=b00b12db" defer></script>
-    <script type="text/javascript" src="./skin/viewer.js?cacheid=d575e81a" defer></script>
+    <script type="text/javascript" src="./skin/viewer.js?cacheid=d407a38a" defer></script>
     <script type="text/javascript" src="./skin/autoComplete.min.js?cacheid=1191aaaf"></script>
       const blankPageUrl = root + "/skin/blank.html?cacheid=6b1fa032";
             <img src="./skin/langSelector.svg?cacheid=00b59961">

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -73,7 +73,7 @@ const ResourceCollection resources200Compressible{
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/taskbar.css" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/taskbar.css?cacheid=bbdaf425" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/viewer.js" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=b9a574d4" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=d575e81a" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Poppins.ttf" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/fonts/Poppins.ttf?cacheid=af705837" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Roboto.ttf" },
@@ -312,7 +312,7 @@ R"EXPECTEDRESULT(    <link type="text/css" href="./skin/taskbar.css?cacheid=bbda
     <link type="text/css" href="./skin/css/autoComplete.css?cacheid=08951e06" rel="Stylesheet" />
     <script type="module" src="./skin/i18n.js?cacheid=2cf0f8c5" defer></script>
     <script type="text/javascript" src="./skin/languages.js?cacheid=b00b12db" defer></script>
-    <script type="text/javascript" src="./skin/viewer.js?cacheid=b9a574d4" defer></script>
+    <script type="text/javascript" src="./skin/viewer.js?cacheid=d575e81a" defer></script>
     <script type="text/javascript" src="./skin/autoComplete.min.js?cacheid=1191aaaf"></script>
       const blankPageUrl = root + "/skin/blank.html?cacheid=6b1fa032";
             <img src="./skin/langSelector.svg?cacheid=00b59961">


### PR DESCRIPTION
Fixes #943

This PR is an alternative to #946 (as suggested by https://github.com/kiwix/libkiwix/pull/946#issuecomment-1542414873).

Overall this approach is simpler than #946 however while working on it a few issues common for this PR and #946 have been discovered.

Known issues:

- The solution actually introduces a new message-based API for navigation of the viewer window. A committed antiZIMmer can create a malicious page that breaks out of the viewer iframe (though the same could be done with #946 too).
- Ctrl-clicking an external link loads it (or the catch page) both in the viewer window and in a new tab. This can be fixed.
- Middle-clicking (or selecting the "Open in New Tab/Window" from the context menu) doesn't block external links (but that is a common problem for all solutions based solely on intercepting click events).