### PR TITLE
Add Kiwix server a few accesskeys

### DIFF
--- a/static/templates/index.html
+++ b/static/templates/index.html
@@ -93,7 +93,7 @@
         </div>
       </div>
       <form id='kiwixSearchForm' class='kiwixNav__SearchForm'>
-        <input type="text" name="q" placeholder="Search" id="searchFilter" class='kiwixSearch filter'>
+        <input type="text" name="q" accesskey="s" placeholder="Search" id="searchFilter" class='kiwixSearch filter'>
         <span class="kiwixButton tagFilterLabel"></span>
         <input type="submit" class="kiwixButton kiwixButtonHover" id="searchButton" value="Search"/>
       </form>

--- a/static/templates/no_js_library_page.html
+++ b/static/templates/no_js_library_page.html
@@ -90,7 +90,7 @@
         </div>
       </div>
       <form id='kiwixSearchForm' class='kiwixNav__SearchForm' action="{{root}}/nojs">
-        <input type="text" name="q" placeholder="{{translations.search}}" id="searchFilter" class='kiwixSearch filter' value="{{searchQuery}}">
+        <input type="text" name="q" accesskey="s" placeholder="{{translations.search}}" id="searchFilter" class='kiwixSearch filter' value="{{searchQuery}}">
         <input type="submit" class="kiwixButton kiwixButtonHover" value="{{translations.search}}"/>
       </form>
     </div>

--- a/static/viewer.html
+++ b/static/viewer.html
@@ -55,6 +55,7 @@
             <span id="kiwix_serve_taskbar_book_ui_group">
               <a id="kiwix_serve_taskbar_home_button"
                  title="Go to the main page of the current book"
+                 accesskey="h"
                  aria-label="Go to the main page of the current book"
                  onclick="gotoMainPageOfCurrentBook()"></a>
               <a id="kiwix_serve_taskbar_random_button"

--- a/static/viewer.html
+++ b/static/viewer.html
@@ -45,7 +45,13 @@
           <input type="checkbox" id="kiwix_button_show_toggle">
           <label for="kiwix_button_show_toggle"><img src="./skin/caret.png?KIWIXCACHEID" alt=""></label>
           <div class="kiwix_button_cont">
-            <a id="kiwix_serve_taskbar_library_button" title="Go to welcome page" aria-label="Go to welcome page" href="./"><button>&#x1f3e0;</button></a>
+            <a id="kiwix_serve_taskbar_library_button"
+               title="Go to welcome page"
+               accesskey="w"
+               aria-label="Go to welcome page"
+               href="./">
+              <button>&#x1f3e0;</button>
+            </a>
             <span id="kiwix_serve_taskbar_book_ui_group">
               <a id="kiwix_serve_taskbar_home_button"
                  title="Go to the main page of the current book"

--- a/static/viewer.html
+++ b/static/viewer.html
@@ -53,6 +53,7 @@
                  onclick="gotoMainPageOfCurrentBook()"></a>
               <a id="kiwix_serve_taskbar_random_button"
                  title="Go to a randomly selected page"
+                 accesskey="r"
                  aria-label="Go to a randomly selected page"
                  onclick="gotoRandomPage()">
                 <button>&#x1F3B2;</button>

--- a/test/library_server.cpp
+++ b/test/library_server.cpp
@@ -1171,7 +1171,7 @@ TEST_F(LibraryServerTest, no_name_mapper_catalog_v2_individual_entry_access)
   "        </div>\n" \
   "      </div>\n" \
   "      <form id='kiwixSearchForm' class='kiwixNav__SearchForm' action=\"/ROOT%23%3F/nojs\">\n" \
-  "        <input type=\"text\" name=\"q\" placeholder=\"Search\" id=\"searchFilter\" class='kiwixSearch filter' value=\"\">\n" \
+  "        <input type=\"text\" name=\"q\" accesskey=\"s\" placeholder=\"Search\" id=\"searchFilter\" class='kiwixSearch filter' value=\"\">\n" \
   "        <input type=\"submit\" class=\"kiwixButton kiwixButtonHover\" value=\"Search\"/>\n" \
   "      </form>\n" \
   "    </div>\n"


### PR DESCRIPTION
Fixes #1072

Except for the "Library" button, the accesskey values are the same as on Kiwix Desktop or should be implemented the same (like for input search and switch to library) in Kiwix Desktop, see https://github.com/kiwix/kiwix-desktop/issues/1083. This is the reason why I don't have respected exactly the request like requested by @patrick-emmabuntus.