### PR TITLE
[CI] Fix macos python installation.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,8 @@ jobs:
         run: |
           brew update
           brew unlink python3
-          # upgrade from python@3.11.2_1 to python@3.11.3 fails to overwrite those
-          rm -f /usr/local/bin/2to3 /usr/local/bin/2to3-3.11 /usr/local/bin/idle3 /usr/local/bin/idle3.11 /usr/local/bin/pydoc3 /usr/local/bin/pydoc3.11 /usr/local/bin/python3 /usr/local/bin/python3-config /usr/local/bin/python3.11 /usr/local/bin/python3.11-config
+          # upgrade from python@3.12 to python@3.12.2 fails to overwrite those
+          rm -f /usr/local/bin/2to3 /usr/local/bin/2to3-3.12 /usr/local/bin/idle3 /usr/local/bin/idle3.12 /usr/local/bin/pydoc3 /usr/local/bin/pydoc3.12 /usr/local/bin/python3 /usr/local/bin/python3-config /usr/local/bin/python3.12 /usr/local/bin/python3.12-config
           brew install pkg-config ninja meson
         env:
           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1


### PR DESCRIPTION
Brew update its receipe about python and now use python 3.12 instead of python 3.11.