### PR TITLE
Kiwix frontend style cleanup

### DIFF
--- a/static/resources_list.txt
+++ b/static/resources_list.txt
@@ -10,6 +10,7 @@ skin/iso6391To3.js
 skin/isotope.pkgd.min.js
 skin/index.js
 skin/autoComplete.min.js
+skin/kiwix.css
 skin/taskbar.css
 skin/index.css
 skin/fonts/Poppins.ttf

--- a/static/skin/index.css
+++ b/static/skin/index.css
@@ -325,58 +325,6 @@ body {
     -webkit-box-orient: vertical;
 }
 
-.modal-wrapper {
-    position: fixed;
-    z-index: 100;
-    top: 0;
-    left: 0;
-    width: 100vw;
-    height: 100vh;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    align-content: center;
-    background-color: rgba(0, 0, 0, 30%);
-}
-
-.modal {
-    color: #444343;
-    height: 280px;
-    width: 250px;
-    margin: 15px;
-    background-color: #f7f7f7;
-    border: 1px solid #ececec;
-    border-radius: 3px;
-}
-
-.modal-heading {
-    background-color: #f0f0f0;
-    height: 20%;
-    width: 100%;
-    border-bottom: 1px solid #ececec;
-    display: grid;
-    grid-template-columns: 3fr 1fr;
-}
-
-.modal-title {
-    display: flex;
-    font-size: 15px;
-    align-items: center;
-    padding-left: 20px;
-    font-family: poppins;
-}
-
-.modal-close-button {
-    cursor: pointer;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-}
-
-.modal-content {
-    padding: 20px;
-}
-
 .modal-content div {
     width: 100%;
     height: 40px;

--- a/static/skin/index.css
+++ b/static/skin/index.css
@@ -517,3 +517,13 @@ body {
         grid-template-columns: 1fr;
     }
 }
+
+@font-face {
+  font-family: "poppins";
+  src: url("../skin/fonts/Poppins.ttf?KIWIXCACHEID") format("truetype");
+}
+
+@font-face {
+  font-family: "roboto";
+  src: url("../skin/fonts/Roboto.ttf?KIWIXCACHEID") format("truetype");
+}

--- a/static/skin/index.css
+++ b/static/skin/index.css
@@ -140,29 +140,6 @@
     font-weight: bolder;
 }
 
-#uiLanguageSelector {
-  display: none;
-}
-
-#uiLanguageSelector .modal {
-  height: 140px;
-}
-
-#uiLanguageSelector .modal-heading {
-  height: 40%;
-}
-
-#uiLanguageSelector .modal-content #ui_language {
-  font-size: 1.6rem;
-  width: 100%;
-}
-
-#uiLanguageSelectorButton {
-  margin: 0 12px 0 0;
-  float: right;
-  cursor: pointer;
-}
-
 .book__list {
     position: relative;
     margin: 0 auto;
@@ -395,7 +372,7 @@
     width: auto;
 }
 
-.feedLogo, #uiLanguageSelectorButton {
+.feedLogo {
     height: 30px;
     float: right;
 }

