### PR TITLE
Get correct href value on `onClick` for "warc2zim" files.

### DIFF
--- a/static/skin/viewer.js
+++ b/static/skin/viewer.js
@@ -290,12 +290,23 @@ function isExternalUrl(url) {
       || url.startsWith("https:");
 }
 
+function getRealHref(target) {
+  // In case of wombat in the middle, wombat will rewrite the href value to the original url (external link)
+  // This is not what we want. Let's ask wombat to not rewrite href
+  const old_no_rewrite = target._no_rewrite;
+  target._no_rewrite = true;
+  const target_href = target.href;
+  target._no_rewrite = old_no_rewrite;
+  return target_href;
+}
+
 function onClickEvent(e) {
   const iframeDocument = contentIframe.contentDocument;
   const target = matchingAncestorElement(e.target, iframeDocument, "a");
   if (target !== null && "href" in target) {
-    if ( isExternalUrl(target.href) ) {
-      const possiblyBlockedLink = blockLink(target.href);
+    const target_href = getRealHref(target);
+    if (isExternalUrl(target_href)) {
+      const possiblyBlockedLink = blockLink(target_href);
       if ( e.ctrlKey || e.shiftKey ) {
         // The link will be loaded in a new tab/window - update the link
         // and let the browser handle the rest.

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -75,7 +75,7 @@ const ResourceCollection resources200Compressible{
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/taskbar.css" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/taskbar.css?cacheid=e014a885" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/viewer.js" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=201653b8" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=948df083" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Poppins.ttf" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/fonts/Poppins.ttf?cacheid=af705837" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Roboto.ttf" },
@@ -320,7 +320,7 @@ R"EXPECTEDRESULT(    <link type="text/css" href="./skin/kiwix.css?cacheid=2158fa
     <link type="text/css" href="./skin/autoComplete/css/autoComplete.css?cacheid=ef30cd42" rel="Stylesheet" />
     <script type="module" src="./skin/i18n.js?cacheid=6a8c6fb2" defer></script>
     <script type="text/javascript" src="./skin/languages.js?cacheid=96f2cf73" defer></script>
-    <script type="text/javascript" src="./skin/viewer.js?cacheid=201653b8" defer></script>
+    <script type="text/javascript" src="./skin/viewer.js?cacheid=948df083" defer></script>
     <script type="text/javascript" src="./skin/autoComplete/autoComplete.min.js?cacheid=1191aaaf"></script>
       const blankPageUrl = root + "/skin/blank.html?cacheid=6b1fa032";
           <label for="kiwix_button_show_toggle"><img src="./skin/caret.png?cacheid=22b942b4" alt=""></label>


### PR DESCRIPTION
Next to come warc2zim archive will come with "wombat" embedded. The purpose of wombat is to be an interface with js code to mask that we are in a scrapped/zim context to the js.

So it rewrite the `.href` attributes to the original url (ie, an absolute url to the original website), even if the local relative url is valid.

Let's ask to wombat to not rewrite href in our special case.