### PR TITLE
meson.build: Fix detection of libzim built with Xapian

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -36,7 +36,7 @@ else
 endif
 
 libzim_dep = dependency('libzim', version : '>=8.1.0', static:static_deps)
-if not compiler.has_header_symbol('zim/zim.h', 'LIBZIM_WITH_XAPIAN')
+if not compiler.has_header_symbol('zim/zim.h', 'LIBZIM_WITH_XAPIAN', dependencies: libzim_dep)
   error('Libzim seems to be compiled without xapian. Xapian support is mandatory.')
 endif
 


### PR DESCRIPTION
The dependency on libzim must be specified in compiler.has_header_symbol() for it to find the header in all cases.

Fixes a configure error on FreeBSD:
"""
Header "zim/zim.h" has symbol "LIBZIM_WITH_XAPIAN" : NO

meson.build:33:2: ERROR: Problem encountered: Libzim seems to be compiled without xapian. Xapian support is mandatory. """