### PR TITLE
Include netinet/in.h everywhere except Windows

### DIFF
--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -19,7 +19,7 @@
 
 #include "internalServer.h"
 
-#ifdef __FreeBSD__
+#ifndef _WIN32
 #include <netinet/in.h>
 #endif
 


### PR DESCRIPTION
libkiwix fails to build on OpenBSD:

```
c++ -Isrc/libkiwix.so.0.0.p -Isrc -I../libkiwix-12.0.0/src -Iinclude -I../libkiwix-12.0.0/include -Istatic -I/usr/local/include -I/usr/local/include/p11-kit-1 -fcolor-diagnostics -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Werror -std=c++11 -O2 -pipe -fPIC -MD -MQ src/libkiwix.so.0.0.p/server_internalServer.cpp.o -MF src/libkiwix.so.0.0.p/server_internalServer.cpp.o.d -o src/libkiwix.so.0.0.p/server_internalServer.cpp.o -c ../libkiwix-12.0.0/src/server/internalServer.cpp
../libkiwix-12.0.0/src/server/internalServer.cpp:434:22: error: variable has incomplete type 'struct sockaddr_in'
  struct sockaddr_in sockAddr;
                     ^
../libkiwix-12.0.0/src/server/internalServer.cpp:434:10: note: forward declaration of 'sockaddr_in'
  struct sockaddr_in sockAddr;
         ^
```

This can be resolved by adding OpenBSD to an existing FreeBSD check. But OpenBSD and FreeBSD are doing nothing wrong here—according to POSIX, the correct header to include for `sockaddr_in` is `netinet/in.h`, meaning they are compliant with the spec. Other POSIX systems may hit the same issue.

Linux seems to be more relaxed by declaring `sockaddr_in` via some other header as well. But it does no harm to include `netinet/in.h` on Linux, and doing so is better than continuing to add operating systems to the `#ifdef`.