### PR TITLE
Add String Slugification for Generating File Name

### DIFF
--- a/include/tools.h
+++ b/include/tools.h
@@ -282,5 +282,14 @@ FeedCategories readCategoriesFromFeed(const std::string& content);
  * @return full language name.
  */
 std::string getLanguageSelfName(const std::string& lang);
+
+/**
+ * Slugifies the filename by converting any characters reserved by the operating
+ * system to '_'. Note filename is only the file name and not a path.
+ *
+ * @param filename Valid UTF-8 encoded file name string. 
+ * @return slugified string.
+ */
+std::string getSlugifiedFileName(const std::string& filename);
 }
 #endif // KIWIX_TOOLS_H

--- a/src/tools/stringTools.cpp
+++ b/src/tools/stringTools.cpp
@@ -32,6 +32,7 @@
 
 #include <iostream>
 #include <iomanip>
+#include <regex>
 
 /* tell ICU where to find its dat file (tables) */
 void kiwix::loadICUExternalTables()
@@ -438,4 +439,14 @@ std::vector<std::string> kiwix::getTitleVariants(const std::string& title) {
 template<>
 std::string kiwix::extractFromString(const std::string& str) {
   return str;
+}
+
+std::string kiwix::getSlugifiedFileName(const std::string& filename)
+{
+#ifdef _WIN32
+  const std::regex reservedCharsReg(R"([<>:"/\\|?*])");
+#else
+  const std::regex reservedCharsReg("/");
+#endif
+  return std::regex_replace(filename, reservedCharsReg, "_"); 
 }

--- a/test/stringTools.cpp
+++ b/test/stringTools.cpp
@@ -19,6 +19,7 @@
 
 #include "gtest/gtest.h"
 #include "../src/tools/stringTools.h"
+#include "../include/tools.h"
 #include <string>
 #include <vector>
 
@@ -168,6 +169,19 @@ TEST(stringTools, stripSuffix)
   EXPECT_EQ(stripSuffix("abc123", "123"), "abc");
   EXPECT_EQ(stripSuffix("abc123", "123456789"), "abc123");
   EXPECT_EQ(stripSuffix("abc123", "987"), "abc123");
+}
+
+TEST(stringTools, getSlugifiedFileName)
+{
+  EXPECT_EQ(getSlugifiedFileName("abc123.png"), "abc123.png");
+  EXPECT_EQ(getSlugifiedFileName("/"), "_");
+  EXPECT_EQ(getSlugifiedFileName("abc/123.pdf"), "abc_123.pdf");
+  EXPECT_EQ(getSlugifiedFileName("abc//123.yaml"), "abc__123.yaml");
+  EXPECT_EQ(getSlugifiedFileName("//abc//123//"), "__abc__123__");
+#ifdef _WIN32
+  EXPECT_EQ(getSlugifiedFileName(R"(<>:"/\\|?*)"), "__________");
+  EXPECT_EQ(getSlugifiedFileName(R"(<abc>:"/123\\|?*<.txt>)"), "_abc____123______.txt_");
+#endif
 }
 
 };


### PR DESCRIPTION
kiwix/kiwix-desktop#1134

Introduced function to do basic sanitization to strings that we intend to use as file names in an operating system. Currently, it only sanitizes reserved characters. In the future, this can be extended to handle the complex file name requirements by Windows.