### PR TITLE
Update deb packages CI/CD

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -15,10 +15,10 @@ jobs:
       fail-fast: false
       matrix:
         distro:
-          - debian-unstable
-          - debian-trixie
-          - debian-bookworm
-          - debian-bullseye
+#          - debian-unstable
+#          - debian-trixie
+#          - debian-bookworm
+#          - debian-bullseye
           - ubuntu-noble
           - ubuntu-jammy
           - ubuntu-focal
@@ -45,33 +45,33 @@ jobs:
           email: release+launchpad@kiwix.org
           distro: ${{ matrix.distro }}
 
-      - uses: legoktm/gh-action-build-deb@debian-unstable
-        if: matrix.distro == 'debian-unstable'
-        name: Build package for debian-unstable
-        id: build-debian-unstable
-        with:
-          args: --no-sign
-
-      - uses: legoktm/gh-action-build-deb@b47978ba8498dc8b8153cc3b5f99a5fc1afa5de1 # pin@debian-trixie
-        if: matrix.distro == 'debian-trixie'
-        name: Build package for debian-trixie
-        id: build-debian-trixie
-        with:
-          args: --no-sign
-
-      - uses: legoktm/gh-action-build-deb@1f4e86a6bb34aaad388167eaf5eb85d553935336 # pin@debian-bookworm
-        if: matrix.distro == 'debian-bookworm'
-        name: Build package for debian-bookworm
-        id: build-debian-bookworm
-        with:
-          args: --no-sign
-
-      - uses: legoktm/gh-action-build-deb@084b4263209252ec80a75d2c78a586192c17f18d # pin@debian-bullseye
-        if: matrix.distro == 'debian-bullseye'
-        name: Build package for debian-bullseye
-        id: build-debian-bullseye
-        with:
-          args: --no-sign
+#      - uses: legoktm/gh-action-build-deb@debian-unstable
+#        if: matrix.distro == 'debian-unstable'
+#        name: Build package for debian-unstable
+#        id: build-debian-unstable
+#        with:
+#          args: --no-sign
+#
+#      - uses: legoktm/gh-action-build-deb@b47978ba8498dc8b8153cc3b5f99a5fc1afa5de1 # pin@debian-trixie
+#        if: matrix.distro == 'debian-trixie'
+#        name: Build package for debian-trixie
+#        id: build-debian-trixie
+#        with:
+#          args: --no-sign
+#
+#      - uses: legoktm/gh-action-build-deb@1f4e86a6bb34aaad388167eaf5eb85d553935336 # pin@debian-bookworm
+#        if: matrix.distro == 'debian-bookworm'
+#        name: Build package for debian-bookworm
+#        id: build-debian-bookworm
+#        with:
+#          args: --no-sign
+#
+#      - uses: legoktm/gh-action-build-deb@084b4263209252ec80a75d2c78a586192c17f18d # pin@debian-bullseye
+#        if: matrix.distro == 'debian-bullseye'
+#        name: Build package for debian-bullseye
+#        id: build-debian-bullseye
+#        with:
+#          args: --no-sign
 
       - uses: legoktm/gh-action-build-deb@9114a536498b65c40b932209b9833aa942bf108d # pin@ubuntu-noble
         if: matrix.distro == 'ubuntu-noble'

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -16,10 +16,15 @@ jobs:
       matrix:
         distro:
           - debian-unstable
+          - debian-trixie
+          - debian-bookworm
+          - debian-bullseye
+          - ubuntu-noble
           - ubuntu-jammy
           - ubuntu-focal
+
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Determine which PPA we should upload to
       - name: PPA
@@ -34,7 +39,7 @@ jobs:
         env:
           REF: ${{ github.ref }}
 
-      - uses: legoktm/gh-action-auto-dch@master
+      - uses: legoktm/gh-action-auto-dch@main
         with:
           fullname: Kiwix builder
           email: release+launchpad@kiwix.org
