### PR TITLE
[fixes]ZIM size being advertized inconsistently between MB and MiB

### DIFF
--- a/static/skin/index.js
+++ b/static/skin/index.js
@@ -78,15 +78,21 @@
         return result;
     }
 
+    function humanFriendlyNumStr(num, precision) {
+        const n = Math.abs(num).toFixed().length;
+        return num.toFixed(Math.max(0, precision - n));
+    }
+
     const humanFriendlySize = (fileSize) => {
         if (fileSize === 0) {
             return '';
         }
-        const units = ['bytes', 'kB', 'MB', 'GB', 'TB'];
-        let quotient = Math.floor(Math.log10(fileSize) / 3);
-        quotient = quotient < units.length ? quotient : units.length - 1;
-        fileSize /= (1000 ** quotient);
-        return `${+fileSize.toFixed(2)} ${units[quotient]}`;
+        const units = ['bytes', 'KiB', 'MiB', 'GiB', 'TiB'];
+        let quotient = Math.floor(Math.log2(fileSize) / 10);
+        quotient = Math.min(quotient, units.length - 1);
+        fileSize /= (1024 ** quotient);
+        const fileSizeStr = humanFriendlyNumStr(fileSize, 3);
+        return `${fileSizeStr} ${units[quotient]}`;
     };
 
     const humanFriendlyTitle = (title) => {

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -63,7 +63,7 @@ const ResourceCollection resources200Compressible{
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/index.css" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/index.css?cacheid=1e78e7cf" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/index.js" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/index.js?cacheid=436e0a63" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/index.js?cacheid=f43eb0b9" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/iso6391To3.js" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/iso6391To3.js?cacheid=ecde2bb3" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/isotope.pkgd.min.js" },
@@ -292,7 +292,7 @@ R"EXPECTEDRESULT(      href="/ROOT%23%3F/skin/kiwix.css?cacheid=2158fad9"
     <script type="text/javascript" src="/ROOT%23%3F/skin/languages.js?cacheid=ee7d95b5" defer></script>
     <script src="/ROOT%23%3F/skin/isotope.pkgd.min.js?cacheid=2e48d392" defer></script>
     <script src="/ROOT%23%3F/skin/iso6391To3.js?cacheid=ecde2bb3"></script>
-    <script type="text/javascript" src="/ROOT%23%3F/skin/index.js?cacheid=436e0a63" defer></script>
+    <script type="text/javascript" src="/ROOT%23%3F/skin/index.js?cacheid=f43eb0b9" defer></script>
         <img src="/ROOT%23%3F/skin/feed.svg?cacheid=055b333f"
         <img src="/ROOT%23%3F/skin/langSelector.svg?cacheid=00b59961"
 )EXPECTEDRESULT"


### PR DESCRIPTION
Fixes https://github.com/kiwix/libkiwix/issues/1095

- Switched from decimal (MB) to binary (MiB) units for file sizes
- Used powers of 1024 instead of 1000 for size calculations
- Adjusted precision to display up to 3 significant digits
- Updated unit labels to KiB, MiB, GiB, TiB
- Implemented log2-based calculation for determining appropriate unit