### PR TITLE
More predictable Downloader::startDownload()

### DIFF
--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -169,12 +169,6 @@ std::vector<std::string> Downloader::getDownloadIds() const {
 std::shared_ptr<Download> Downloader::startDownload(const std::string& uri, const std::vector<std::pair<std::string, std::string>>& options)
 {
   std::unique_lock<std::mutex> lock(m_lock);
-  for (auto& p: m_knownDownloads) {
-    auto& d = p.second;
-    auto& uris = d->getUris();
-    if (std::find(uris.begin(), uris.end(), uri) != uris.end())
-      return d;
-  }
   std::vector<std::string> uris = {uri};
   auto gid = mp_aria->addUri(uris, options);
   m_knownDownloads[gid] = std::make_shared<Download>(mp_aria, gid);


### PR DESCRIPTION
Fixes kiwix/kiwix-desktop#1022 (as well as the other case described in #1050 without fixing the latter)

Before this change `Downloader::startDownload()` might avoid starting a new download when a download with the specified URI was already present in its cache. This might be confusing for the following reasons:
    
1. uri is not the only parameter of `Downloader::startDownload()` - a target download directory may also be specified through the second `options` parameter. Thus calling `Downloader::startDownload()` twice with the same URI but different download directories would not save files into the second directory.
    
2. Files of a completed download may be removed, whereupon downloading the same files again won't be a no-op. However in such a situation `Downloader` refuses to actually repeat a previous download.

This change is sufficient to fix the bugs described in #1050 without any changes in `kiwix-desktop`. However I am not sure that it is the right way to do that - maybe adding a `removeDownload()` function to `kiwix::Downloader` (and thus fixing #1050) is justified in any case.