### PR TITLE
Revert ABI breakage in kiwix::Downloader::getDownloadIds()

### DIFF
--- a/include/downloader.h
+++ b/include/downloader.h
@@ -204,7 +204,7 @@ class Downloader
   /**
    * Get the ids of the managed downloads.
    */
-  std::vector<std::string> getDownloadIds() const;
+  std::vector<std::string> getDownloadIds();
 
  private:
   mutable std::mutex m_lock;

--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -157,7 +157,7 @@ void Downloader::close()
   mp_aria->close();
 }
 
-std::vector<std::string> Downloader::getDownloadIds() const {
+std::vector<std::string> Downloader::getDownloadIds() {
   std::unique_lock<std::mutex> lock(m_lock);
   std::vector<std::string> ret;
   for(auto& p:m_knownDownloads) {


### PR DESCRIPTION
Changing it to be `const` is an ABI change since the symbol changes from `_ZN5...` to `_ZNK5...` (addition of "K").

The other changes made in 18b7b5f27 are probably fine to keep since they don't appear to be used from what I can tell.

Fixes https://github.com/kiwix/libkiwix/issues/998.