### PR TITLE
Testing of `books.name` and `books.filter.name` book selection methods in /search API

### DIFF
--- a/test/data/lib_for_server_search_test.xml
+++ b/test/data/lib_for_server_search_test.xml
@@ -1,4 +1,4 @@
 <library version="20110515">
-  <book id="5dc0b3af-5df2-0925-f0ca-d2bf75e78af6" path="example.zim" title="Wikibooks" description="testZim" language="eng" creator="test" publisher="test" tags="_ftindex:yes;_ftindex:yes;_pictures:yes;_videos:yes;_details:yes" date="2021-04-17" mediaCount="22" size="253" />
+  <book id="5dc0b3af-5df2-0925-f0ca-d2bf75e78af6" path="example.zim" title="Wikibooks" description="testZim" language="eng" creator="test" publisher="test" name="bookname_of_example_zim" tags="_ftindex:yes;_ftindex:yes;_pictures:yes;_videos:yes;_details:yes" date="2021-04-17" mediaCount="22" size="253" />
   <book id="6f1d19d0-633f-087b-fb55-7ac324ff9baf" path="zimfile.zim" title="Ray Charles" description="Wikipedia articles about Ray Charles" language="eng" creator="Wikipedia" publisher="Kiwix" name="wikipedia_en_ray_charles" flavour="_mini" tags="wikipedia;_category:wikipedia;_pictures:no;_videos:no;_details:no;_ftindex:yes" date="2020-03-31" articleCount="129" mediaCount="45" size="555" />
 </library>

--- a/test/server_search.cpp
+++ b/test/server_search.cpp
@@ -194,6 +194,23 @@ struct SearchResult
         SearchResult{LINK, TITLE, SNIPPET, BOOK_TITLE, WORDCOUNT}
 
 
+const SearchResult SEARCH_RESULT_FOR_TRAVEL_IN_RAYCHARLESZIM {
+  /*link*/   "/ROOT%23%3F/content/zimfile/A/If_You_Go_Away",
+  /*title*/  "If You Go Away",
+  /*snippet*/    R"SNIPPET(...<b>Travel</b> On" (1965) "If You Go Away" (1966) "Walk Away" (1967) Damita Jo reached #10 on the Adult Contemporary chart and #68 on the Billboard Hot 100 in 1966 for her version of the song. Terry Jacks recorded a version of the song which was released as a single in 1974 and reached #29 on the Adult Contemporary chart, #68 on the Billboard Hot 100, and went to #8 in the UK. The complex melody is partly derivative of classical music - the poignant "But if you stay..." passage comes from Franz Liszt's......)SNIPPET",
+  /*bookTitle*/  "Ray Charles",
+  /*wordCount*/  "204"
+};
+
+
+const SearchResult SEARCH_RESULT_FOR_TRAVEL_IN_EXAMPLEZIM {
+  /*link*/   "/ROOT%23%3F/content/example/Wikibooks.html",
+  /*title*/  "Wikibooks",
+  /*snippet*/    R"SNIPPET(...<b>Travel</b> guide Wikidata Knowledge database Commons Media repository Meta Coordination MediaWiki MediaWiki software Phabricator MediaWiki bug tracker Wikimedia Labs MediaWiki development The Wikimedia Foundation is a non-profit organization that depends on your voluntarism and donations to operate. If you find Wikibooks or other projects hosted by the Wikimedia Foundation useful, please volunteer or make a donation. Your donations primarily helps to purchase server equipment, launch new projects......)SNIPPET",
+  /*bookTitle*/  "Wikibooks",
+  /*wordCount*/  "538"
+};
+
 
 const std::vector<SearchResult> LARGE_SEARCH_RESULTS = {
   SEARCH_RESULT(
@@ -1342,21 +1359,8 @@ TEST(ServerSearchTest, searchResults)
       /* totalResultCount */ 2,
       /* firstResultIndex */ 1,
       /* results */          {
-        SEARCH_RESULT(
-          /*link*/   "/ROOT%23%3F/content/zimfile/A/If_You_Go_Away",
-          /*title*/  "If You Go Away",
-          /*snippet*/    R"SNIPPET(...<b>Travel</b> On" (1965) "If You Go Away" (1966) "Walk Away" (1967) Damita Jo reached #10 on the Adult Contemporary chart and #68 on the Billboard Hot 100 in 1966 for her version of the song. Terry Jacks recorded a version of the song which was released as a single in 1974 and reached #29 on the Adult Contemporary chart, #68 on the Billboard Hot 100, and went to #8 in the UK. The complex melody is partly derivative of classical music - the poignant "But if you stay..." passage comes from Franz Liszt's......)SNIPPET",
-          /*bookTitle*/  "Ray Charles",
-          /*wordCount*/  "204"
-        ),
-
-        SEARCH_RESULT(
-          /*link*/   "/ROOT%23%3F/content/example/Wikibooks.html",
-          /*title*/  "Wikibooks",
-          /*snippet*/    R"SNIPPET(...<b>Travel</b> guide Wikidata Knowledge database Commons Media repository Meta Coordination MediaWiki MediaWiki software Phabricator MediaWiki bug tracker Wikimedia Labs MediaWiki development The Wikimedia Foundation is a non-profit organization that depends on your voluntarism and donations to operate. If you find Wikibooks or other projects hosted by the Wikimedia Foundation useful, please volunteer or make a donation. Your donations primarily helps to purchase server equipment, launch new projects......)SNIPPET",
-          /*bookTitle*/  "Wikibooks",
-          /*wordCount*/  "538"
-        )
+        SEARCH_RESULT_FOR_TRAVEL_IN_RAYCHARLESZIM,
+        SEARCH_RESULT_FOR_TRAVEL_IN_EXAMPLEZIM
       },
       /* pagination */       {}
     },
@@ -1369,21 +1373,8 @@ TEST(ServerSearchTest, searchResults)
        /* totalResultCount */ 2,
        /* firstResultIndex */ 1,
        /* results */          {
-         SEARCH_RESULT(
-           /*link*/   "/ROOT%23%3F/content/zimfile/A/If_You_Go_Away",
-           /*title*/  "If You Go Away",
-           /*snippet*/    R"SNIPPET(...<b>Travel</b> On" (1965) "If You Go Away" (1966) "Walk Away" (1967) Damita Jo reached #10 on the Adult Contemporary chart and #68 on the Billboard Hot 100 in 1966 for her version of the song. Terry Jacks recorded a version of the song which was released as a single in 1974 and reached #29 on the Adult Contemporary chart, #68 on the Billboard Hot 100, and went to #8 in the UK. The complex melody is partly derivative of classical music - the poignant "But if you stay..." passage comes from Franz Liszt's......)SNIPPET",
-           /*bookTitle*/  "Ray Charles",
-           /*wordCount*/  "204"
-         ),
-
-        SEARCH_RESULT(
-          /*link*/   "/ROOT%23%3F/content/example/Wikibooks.html",
-          /*title*/  "Wikibooks",
-          /*snippet*/    R"SNIPPET(...<b>Travel</b> guide Wikidata Knowledge database Commons Media repository Meta Coordination MediaWiki MediaWiki software Phabricator MediaWiki bug tracker Wikimedia Labs MediaWiki development The Wikimedia Foundation is a non-profit organization that depends on your voluntarism and donations to operate. If you find Wikibooks or other projects hosted by the Wikimedia Foundation useful, please volunteer or make a donation. Your donations primarily helps to purchase server equipment, launch new projects......)SNIPPET",
-          /*bookTitle*/  "Wikibooks",
-          /*wordCount*/  "538"
-        )
+        SEARCH_RESULT_FOR_TRAVEL_IN_RAYCHARLESZIM,
+        SEARCH_RESULT_FOR_TRAVEL_IN_EXAMPLEZIM
       },
       /* pagination */       {}
     },