@@ -46,6 +51,35 @@ jobs:
         id: build-debian-unstable
         with:
           args: --no-sign
+
+      - uses: legoktm/gh-action-build-deb@b47978ba8498dc8b8153cc3b5f99a5fc1afa5de1 # pin@debian-trixie
+        if: matrix.distro == 'debian-trixie'
+        name: Build package for debian-trixie
+        id: build-debian-trixie
+        with:
+          args: --no-sign
+
+      - uses: legoktm/gh-action-build-deb@1f4e86a6bb34aaad388167eaf5eb85d553935336 # pin@debian-bookworm
+        if: matrix.distro == 'debian-bookworm'
+        name: Build package for debian-bookworm
+        id: build-debian-bookworm
+        with:
+          args: --no-sign
+
+      - uses: legoktm/gh-action-build-deb@084b4263209252ec80a75d2c78a586192c17f18d # pin@debian-bullseye
+        if: matrix.distro == 'debian-bullseye'
+        name: Build package for debian-bullseye
+        id: build-debian-bullseye
+        with:
+          args: --no-sign
+
+      - uses: legoktm/gh-action-build-deb@9114a536498b65c40b932209b9833aa942bf108d # pin@ubuntu-noble
+        if: matrix.distro == 'ubuntu-noble'
+        name: Build package for ubuntu-noble
+        id: build-ubuntu-noble
+        with:
+          args: --no-sign
+          ppa: ${{ steps.ppa.outputs.ppa }}
 
       - uses: legoktm/gh-action-build-deb@ubuntu-jammy
         if: matrix.distro == 'ubuntu-jammy'
@@ -68,7 +102,7 @@ jobs:
           name: Packages for ${{ matrix.distro }}
           path: output
 
-      - uses: legoktm/gh-action-dput@master
+      - uses: legoktm/gh-action-dput@main
         name: Upload dev package
         # Only upload on pushes to main
         if: github.event_name == 'push' && github.event.ref == 'refs/heads/main' && startswith(matrix.distro, 'ubuntu-')
@@ -77,7 +111,7 @@ jobs:
           repository: ppa:kiwixteam/dev
           packages: output/*_source.changes
 
-      - uses: legoktm/gh-action-dput@master
+      - uses: legoktm/gh-action-dput@main
         name: Upload release package
         if: github.event_name == 'release' && startswith(matrix.distro, 'ubuntu-')
         with:

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Maintainer: Kiwix team <kiwix@kiwix.org>
 Build-Depends: debhelper-compat (= 13),
  meson,
  pkgconf,
- libzim-dev (>= 7.2.0~),
+ libzim-dev (>= 9.0.0~),
  libcurl4-gnutls-dev,
  libicu-dev,
  libgtest-dev,
@@ -23,7 +23,7 @@ Section: libdevel
 Architecture: any
 Multi-Arch: same
 Depends: libkiwix10 (= ${binary:Version}), ${misc:Depends}, python3,
- libzim-dev (>= 7.2.0~),
+ libzim-dev (>= 9.0.0~),
  libicu-dev,
  libpugixml-dev,
  libcurl4-gnutls-dev,

--- a/meson.build
+++ b/meson.build
@@ -35,7 +35,7 @@ else
   error('Cannot found header mustache.hpp')
 endif
 
-libzim_dep = dependency('libzim', version : '>=8.1.0', static:static_deps)
+libzim_dep = dependency('libzim', version : '>=9.0.0', static:static_deps)
 if not compiler.has_header_symbol('zim/zim.h', 'LIBZIM_WITH_XAPIAN', dependencies: libzim_dep)
   error('Libzim seems to be compiled without xapian. Xapian support is mandatory.')
 endif


### PR DESCRIPTION
Refreshing the whole deb package CI/CD, but because libzim9 is not available on Debian, we have to comment out the Debian related builds, see https://github.com/kiwix/libkiwix/issues/1115