--- a/static/skin/index.css
+++ b/static/skin/index.css
@@ -1,25 +1,3 @@
-*,
-*::after,
-*::before {
-  margin: 0;
-  padding: 0;
-  box-sizing: inherit;
-}
-
-html {
-    font-size: 62.5%;
-}
-
-body {
-    position: relative;
-    box-sizing: border-box;
-}
-
-::selection {
-    background-color: #00b4e4;
-    color: white;
-}
-
 .kiwixNav {
     background-color: #f4f6f8;
     width: 100%;

--- a/static/skin/index.css
+++ b/static/skin/index.css
@@ -1,7 +1,7 @@
 .kiwixNav {
     background-color: #f4f6f8;
     width: 100%;
-    padding: 20px;
+    padding: 10px 20px;
     position: sticky;
     top: 0;
     z-index: 3;
@@ -37,10 +37,10 @@
     background-image: none;
     border-radius: 1px;
     width: 195px;
-    height: 35px;
+    height: 30px;
     flex: 1;
     color: black;
-    padding: 7px 10px 10px;
+    padding: 0px 10px 0px 10px;
     cursor: pointer;
  }
 
@@ -52,7 +52,7 @@
     position: relative;
     display: flex;
     width: 231px;
-    height: 35px;
+    height: 30px;
     line-height: 3;
     background: #909090;
     overflow: hidden;
@@ -82,7 +82,7 @@
 }
 
 .kiwixSearch {
-    height: 35px;
+    height: 30px;
     width: 231px;
     border-radius: 10px;
     border: solid 1px #b5b2b2;
@@ -96,7 +96,7 @@
 
 .kiwixButton {
     margin: 0 17px;
-    height: 35px;
+    height: 30px;
     width: 100px;
     border-radius: 10px;
     color: white;

--- a/static/skin/index.css
+++ b/static/skin/index.css
@@ -517,13 +517,3 @@ body {
         grid-template-columns: 1fr;
     }
 }
-
-@font-face {
-  font-family: "poppins";
-  src: url("../skin/fonts/Poppins.ttf?KIWIXCACHEID") format("truetype");
-}
-
-@font-face {
-  font-family: "roboto";
-  src: url("../skin/fonts/Roboto.ttf?KIWIXCACHEID") format("truetype");
-}

--- a/static/skin/kiwix.css
+++ b/static/skin/kiwix.css
@@ -72,6 +72,30 @@ body {
     padding: 20px;
 }
 
+#uiLanguageSelector {
+  display: none;
+}
+
+#uiLanguageSelector .modal {
+  height: 140px;
+}
+
+#uiLanguageSelector .modal-heading {
+  height: 40%;
+}
+
+#uiLanguageSelector .modal-content #ui_language {
+  font-size: 1.6rem;
+  width: 100%;
+}
+
+#uiLanguageSelectorButton {
+  margin: 0px 12px 6px 12px;
+  float: right;
+  cursor: pointer;
+  height: 30px;
+}
+
 @font-face {
   font-family: "poppins";
   src: url("../skin/fonts/Poppins.ttf?KIWIXCACHEID") format("truetype");

--- a/static/skin/kiwix.css
+++ b/static/skin/kiwix.css
@@ -1,3 +1,25 @@
+*,
+*::after,
+*::before {
+  margin: 0;
+  padding: 0;
+  box-sizing: inherit;
+}
+
+html {
+    font-size: 62.5%;
+}
+
+body {
+    position: relative;
+    box-sizing: border-box;
+}
+
+::selection {
+    background-color: #00b4e4;
+    color: white;
+}
+
 .modal-wrapper {
     position: fixed;
     z-index: 100;

--- a/static/skin/kiwix.css
+++ b/static/skin/kiwix.css
@@ -1,3 +1,55 @@
+.modal-wrapper {
+    position: fixed;
+    z-index: 100;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    align-content: center;
+    background-color: rgba(0, 0, 0, 30%);
+}
+
+.modal {
+    color: #444343;
+    height: 280px;
+    width: 250px;
+    margin: 15px;
+    background-color: #f7f7f7;
+    border: 1px solid #ececec;
+    border-radius: 3px;
+}
+
+.modal-heading {
+    background-color: #f0f0f0;
+    height: 20%;
+    width: 100%;
+    border-bottom: 1px solid #ececec;
+    display: grid;
+    grid-template-columns: 3fr 1fr;
+}
+
+.modal-title {
+    display: flex;
+    font-size: 15px;
+    align-items: center;
+    padding-left: 20px;
+    font-family: poppins;
+}
+
+.modal-close-button {
+    cursor: pointer;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.modal-content {
+    padding: 20px;
+}
+
 @font-face {
   font-family: "poppins";
   src: url("../skin/fonts/Poppins.ttf?KIWIXCACHEID") format("truetype");

--- a/static/skin/kiwix.css
+++ b/static/skin/kiwix.css
@@ -1,0 +1,9 @@
+@font-face {
+  font-family: "poppins";
+  src: url("../skin/fonts/Poppins.ttf?KIWIXCACHEID") format("truetype");
+}
+
+@font-face {
+  font-family: "roboto";
+  src: url("../skin/fonts/Roboto.ttf?KIWIXCACHEID") format("truetype");
+}

--- a/static/skin/taskbar.css
+++ b/static/skin/taskbar.css
@@ -131,30 +131,6 @@ a.suggest, a.suggest:visited, a.suggest:hover, a.suggest:active {
     column-count: 1 !important;
 }
 
-#uiLanguageSelector {
-  display: none;
-}
-
-#uiLanguageSelector .modal {
-  height: 140px;
-}
-
-#uiLanguageSelector .modal-heading {
-  height: 40%;
-}
-
-#uiLanguageSelector .modal-content #ui_language {
-  font-size: 1.6rem;
-  width: 100%;
-}
-
-#uiLanguageSelectorButton {
-  margin: 0px 12px 6px 12px;
-  float: right;
-  cursor: pointer;
-  height: 30px;
-}
-
 @media(min-width:420px) {
     .kiwix_button_cont {
         display: inline-block !important;

--- a/static/skin/taskbar.css
+++ b/static/skin/taskbar.css
@@ -21,6 +21,7 @@
 }
 
 .kiwixsearch {
+    font-size: 1.6rem;
     position: relative;
     height: 26px;
     width: 100%;
@@ -119,6 +120,7 @@ label[for=kiwixsearchbox] {
 }
 
 a.suggest, a.suggest:visited, a.suggest:hover, a.suggest:active {
+    font-size: 1.6rem;
     display: block;
     text-decoration: none;
     color: inherit;
@@ -142,7 +144,7 @@ a.suggest, a.suggest:visited, a.suggest:hover, a.suggest:active {
 }
 
 #uiLanguageSelector .modal-content #ui_language {
-  font-size: 1rem;
+  font-size: 1.6rem;
   width: 100%;
 }
 

--- a/static/skin/taskbar.css
+++ b/static/skin/taskbar.css
@@ -256,13 +256,3 @@ a.suggest, a.suggest:visited, a.suggest:hover, a.suggest:active {
         width: 80%;
     }
 }
-
-@font-face {
-  font-family: "poppins";
-  src: url("../skin/fonts/Poppins.ttf?KIWIXCACHEID") format("truetype");
-}
-
-@font-face {
-    font-family: "roboto";
-    src: url("../skin/fonts/Roboto.ttf?KIWIXCACHEID") format("truetype");
-}

--- a/static/skin/taskbar.css
+++ b/static/skin/taskbar.css
@@ -3,7 +3,7 @@
     transition: 0.3s;
     width: 100%;
     box-sizing: border-box;
-    background: #e3e3e3;
+    background: #f4f6f8;
     border-bottom: 1px solid #aaa;
 }
 
