### PR TITLE
kiwix::Downloader's constructor pauses all downloads found in the aria session file

### DIFF
--- a/src/aria2.cpp
+++ b/src/aria2.cpp
@@ -117,6 +117,9 @@ Aria2::Aria2():
 
 void Aria2::close()
 {
+  MethodCall methodCall("aria2.pauseAll", m_secret);
+  doRequest(methodCall);
+
   saveSession();
   shutdown();
 }

--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -151,11 +151,20 @@ Downloader::Downloader() :
 /* Destructor */
 Downloader::~Downloader()
 {
+  close();
 }
 
 void Downloader::close()
 {
-  mp_aria->close();
+  if ( mp_aria ) {
+    try {
+      mp_aria->close();
+    } catch (const std::exception& err) {
+      std::cerr << "ERROR: Failed to save the downloader state: "
+                << err.what() << std::endl;
+    }
+    mp_aria.reset();
+  }
 }
 
 std::vector<std::string> Downloader::getDownloadIds() const {


### PR DESCRIPTION
This PR addresses one of the problems observed while working on kiwix/kiwix-desktop#1118. See the commit messages for details.