### PR TITLE
Revert "Removed getDataDirectory()"

### DIFF
--- a/include/downloader.h
+++ b/include/downloader.h
@@ -172,12 +172,7 @@ class Downloader
   typedef std::vector<std::pair<std::string, std::string>> Options;
 
  public: // functions
-  /*
-  * Create a new Downloader object.
-  *
-  * @param sessionFileDir: The directory where aria2 will store its session file.
-  */
-  explicit Downloader(std::string sessionFileDir);
+  Downloader();
   virtual ~Downloader();
 
   void close();
@@ -196,11 +191,10 @@ class Downloader
    * User should call `update` on the returned `Download` to have an accurate status.
    *
    * @param uri: The uri of the thing to download.
-   * @param downloadDir: The download directory where the thing should be stored (takes precedence over any "dir" in `options`).
    * @param options: A series of pair <option_name, option_value> to pass to aria.
    * @return: The newly created Download.
    */
-  std::shared_ptr<Download> startDownload(const std::string& uri, const std::string& downloadDir, Options options = {});
+  std::shared_ptr<Download> startDownload(const std::string& uri, const Options& options = {});
 
   /**
    * Get a download corrsponding to a download id (did)

--- a/include/tools.h
+++ b/include/tools.h
@@ -45,6 +45,32 @@ typedef std::vector<std::string> FeedCategories;
  */
 std::string getCurrentDirectory();
 
+/**
+ * Return the data directory
+ *
+ * The data directory is the default directory where downloaded files
+ * should be saved (it can be overriden via the options parameter of
+ * `kiwix::Downloader::startDownload()`).
+ *
+ * Its path can vary and is determined as follows:
+ *
+ * * `$KIWIX_DATA_DIR` if `$KIWIX_DATA_DIR` environment variable set, *otherwise...*
+ * * On Windows:
+ *
+ *   * `$APPDATA/kiwix` if environment variable `$APPDATA` set, *otherwise...*
+ *   * `$USERPROFILE/kiwix` if environment variable `$USERPROFILE` set, *otherwise...*
+ *
+ * * On other Operating Systems:
+ *
+ *   * `$XDG_DATA_HOME/kiwix` if environment variable `$XDG_DATA_HOME` set, *otherwise...*
+ *   * `$HOME/.local/share/kiwx` if environment variable `$HOME` set, *otherwise...*
+ *
+ * * Current working directory.
+ *
+ * @return the path of the data directory (UTF-8 encoded)
+ */
+std::string getDataDirectory();
+
 /** Return the path of the executable
  *
  * Some application may be packaged in auto extractible archive (Appimage) and the

--- a/src/aria2.cpp
+++ b/src/aria2.cpp
@@ -55,15 +55,18 @@ void pauseAnyActiveDownloads(const std::string& ariaSessionFilePath)
 
 } // unnamed namespace
 
-Aria2::Aria2(std::string sessionFileDir):
+Aria2::Aria2():
   mp_aria(nullptr),
   m_port(42042),
   m_secret(getNewRpcSecret())
 {
+  m_downloadDir = getDataDirectory();
+  makeDirectory(m_downloadDir);
   std::vector<const char*> callCmd;
 
   std::string rpc_port = "--rpc-listen-port=" + to_string(m_port);
-  std::string session_file = appendToDirectory(sessionFileDir, "kiwix.session");
+  std::string download_dir = "--dir=" + getDataDirectory();
+  std::string session_file = appendToDirectory(getDataDirectory(), "kiwix.session");
   pauseAnyActiveDownloads(session_file);
   std::string session = "--save-session=" + session_file;
   std::string inputFile = "--input-file=" + session_file;
@@ -91,6 +94,7 @@ Aria2::Aria2(std::string sessionFileDir):
   callCmd.push_back("--enable-rpc");
   callCmd.push_back(rpc_secret.c_str());
   callCmd.push_back(rpc_port.c_str());
+  callCmd.push_back(download_dir.c_str());
   if (fileReadable(session_file)) {
     callCmd.push_back(inputFile.c_str());
   }

--- a/src/aria2.h
+++ b/src/aria2.h
@@ -22,10 +22,11 @@ class Aria2
     std::unique_ptr<Subprocess> mp_aria;
     int m_port;
     std::string m_secret;
+    std::string m_downloadDir;
     std::string doRequest(const MethodCall& methodCall);
 
   public:
-    explicit Aria2(std::string sessionFileDir);
+    Aria2();
     virtual ~Aria2() = default;
     void close();
 

--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -125,8 +125,8 @@ void Download::cancelDownload()
 }
 
 /* Constructor */
-Downloader::Downloader(std::string sessionFileDir) :
-  mp_aria(new Aria2(sessionFileDir))
+Downloader::Downloader() :
+  mp_aria(new Aria2())
 {
   try {
     for (auto gid : mp_aria->tellWaiting()) {
@@ -209,13 +209,9 @@ bool downloadCanBeReused(const Download& d,
 
 } // unnamed namespace
 
-std::shared_ptr<Download> Downloader::startDownload(const std::string& uri, const std::string& downloadDir, Options options)
+std::shared_ptr<Download> Downloader::startDownload(const std::string& uri, const Options& options)
 {
   std::unique_lock<std::mutex> lock(m_lock);
-  options.erase(std::remove_if(options.begin(), options.end(), [](const auto& option) {
-    return option.first == "dir";
-  }), options.end());
-  options.push_back({"dir", downloadDir});
   for (auto& p: m_knownDownloads) {
     auto& d = p.second;
     if ( downloadCanBeReused(*d, uri, options) )

--- a/src/tools/pathTools.h
+++ b/src/tools/pathTools.h
@@ -29,6 +29,7 @@ std::wstring Utf8ToWide(const std::string& str);
 
 unsigned int getFileSize(const std::string& path);
 std::string getFileSizeAsString(const std::string& path);
+bool makeDirectory(const std::string& path);
 std::string makeTmpDirectory();
 bool copyFile(const std::string& sourcePath, const std::string& destPath);
 bool writeTextFile(const std::string& path, const std::string& content);


### PR DESCRIPTION
This reverts kiwix/libkiwix#1107

kiwix-desktop is not ready to merge the PR using this new API. As this is a API break, now
CI fails to compile kiwix-desktop. We revert the pr #1107 until kiwix-desktop is ready.