### PR TITLE
Fix wrong usage of `extra_link_args` variable.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -48,11 +48,14 @@ if host_machine.system() == 'windows' and static_deps
 endif
 
 if host_machine.system() == 'windows'
-     add_project_arguments('-DNOMINMAX', language: 'cpp')
-     extra_libs += ['-liphlpapi']
-else
-     extra_link_args = []
+  add_project_arguments('-DNOMINMAX', language: 'cpp')
+  extra_libs += ['-liphlpapi']
 endif
+
+if build_machine.system() == 'windows'
+  extra_libs += ['-lshlwapi', '-lwinmm']
+endif
+
 
 all_deps = [thread_dep, libicu_dep, libzim_dep, pugixml_dep, libcurl_dep, microhttpd_dep, zlib_dep, xapian_dep]
 

--- a/test/meson.build
+++ b/test/meson.build
@@ -77,7 +77,7 @@ if gtest_dep.found() and not meson.is_cross_build()
                               implicit_include_directories: false,
                               include_directories : inc,
                               link_with : libkiwix,
-                              link_args: extra_link_args,
+                              link_args: extra_libs,
                               dependencies : all_deps + [gtest_dep],
                              build_rpath : '$ORIGIN')
         test(test_name, test_exe, timeout : 160)


### PR DESCRIPTION
Previous PR #1074 remove a bit too much in meson.build around extra_libs, extra_link_args.
So the compilation on Windows was failing. This PR fixes that.

The question about `host_machine`/`build_machine` should probably better handled but it will be once we will have a proper native compilation on Windows (soon™️).
This PR is just making compilation of libkiwix works on Windows.