### PR TITLE
Remove Ubuntu Kinetic from CI/CD (deprecated)

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -13,7 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         distro:
-          - ubuntu-kinetic
           - ubuntu-jammy
           - ubuntu-focal
     steps:
@@ -37,14 +36,6 @@ jobs:
           fullname: Kiwix builder
           email: release+launchpad@kiwix.org
           distro: ${{ matrix.distro }}
-
-      - uses: legoktm/gh-action-build-deb@ubuntu-kinetic
-        if: matrix.distro == 'ubuntu-kinetic'
-        name: Build package for ubuntu-kinetic
-        id: build-ubuntu-kinetic
-        with:
-          args: --no-sign
-          ppa: ${{ steps.ppa.outputs.ppa }}
 
       - uses: legoktm/gh-action-build-deb@ubuntu-jammy
         if: matrix.distro == 'ubuntu-jammy'


### PR DESCRIPTION
This commit is taken from #983