@@ -88,7 +88,7 @@ label[for="kiwix_button_show_toggle"],
     line-height: 20px !important;
     margin-right: 5px !important;
     padding: 2px 6px !important;
-    border: 1px solid #999 !important;
+    border: 1px solid #b5b2b2 !important;
     border-radius: 3px !important;
     background-color: #ededed !important;
     font-weight: normal !important;
@@ -102,7 +102,7 @@ label[for="kiwix_button_show_toggle"],
     width: 100%;
     height: 26px !important;
     line-height: 20px !important;
-    border: 1px solid #999 !important;
+    border: 1px solid #b5b2b2 !important;
     border-radius: 3px !important;
     background-color: #fff !important;
     padding: 2px 2px 2px 27px !important;

--- a/static/skin/taskbar.css
+++ b/static/skin/taskbar.css
@@ -129,58 +129,6 @@ a.suggest, a.suggest:visited, a.suggest:hover, a.suggest:active {
     column-count: 1 !important;
 }
 
-.modal-wrapper {
-    position: fixed;
-    z-index: 100;
-    top: 0;
-    left: 0;
-    width: 100vw;
-    height: 100vh;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    align-content: center;
-    background-color: rgba(0, 0, 0, 30%);
-}
-
-.modal {
-    color: #444343;
-    height: 280px;
-    width: 250px;
-    margin: 15px;
-    background-color: #f7f7f7;
-    border: 1px solid #ececec;
-    border-radius: 3px;
-}
-
-.modal-heading {
-    background-color: #f0f0f0;
-    height: 20%;
-    width: 100%;
-    border-bottom: 1px solid #ececec;
-    display: grid;
-    grid-template-columns: 3fr 1fr;
-}
-
-.modal-title {
-    display: flex;
-    font-size: 15px;
-    align-items: center;
-    padding-left: 20px;
-    font-family: poppins;
-}
-
-.modal-close-button {
-    cursor: pointer;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-}
-
-.modal-content {
-    padding: 20px;
-}
-
 #uiLanguageSelector {
   display: none;
 }

--- a/static/templates/index.html
+++ b/static/templates/index.html
@@ -26,17 +26,6 @@
     <meta name="msapplication-TileColor" content="#da532c">
     <meta name="msapplication-config" content="{{root}}/skin/favicon/browserconfig.xml?KIWIXCACHEID">
     <meta name="theme-color" content="#ffffff">
-    <style>
-      @font-face {
-        font-family: "poppins";
-        src: url("{{root}}/skin/fonts/Poppins.ttf?KIWIXCACHEID") format("truetype");
-      }
-
-      @font-face {
-          font-family: "roboto";
-          src: url("{{root}}/skin/fonts/Roboto.ttf?KIWIXCACHEID") format("truetype");
-      }
-    </style>
     <script type="text/javascript" src="./viewer_settings.js"></script>
     <script type="module" src="{{root}}/skin/i18n.js?KIWIXCACHEID" defer></script>
     <script type="text/javascript" src="{{root}}/skin/languages.js?KIWIXCACHEID" defer></script>

--- a/static/templates/index.html
+++ b/static/templates/index.html
@@ -7,6 +7,11 @@
     <title>Welcome to Kiwix Server</title>
     <link
       type="text/css"
+      href="{{root}}/skin/kiwix.css?KIWIXCACHEID"
+      rel="Stylesheet"
+    />
+    <link
+      type="text/css"
       href="{{root}}/skin/index.css?KIWIXCACHEID"
       rel="Stylesheet"
     />

--- a/static/templates/no_js_library_page.html
+++ b/static/templates/no_js_library_page.html
@@ -7,6 +7,11 @@
     <title>{{translations.welcome-to-kiwix-server}}</title>
     <link
       type="text/css"
+      href="{{root}}/skin/kiwix.css?KIWIXCACHEID"
+      rel="Stylesheet"
+    />
+    <link
+      type="text/css"
       href="{{root}}/skin/index.css?KIWIXCACHEID"
       rel="Stylesheet"
     />

--- a/static/viewer.html
+++ b/static/viewer.html
@@ -8,6 +8,7 @@
                    object-src 'none';">
     <title>ZIM Viewer</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link type="text/css" href="./skin/kiwix.css?KIWIXCACHEID" rel="Stylesheet" />
     <link type="text/css" href="./skin/taskbar.css?KIWIXCACHEID" rel="Stylesheet" />
     <link type="text/css" href="./skin/css/autoComplete.css?KIWIXCACHEID" rel="Stylesheet" />
     <script type="text/javascript" src="./viewer_settings.js"></script>

--- a/test/library_server.cpp
+++ b/test/library_server.cpp
@@ -1033,7 +1033,7 @@ TEST_F(LibraryServerTest, no_name_mapper_catalog_v2_individual_entry_access)
   "    />\n" \
   "    <link\n" \
   "      type=\"text/css\"\n" \
-  "      href=\"/ROOT%23%3F/skin/index.css?cacheid=4196ad7d\"\n" \
+  "      href=\"/ROOT%23%3F/skin/index.css?cacheid=1e78e7cf\"\n" \
   "      rel=\"Stylesheet\"\n" \
   "    />\n" \
   "    <link rel=\"apple-touch-icon\" sizes=\"180x180\" href=\"/ROOT%23%3F/skin/favicon/apple-touch-icon.png?cacheid=f86f8df3\">\n" \

