### PR TITLE
Hack for mirrobrain magnet URIs

### DIFF
--- a/test/server.cpp
+++ b/test/server.cpp
@@ -63,7 +63,7 @@ const ResourceCollection resources200Compressible{
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/index.css" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/index.css?cacheid=e4d76d16" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/index.js" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/index.js?cacheid=e1b1ae55" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/index.js?cacheid=ce19da2a" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/iso6391To3.js" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/iso6391To3.js?cacheid=ecde2bb3" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/isotope.pkgd.min.js" },
@@ -288,7 +288,7 @@ R"EXPECTEDRESULT(      href="/ROOT%23%3F/skin/index.css?cacheid=e4d76d16"
     <script type="text/javascript" src="/ROOT%23%3F/skin/languages.js?cacheid=648526e1" defer></script>
     <script src="/ROOT%23%3F/skin/isotope.pkgd.min.js?cacheid=2e48d392" defer></script>
     <script src="/ROOT%23%3F/skin/iso6391To3.js?cacheid=ecde2bb3"></script>
-    <script type="text/javascript" src="/ROOT%23%3F/skin/index.js?cacheid=e1b1ae55" defer></script>
+    <script type="text/javascript" src="/ROOT%23%3F/skin/index.js?cacheid=ce19da2a" defer></script>
         <img src="/ROOT%23%3F/skin/feed.svg?cacheid=055b333f"
         <img src="/ROOT%23%3F/skin/langSelector.svg?cacheid=00b59961"
 )EXPECTEDRESULT"


### PR DESCRIPTION
As per #938, in regard to https://github.com/kiwix/container-images/issues/242, this adds some processing to the creation of the `magnet:` link for downloads.

It mostly fixes the parameter names/values of the magnet string but also fetches the list of mirrored URLs (using metalink) to add them as alternative webseeds.

Tested with Vuze/Azureus on Windows as well as Tixati on Windows (Tixati is smart enough to retrieve metalink from the webseed and thus didn't even need the extra `ws=`).

Please note that while Transmission understands it's multiple webseeds, there's no support for fetching the torrent/DHT and so the download never starts. Don't be fooled 😉! I guess it's similar in most other torrent client (most of them dont support webseed magnets).

**Suggestion**: `target="_blank"` for magnet is really annoying (leaves a blank tab open). I think it should be removed.