### PR TITLE
Smarter Downloader::startDownload()

### DIFF
--- a/include/downloader.h
+++ b/include/downloader.h
@@ -187,8 +187,6 @@ class Downloader
    * have different values for the download directory or output file name
    * options, after the download is reported to be complete the downloaded file
    * will be present only at the location specified for the first request.
-   * Also, due to the above peculiarity there is no straightforward way to
-   * repeat a completed or cancelled download whose files have been deleted.
    *
    * User should call `update` on the returned `Download` to have an accurate status.
    *

--- a/include/downloader.h
+++ b/include/downloader.h
@@ -168,7 +168,10 @@ class Download {
  */
 class Downloader
 {
- public:
+ public: // types
+  typedef std::vector<std::pair<std::string, std::string>> Options;
+
+ public: // functions
   Downloader();
   virtual ~Downloader();
 
@@ -193,7 +196,7 @@ class Downloader
    * @param options: A series of pair <option_name, option_value> to pass to aria.
    * @return: The newly created Download.
    */
-  std::shared_ptr<Download> startDownload(const std::string& uri, const std::vector<std::pair<std::string, std::string>>& options = {});
+  std::shared_ptr<Download> startDownload(const std::string& uri, const Options& options = {});
 
   /**
    * Get a download corrsponding to a download id (did)
@@ -215,7 +218,7 @@ class Downloader
    */
   std::vector<std::string> getDownloadIds() const;
 
- private:
+ private: // data
   mutable std::mutex m_lock;
   std::map<std::string, std::shared_ptr<Download>> m_knownDownloads;
   std::shared_ptr<Aria2> mp_aria;

--- a/include/downloader.h
+++ b/include/downloader.h
@@ -177,7 +177,16 @@ class Downloader
   /**
    * Start a new download.
    *
-   * This method is thread safe and return a pointer to a newly created `Download`.
+   * This method is thread safe and returns a pointer to a newly created
+   * `Download` or an existing one with a matching URI. In the latter case
+   * the options parameter is ignored, which can lead to surprising results.
+   * For example, if the old and new download requests (sharing the same URI)
+   * have different values for the download directory or output file name
+   * options, after the download is reported to be complete the downloaded file
+   * will be present only at the location specified for the first request.
+   * Also, due to the above peculiarity there is no straightforward way to
+   * repeat a completed or cancelled download whose files have been deleted.
+   *
    * User should call `update` on the returned `Download` to have an accurate status.
    *
    * @param uri: The uri of the thing to download.

--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "downloader.h"
+#include "tools.h"
 #include "tools/pathTools.h"
 #include "tools/stringTools.h"
 
@@ -176,7 +177,25 @@ bool downloadCanBeReused(const Download& d,
   const auto& uris = d.getUris();
   const bool sameURI = std::find(uris.begin(), uris.end(), uri) != uris.end();
 
-  return sameURI;
+  if ( !sameURI )
+    return false;
+
+  switch ( d.getStatus() ) {
+  case Download::K_ERROR:
+  case Download::K_UNKNOWN:
+  case Download::K_REMOVED:
+    return false;
+
+  case Download::K_ACTIVE:
+  case Download::K_WAITING:
+  case Download::K_PAUSED:
+    return true; // XXX: what if options are different?
+
+  case Download::K_COMPLETE:
+    return fileExists(d.getPath()); // XXX: what if options are different?
+  }
+
+  return false;
 }
 
 } // unnamed namespace

--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -166,13 +166,27 @@ std::vector<std::string> Downloader::getDownloadIds() const {
   return ret;
 }
 
+namespace
+{
+
+bool downloadCanBeReused(const Download& d,
+                         const std::string& uri,
+                         const Downloader::Options& /*options*/)
+{
+  const auto& uris = d.getUris();
+  const bool sameURI = std::find(uris.begin(), uris.end(), uri) != uris.end();
+
+  return sameURI;
+}
+
+} // unnamed namespace
+
 std::shared_ptr<Download> Downloader::startDownload(const std::string& uri, const Options& options)
 {
   std::unique_lock<std::mutex> lock(m_lock);
   for (auto& p: m_knownDownloads) {
     auto& d = p.second;
-    auto& uris = d->getUris();
-    if (std::find(uris.begin(), uris.end(), uri) != uris.end())
+    if ( downloadCanBeReused(*d, uri, options) )
       return d;
   }
   std::vector<std::string> uris = {uri};

--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -166,7 +166,7 @@ std::vector<std::string> Downloader::getDownloadIds() const {
   return ret;
 }
 
-std::shared_ptr<Download> Downloader::startDownload(const std::string& uri, const std::vector<std::pair<std::string, std::string>>& options)
+std::shared_ptr<Download> Downloader::startDownload(const std::string& uri, const Options& options)
 {
   std::unique_lock<std::mutex> lock(m_lock);
   for (auto& p: m_knownDownloads) {


### PR DESCRIPTION
This PR is an alternative to #1052. Similar to the latter it addresses the user-observable problems behind #1050 without fixing that issue the way it was formulated.

The shared property of #1052 and this PR is that they try to solve the bugs without enhancing the libkiwix API. The difference is that this PR tries to make `Downloader::startDownload()` smarter, whereas #1052 deprived it of the slightest smartness that it tried to exercise.

Now having tried both approaches I think that we better follow the dumb path. Although we can close the seemingly small gap in `downloadCanBeReused()` (marked with an `XXX` comment) my feeling is that trying to optimize for a theoretical situation that can hardly happen in practice is not justified.