--- a/test/library_server.cpp
+++ b/test/library_server.cpp
@@ -1028,12 +1028,12 @@ TEST_F(LibraryServerTest, no_name_mapper_catalog_v2_individual_entry_access)
   "    <title>Welcome to Kiwix Server</title>\n" \
   "    <link\n" \
   "      type=\"text/css\"\n" \
-  "      href=\"/ROOT%23%3F/skin/kiwix.css?cacheid=28889647\"\n" \
+  "      href=\"/ROOT%23%3F/skin/kiwix.css?cacheid=bdae4d22\"\n" \
   "      rel=\"Stylesheet\"\n" \
   "    />\n" \
   "    <link\n" \
   "      type=\"text/css\"\n" \
-  "      href=\"/ROOT%23%3F/skin/index.css?cacheid=624104e6\"\n" \
+  "      href=\"/ROOT%23%3F/skin/index.css?cacheid=081e1606\"\n" \
   "      rel=\"Stylesheet\"\n" \
   "    />\n" \
   "    <link rel=\"apple-touch-icon\" sizes=\"180x180\" href=\"/ROOT%23%3F/skin/favicon/apple-touch-icon.png?cacheid=f86f8df3\">\n" \

--- a/test/library_server.cpp
+++ b/test/library_server.cpp
@@ -1028,12 +1028,12 @@ TEST_F(LibraryServerTest, no_name_mapper_catalog_v2_individual_entry_access)
   "    <title>Welcome to Kiwix Server</title>\n" \
   "    <link\n" \
   "      type=\"text/css\"\n" \
-  "      href=\"/ROOT%23%3F/skin/kiwix.css?cacheid=27f092fb\"\n" \
+  "      href=\"/ROOT%23%3F/skin/kiwix.css?cacheid=28889647\"\n" \
   "      rel=\"Stylesheet\"\n" \
   "    />\n" \
   "    <link\n" \
   "      type=\"text/css\"\n" \
-  "      href=\"/ROOT%23%3F/skin/index.css?cacheid=e4d76d16\"\n" \
+  "      href=\"/ROOT%23%3F/skin/index.css?cacheid=624104e6\"\n" \
   "      rel=\"Stylesheet\"\n" \
   "    />\n" \
   "    <link rel=\"apple-touch-icon\" sizes=\"180x180\" href=\"/ROOT%23%3F/skin/favicon/apple-touch-icon.png?cacheid=f86f8df3\">\n" \

--- a/test/library_server.cpp
+++ b/test/library_server.cpp
@@ -1028,12 +1028,12 @@ TEST_F(LibraryServerTest, no_name_mapper_catalog_v2_individual_entry_access)
   "    <title>Welcome to Kiwix Server</title>\n" \
   "    <link\n" \
   "      type=\"text/css\"\n" \
-  "      href=\"/ROOT%23%3F/skin/kiwix.css?cacheid=bdae4d22\"\n" \
+  "      href=\"/ROOT%23%3F/skin/kiwix.css?cacheid=9b1b089f\"\n" \
   "      rel=\"Stylesheet\"\n" \
   "    />\n" \
   "    <link\n" \
   "      type=\"text/css\"\n" \
-  "      href=\"/ROOT%23%3F/skin/index.css?cacheid=081e1606\"\n" \
+  "      href=\"/ROOT%23%3F/skin/index.css?cacheid=4196ad7d\"\n" \
   "      rel=\"Stylesheet\"\n" \
   "    />\n" \
   "    <link rel=\"apple-touch-icon\" sizes=\"180x180\" href=\"/ROOT%23%3F/skin/favicon/apple-touch-icon.png?cacheid=f86f8df3\">\n" \

--- a/test/library_server.cpp
+++ b/test/library_server.cpp
@@ -1028,7 +1028,12 @@ TEST_F(LibraryServerTest, no_name_mapper_catalog_v2_individual_entry_access)
   "    <title>Welcome to Kiwix Server</title>\n" \
   "    <link\n" \
   "      type=\"text/css\"\n" \
-  "      href=\"/ROOT%23%3F/skin/index.css?cacheid=2446b723\"\n" \
+  "      href=\"/ROOT%23%3F/skin/kiwix.css?cacheid=27f092fb\"\n" \
+  "      rel=\"Stylesheet\"\n" \
+  "    />\n" \
+  "    <link\n" \
+  "      type=\"text/css\"\n" \
+  "      href=\"/ROOT%23%3F/skin/index.css?cacheid=e4d76d16\"\n" \
   "      rel=\"Stylesheet\"\n" \
   "    />\n" \
   "    <link rel=\"apple-touch-icon\" sizes=\"180x180\" href=\"/ROOT%23%3F/skin/favicon/apple-touch-icon.png?cacheid=f86f8df3\">\n" \
@@ -1145,7 +1150,7 @@ TEST_F(LibraryServerTest, no_name_mapper_catalog_v2_individual_entry_access)
   "    </div>\n" \
   "    <div id=\"kiwixfooter\" class=\"kiwixfooter\">Powered by&nbsp;<a href=\"https://kiwix.org\">Kiwix</a></div>\n" \
   "    </body>\n" \