--- a/test/server_search.cpp
+++ b/test/server_search.cpp
@@ -1379,6 +1379,36 @@ TEST(ServerSearchTest, searchResults)
       /* pagination */       {}
     },
 
+    // books.name filters by the name of the ZIM file
+    {
+      /* query */          "pattern=travel"
+                           "&books.name=zimfile",
+      /* start */            0,
+      /* resultsPerPage */   10,
+      /* totalResultCount */ 1,
+      /* firstResultIndex */ 1,
+      /* results */          {
+        SEARCH_RESULT_FOR_TRAVEL_IN_RAYCHARLESZIM
+      },
+
+      /* pagination */       {}
+    },
+
+    // books.name filters by the name of the ZIM file
+    {
+      /* query */          "pattern=travel"
+                           "&books.name=example",
+      /* start */            0,
+      /* resultsPerPage */   10,
+      /* totalResultCount */ 1,
+      /* firstResultIndex */ 1,
+      /* results */          {
+        SEARCH_RESULT_FOR_TRAVEL_IN_EXAMPLEZIM
+      },
+
+      /* pagination */       {}
+    },
+
     // Adding a book (without match) doesn't change the results
     {
       /* query */          "pattern=jazz"

--- a/test/server_search.cpp
+++ b/test/server_search.cpp
@@ -1409,6 +1409,36 @@ TEST(ServerSearchTest, searchResults)
       /* pagination */       {}
     },
 
+    // books.filter.name filters by the book name
+    {
+       /* query */          "pattern=travel"
+                            "&books.filter.name=wikipedia_en_ray_charles",
+       /* start */            0,
+       /* resultsPerPage */   10,
+       /* totalResultCount */ 1,
+       /* firstResultIndex */ 1,
+       /* results */          {
+        SEARCH_RESULT_FOR_TRAVEL_IN_RAYCHARLESZIM
+      },
+
+      /* pagination */       {}
+    },
+
+    // books.filter.name filters by the book name
+    {
+      /* query */          "pattern=travel"
+                           "&books.filter.name=bookname_of_example_zim",
+      /* start */            0,
+      /* resultsPerPage */   10,
+      /* totalResultCount */ 1,
+      /* firstResultIndex */ 1,
+      /* results */          {
+        SEARCH_RESULT_FOR_TRAVEL_IN_EXAMPLEZIM
+      },
+
+      /* pagination */       {}
+    },
+
     // Adding a book (without match) doesn't change the results
     {
       /* query */          "pattern=jazz"


### PR DESCRIPTION
In the `kiwix-serve`'s `/search` API there are two confusingly similar filtering parameters `books.name` and `books.filter.name`. Their effect on book selection is very different from what one might expect from their names. This PR demonstrates the difference  via unit tests.