### PR TITLE
Quasi-URI-encoded suggestion links

### DIFF
--- a/test/server.cpp
+++ b/test/server.cpp
@@ -73,7 +73,7 @@ const ResourceCollection resources200Compressible{
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/taskbar.css" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/taskbar.css?cacheid=bbdaf425" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/viewer.js" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=cb9b1f75" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=bb748367" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Poppins.ttf" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/fonts/Poppins.ttf?cacheid=af705837" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Roboto.ttf" },
@@ -312,7 +312,7 @@ R"EXPECTEDRESULT(    <link type="text/css" href="./skin/taskbar.css?cacheid=bbda
     <link type="text/css" href="./skin/css/autoComplete.css?cacheid=08951e06" rel="Stylesheet" />
     <script type="module" src="./skin/i18n.js?cacheid=2cf0f8c5" defer></script>
     <script type="text/javascript" src="./skin/languages.js?cacheid=648526e1" defer></script>
-    <script type="text/javascript" src="./skin/viewer.js?cacheid=cb9b1f75" defer></script>
+    <script type="text/javascript" src="./skin/viewer.js?cacheid=bb748367" defer></script>
     <script type="text/javascript" src="./skin/autoComplete.min.js?cacheid=1191aaaf"></script>
       const blankPageUrl = root + "/skin/blank.html?cacheid=6b1fa032";
             <img src="./skin/langSelector.svg?cacheid=00b59961">


### PR DESCRIPTION
Fixes #958

Before this fix suggestion links were built out of fully URI-encoded book name and article path components despite the fact that this measure was taken against only a few dangerous symbols such as '#', '?', '"' and '\'.  However, URI-encoding the slash symbols in the path has some undesirable side-effects.

Henceforth only the problematic symbols are encoded in the article path component. The book name is still fully URI-encoded since I don't see any counter-arguments.