-  "</html>"
+  "</html>\n"
 
 #define FILTERS_HTML(SELECTED_ENG) \
   "      <div class=\"kiwixNav__filters\">\n" \

--- a/test/library_server.cpp
+++ b/test/library_server.cpp
@@ -1028,7 +1028,7 @@ TEST_F(LibraryServerTest, no_name_mapper_catalog_v2_individual_entry_access)
   "    <title>Welcome to Kiwix Server</title>\n" \
   "    <link\n" \
   "      type=\"text/css\"\n" \
-  "      href=\"/ROOT%23%3F/skin/index.css?cacheid=e4d76d16\"\n" \
+  "      href=\"/ROOT%23%3F/skin/index.css?cacheid=2446b723\"\n" \
   "      rel=\"Stylesheet\"\n" \
   "    />\n" \
   "    <link rel=\"apple-touch-icon\" sizes=\"180x180\" href=\"/ROOT%23%3F/skin/favicon/apple-touch-icon.png?cacheid=f86f8df3\">\n" \

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -61,7 +61,7 @@ const ResourceCollection resources200Compressible{
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/i18n.js" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/i18n.js?cacheid=6a8c6fb2" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/index.css" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/index.css?cacheid=624104e6" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/index.css?cacheid=081e1606" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/index.js" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/index.js?cacheid=ce19da2a" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/iso6391To3.js" },
@@ -71,7 +71,7 @@ const ResourceCollection resources200Compressible{
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/mustache.min.js" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/mustache.min.js?cacheid=bd23c4fb" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/taskbar.css" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/taskbar.css?cacheid=786a623c" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/taskbar.css?cacheid=04cb5531" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/viewer.js" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=201653b8" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Poppins.ttf" },
@@ -141,7 +141,7 @@ const ResourceCollection resources200Uncompressible{
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/hash.png" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/hash.png?cacheid=f836e872" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/kiwix.css" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/kiwix.css?cacheid=28889647" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/kiwix.css?cacheid=bdae4d22" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/magnet.png" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/magnet.png?cacheid=73b6bddf" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/search-icon.svg" },
@@ -276,8 +276,8 @@ TEST_F(ServerTest, CacheIdsOfStaticResources)
   const std::vector<UrlAndExpectedResult> testData{
     {
       /* url */ "/ROOT%23%3F/",
-R"EXPECTEDRESULT(      href="/ROOT%23%3F/skin/kiwix.css?cacheid=28889647"
-      href="/ROOT%23%3F/skin/index.css?cacheid=624104e6"
+R"EXPECTEDRESULT(      href="/ROOT%23%3F/skin/kiwix.css?cacheid=bdae4d22"
+      href="/ROOT%23%3F/skin/index.css?cacheid=081e1606"
     <link rel="apple-touch-icon" sizes="180x180" href="/ROOT%23%3F/skin/favicon/apple-touch-icon.png?cacheid=f86f8df3">
     <link rel="icon" type="image/png" sizes="32x32" href="/ROOT%23%3F/skin/favicon/favicon-32x32.png?cacheid=79ded625">
     <link rel="icon" type="image/png" sizes="16x16" href="/ROOT%23%3F/skin/favicon/favicon-16x16.png?cacheid=a986fedc">
@@ -315,8 +315,8 @@ R"EXPECTEDRESULT(                                <img src="${root}/skin/download
     },
     {
       /* url */ "/ROOT%23%3F/viewer",
-R"EXPECTEDRESULT(    <link type="text/css" href="./skin/kiwix.css?cacheid=28889647" rel="Stylesheet" />
-    <link type="text/css" href="./skin/taskbar.css?cacheid=786a623c" rel="Stylesheet" />
+R"EXPECTEDRESULT(    <link type="text/css" href="./skin/kiwix.css?cacheid=bdae4d22" rel="Stylesheet" />
+    <link type="text/css" href="./skin/taskbar.css?cacheid=04cb5531" rel="Stylesheet" />
     <link type="text/css" href="./skin/css/autoComplete.css?cacheid=08951e06" rel="Stylesheet" />
     <script type="module" src="./skin/i18n.js?cacheid=6a8c6fb2" defer></script>
     <script type="text/javascript" src="./skin/languages.js?cacheid=96f2cf73" defer></script>

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -61,7 +61,7 @@ const ResourceCollection resources200Compressible{
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/i18n.js" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/i18n.js?cacheid=6a8c6fb2" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/index.css" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/index.css?cacheid=4196ad7d" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/index.css?cacheid=1e78e7cf" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/index.js" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/index.js?cacheid=ce19da2a" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/iso6391To3.js" },
@@ -277,7 +277,7 @@ TEST_F(ServerTest, CacheIdsOfStaticResources)
     {
       /* url */ "/ROOT%23%3F/",
 R"EXPECTEDRESULT(      href="/ROOT%23%3F/skin/kiwix.css?cacheid=9b1b089f"
-      href="/ROOT%23%3F/skin/index.css?cacheid=4196ad7d"
+      href="/ROOT%23%3F/skin/index.css?cacheid=1e78e7cf"
     <link rel="apple-touch-icon" sizes="180x180" href="/ROOT%23%3F/skin/favicon/apple-touch-icon.png?cacheid=f86f8df3">
     <link rel="icon" type="image/png" sizes="32x32" href="/ROOT%23%3F/skin/favicon/favicon-32x32.png?cacheid=79ded625">
     <link rel="icon" type="image/png" sizes="16x16" href="/ROOT%23%3F/skin/favicon/favicon-16x16.png?cacheid=a986fedc">

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -73,7 +73,7 @@ const ResourceCollection resources200Compressible{
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/mustache.min.js" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/mustache.min.js?cacheid=bd23c4fb" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/taskbar.css" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/taskbar.css?cacheid=8c05f7fc" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/taskbar.css?cacheid=a1200d6b" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/viewer.js" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=201653b8" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Poppins.ttf" },
@@ -316,7 +316,7 @@ R"EXPECTEDRESULT(                                <img src="${root}/skin/download
     {
       /* url */ "/ROOT%23%3F/viewer",
 R"EXPECTEDRESULT(    <link type="text/css" href="./skin/kiwix.css?cacheid=9b1b089f" rel="Stylesheet" />
-    <link type="text/css" href="./skin/taskbar.css?cacheid=8c05f7fc" rel="Stylesheet" />
+    <link type="text/css" href="./skin/taskbar.css?cacheid=a1200d6b" rel="Stylesheet" />
     <link type="text/css" href="./skin/css/autoComplete.css?cacheid=08951e06" rel="Stylesheet" />
     <script type="module" src="./skin/i18n.js?cacheid=6a8c6fb2" defer></script>
     <script type="text/javascript" src="./skin/languages.js?cacheid=96f2cf73" defer></script>

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -61,7 +61,7 @@ const ResourceCollection resources200Compressible{
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/i18n.js" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/i18n.js?cacheid=6a8c6fb2" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/index.css" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/index.css?cacheid=e4d76d16" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/index.css?cacheid=624104e6" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/index.js" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/index.js?cacheid=ce19da2a" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/iso6391To3.js" },
@@ -71,7 +71,7 @@ const ResourceCollection resources200Compressible{
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/mustache.min.js" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/mustache.min.js?cacheid=bd23c4fb" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/taskbar.css" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/taskbar.css?cacheid=74156c3a" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/taskbar.css?cacheid=786a623c" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/viewer.js" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=201653b8" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Poppins.ttf" },
@@ -141,7 +141,7 @@ const ResourceCollection resources200Uncompressible{
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/hash.png" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/hash.png?cacheid=f836e872" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/kiwix.css" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/kiwix.css?cacheid=27f092fb" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/kiwix.css?cacheid=28889647" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/magnet.png" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/magnet.png?cacheid=73b6bddf" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/search-icon.svg" },
@@ -276,8 +276,8 @@ TEST_F(ServerTest, CacheIdsOfStaticResources)
   const std::vector<UrlAndExpectedResult> testData{
     {
       /* url */ "/ROOT%23%3F/",
-R"EXPECTEDRESULT(      href="/ROOT%23%3F/skin/kiwix.css?cacheid=27f092fb"
-      href="/ROOT%23%3F/skin/index.css?cacheid=e4d76d16"
+R"EXPECTEDRESULT(      href="/ROOT%23%3F/skin/kiwix.css?cacheid=28889647"
+      href="/ROOT%23%3F/skin/index.css?cacheid=624104e6"
     <link rel="apple-touch-icon" sizes="180x180" href="/ROOT%23%3F/skin/favicon/apple-touch-icon.png?cacheid=f86f8df3">
     <link rel="icon" type="image/png" sizes="32x32" href="/ROOT%23%3F/skin/favicon/favicon-32x32.png?cacheid=79ded625">
     <link rel="icon" type="image/png" sizes="16x16" href="/ROOT%23%3F/skin/favicon/favicon-16x16.png?cacheid=a986fedc">
@@ -315,8 +315,8 @@ R"EXPECTEDRESULT(                                <img src="${root}/skin/download
     },
     {
       /* url */ "/ROOT%23%3F/viewer",
-R"EXPECTEDRESULT(    <link type="text/css" href="./skin/kiwix.css?cacheid=27f092fb" rel="Stylesheet" />
-    <link type="text/css" href="./skin/taskbar.css?cacheid=74156c3a" rel="Stylesheet" />
+R"EXPECTEDRESULT(    <link type="text/css" href="./skin/kiwix.css?cacheid=28889647" rel="Stylesheet" />
+    <link type="text/css" href="./skin/taskbar.css?cacheid=786a623c" rel="Stylesheet" />
     <link type="text/css" href="./skin/css/autoComplete.css?cacheid=08951e06" rel="Stylesheet" />
     <script type="module" src="./skin/i18n.js?cacheid=6a8c6fb2" defer></script>
     <script type="text/javascript" src="./skin/languages.js?cacheid=96f2cf73" defer></script>

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -61,7 +61,7 @@ const ResourceCollection resources200Compressible{
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/i18n.js" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/i18n.js?cacheid=6a8c6fb2" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/index.css" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/index.css?cacheid=e4d76d16" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/index.css?cacheid=2446b723" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/index.js" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/index.js?cacheid=ce19da2a" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/iso6391To3.js" },
@@ -274,7 +274,7 @@ TEST_F(ServerTest, CacheIdsOfStaticResources)
   const std::vector<UrlAndExpectedResult> testData{
     {
       /* url */ "/ROOT%23%3F/",
-R"EXPECTEDRESULT(      href="/ROOT%23%3F/skin/index.css?cacheid=e4d76d16"
+R"EXPECTEDRESULT(      href="/ROOT%23%3F/skin/index.css?cacheid=2446b723"
     <link rel="apple-touch-icon" sizes="180x180" href="/ROOT%23%3F/skin/favicon/apple-touch-icon.png?cacheid=f86f8df3">
     <link rel="icon" type="image/png" sizes="32x32" href="/ROOT%23%3F/skin/favicon/favicon-32x32.png?cacheid=79ded625">
     <link rel="icon" type="image/png" sizes="16x16" href="/ROOT%23%3F/skin/favicon/favicon-16x16.png?cacheid=a986fedc">
@@ -282,8 +282,6 @@ R"EXPECTEDRESULT(      href="/ROOT%23%3F/skin/index.css?cacheid=e4d76d16"
     <link rel="mask-icon" href="/ROOT%23%3F/skin/favicon/safari-pinned-tab.svg?cacheid=8d487e95" color="#5bbad5">
     <link rel="shortcut icon" href="/ROOT%23%3F/skin/favicon/favicon.ico?cacheid=92663314">
     <meta name="msapplication-config" content="/ROOT%23%3F/skin/favicon/browserconfig.xml?cacheid=f29a7c4a">
-        src: url("/ROOT%23%3F/skin/fonts/Poppins.ttf?cacheid=af705837") format("truetype");
-          src: url("/ROOT%23%3F/skin/fonts/Roboto.ttf?cacheid=84d10248") format("truetype");
     <script type="module" src="/ROOT%23%3F/skin/i18n.js?cacheid=6a8c6fb2" defer></script>
     <script type="text/javascript" src="/ROOT%23%3F/skin/languages.js?cacheid=96f2cf73" defer></script>
     <script src="/ROOT%23%3F/skin/isotope.pkgd.min.js?cacheid=2e48d392" defer></script>
@@ -296,6 +294,8 @@ R"EXPECTEDRESULT(      href="/ROOT%23%3F/skin/index.css?cacheid=e4d76d16"
     {
       /* url */ "/ROOT%23%3F/skin/index.css",
 R"EXPECTEDRESULT(    background-image: url('../skin/search-icon.svg?cacheid=b10ae7ed');
+  src: url("../skin/fonts/Poppins.ttf?cacheid=af705837") format("truetype");
+  src: url("../skin/fonts/Roboto.ttf?cacheid=84d10248") format("truetype");
 )EXPECTEDRESULT"
     },
     {

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -61,7 +61,7 @@ const ResourceCollection resources200Compressible{
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/i18n.js" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/i18n.js?cacheid=6a8c6fb2" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/index.css" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/index.css?cacheid=2446b723" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/index.css?cacheid=e4d76d16" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/index.js" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/index.js?cacheid=ce19da2a" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/iso6391To3.js" },
@@ -71,7 +71,7 @@ const ResourceCollection resources200Compressible{
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/mustache.min.js" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/mustache.min.js?cacheid=bd23c4fb" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/taskbar.css" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/taskbar.css?cacheid=5ab04b5a" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/taskbar.css?cacheid=74156c3a" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/viewer.js" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=201653b8" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Poppins.ttf" },
@@ -140,6 +140,8 @@ const ResourceCollection resources200Uncompressible{
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/favicon/site.webmanifest?cacheid=bc396efb" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/hash.png" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/hash.png?cacheid=f836e872" },
+  { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/kiwix.css" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/kiwix.css?cacheid=27f092fb" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/magnet.png" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/magnet.png?cacheid=73b6bddf" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/search-icon.svg" },
@@ -274,7 +276,8 @@ TEST_F(ServerTest, CacheIdsOfStaticResources)
   const std::vector<UrlAndExpectedResult> testData{
     {
       /* url */ "/ROOT%23%3F/",
-R"EXPECTEDRESULT(      href="/ROOT%23%3F/skin/index.css?cacheid=2446b723"
+R"EXPECTEDRESULT(      href="/ROOT%23%3F/skin/kiwix.css?cacheid=27f092fb"
+      href="/ROOT%23%3F/skin/index.css?cacheid=e4d76d16"
     <link rel="apple-touch-icon" sizes="180x180" href="/ROOT%23%3F/skin/favicon/apple-touch-icon.png?cacheid=f86f8df3">
     <link rel="icon" type="image/png" sizes="32x32" href="/ROOT%23%3F/skin/favicon/favicon-32x32.png?cacheid=79ded625">
     <link rel="icon" type="image/png" sizes="16x16" href="/ROOT%23%3F/skin/favicon/favicon-16x16.png?cacheid=a986fedc">
@@ -292,10 +295,14 @@ R"EXPECTEDRESULT(      href="/ROOT%23%3F/skin/index.css?cacheid=2446b723"
 )EXPECTEDRESULT"
     },
     {
+      /* url */ "/ROOT%23%3F/skin/kiwix.css",
+R"EXPECTEDRESULT(  src: url("../skin/fonts/Poppins.ttf?cacheid=af705837") format("truetype");
+  src: url("../skin/fonts/Roboto.ttf?cacheid=84d10248") format("truetype");
+)EXPECTEDRESULT"
+    },
+    {
       /* url */ "/ROOT%23%3F/skin/index.css",
 R"EXPECTEDRESULT(    background-image: url('../skin/search-icon.svg?cacheid=b10ae7ed');
-  src: url("../skin/fonts/Poppins.ttf?cacheid=af705837") format("truetype");
-  src: url("../skin/fonts/Roboto.ttf?cacheid=84d10248") format("truetype");
 )EXPECTEDRESULT"
     },
     {
@@ -308,7 +315,8 @@ R"EXPECTEDRESULT(                                <img src="${root}/skin/download
     },
     {
       /* url */ "/ROOT%23%3F/viewer",
-R"EXPECTEDRESULT(    <link type="text/css" href="./skin/taskbar.css?cacheid=5ab04b5a" rel="Stylesheet" />
+R"EXPECTEDRESULT(    <link type="text/css" href="./skin/kiwix.css?cacheid=27f092fb" rel="Stylesheet" />
+    <link type="text/css" href="./skin/taskbar.css?cacheid=74156c3a" rel="Stylesheet" />
     <link type="text/css" href="./skin/css/autoComplete.css?cacheid=08951e06" rel="Stylesheet" />
     <script type="module" src="./skin/i18n.js?cacheid=6a8c6fb2" defer></script>
     <script type="text/javascript" src="./skin/languages.js?cacheid=96f2cf73" defer></script>

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -61,17 +61,19 @@ const ResourceCollection resources200Compressible{
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/i18n.js" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/i18n.js?cacheid=6a8c6fb2" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/index.css" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/index.css?cacheid=081e1606" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/index.css?cacheid=4196ad7d" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/index.js" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/index.js?cacheid=ce19da2a" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/iso6391To3.js" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/iso6391To3.js?cacheid=ecde2bb3" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/isotope.pkgd.min.js" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/isotope.pkgd.min.js?cacheid=2e48d392" },
+  { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/kiwix.css" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/kiwix.css?cacheid=9b1b089f" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/mustache.min.js" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/mustache.min.js?cacheid=bd23c4fb" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/taskbar.css" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/taskbar.css?cacheid=04cb5531" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/taskbar.css?cacheid=8c05f7fc" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/viewer.js" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=201653b8" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Poppins.ttf" },
@@ -140,8 +142,6 @@ const ResourceCollection resources200Uncompressible{
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/favicon/site.webmanifest?cacheid=bc396efb" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/hash.png" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/hash.png?cacheid=f836e872" },
-  { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/kiwix.css" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/kiwix.css?cacheid=bdae4d22" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/magnet.png" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/magnet.png?cacheid=73b6bddf" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/search-icon.svg" },
@@ -276,8 +276,8 @@ TEST_F(ServerTest, CacheIdsOfStaticResources)
   const std::vector<UrlAndExpectedResult> testData{
     {
       /* url */ "/ROOT%23%3F/",
-R"EXPECTEDRESULT(      href="/ROOT%23%3F/skin/kiwix.css?cacheid=bdae4d22"
-      href="/ROOT%23%3F/skin/index.css?cacheid=081e1606"
+R"EXPECTEDRESULT(      href="/ROOT%23%3F/skin/kiwix.css?cacheid=9b1b089f"
+      href="/ROOT%23%3F/skin/index.css?cacheid=4196ad7d"
     <link rel="apple-touch-icon" sizes="180x180" href="/ROOT%23%3F/skin/favicon/apple-touch-icon.png?cacheid=f86f8df3">
     <link rel="icon" type="image/png" sizes="32x32" href="/ROOT%23%3F/skin/favicon/favicon-32x32.png?cacheid=79ded625">
     <link rel="icon" type="image/png" sizes="16x16" href="/ROOT%23%3F/skin/favicon/favicon-16x16.png?cacheid=a986fedc">
@@ -315,8 +315,8 @@ R"EXPECTEDRESULT(                                <img src="${root}/skin/download
     },
     {
       /* url */ "/ROOT%23%3F/viewer",
-R"EXPECTEDRESULT(    <link type="text/css" href="./skin/kiwix.css?cacheid=bdae4d22" rel="Stylesheet" />
-    <link type="text/css" href="./skin/taskbar.css?cacheid=04cb5531" rel="Stylesheet" />
+R"EXPECTEDRESULT(    <link type="text/css" href="./skin/kiwix.css?cacheid=9b1b089f" rel="Stylesheet" />
+    <link type="text/css" href="./skin/taskbar.css?cacheid=8c05f7fc" rel="Stylesheet" />
     <link type="text/css" href="./skin/css/autoComplete.css?cacheid=08951e06" rel="Stylesheet" />
     <script type="module" src="./skin/i18n.js?cacheid=6a8c6fb2" defer></script>
     <script type="text/javascript" src="./skin/languages.js?cacheid=96f2cf73" defer></script>


### PR DESCRIPTION
Addresses #917

Unfortunately, I failed to achieve consistent look-and-feel across the library page and the viewer toolbar so that they both look nice.

- large border radius of the library page doesn't look good when applied to the small buttons of the viewer toolbar, whereas small radius used for the viewer buttons looks inferior to what we have now on the library page
- color schemes of the buttons and filters could not be unified too; viewer current button icons don't look nice on dark background, whereas the current design of the toolbar of the library page seems to rely on contrast.

This PR simply reduces the gap in the look-and-feel of the two toolbars. If we want to eliminate it completely, I think that we must come up with a new design first.