### PR TITLE
Bump-up version to 14.0.0

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -35,11 +35,12 @@ Description: library of common code for Kiwix (development)
  .
  This package contains development files.
 
-Package: libkiwix10
+Package: libkiwix14
 Architecture: any
 Multi-Arch: same
 Depends: ${shlibs:Depends}, ${misc:Depends}, aria2
-Conflicts: libkiwix0, libkiwix3, libkiwix9
+Conflicts: libkiwix0, libkiwix3, libkiwix9, libkiwix10, libkiwix11, libkiwix12, libkiwix13
+Replaces: libkiwix0, libkiwix3, libkiwix9, libkiwix10, libkiwix11, libkiwix12, libkiwix13
 Description: library of common code for Kiwix
  Kiwix is an offline Wikipedia reader. libkiwix provides the
  software core for Kiwix, and contains the code shared by all

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('libkiwix', 'cpp',
-  version : '13.1.0',
+  version : '14.0.0',
   license : 'GPLv3+',
   default_options : ['c_std=c11', 'cpp_std=c++17', 'werror=true'])
 


### PR DESCRIPTION
Next version will be `14.0.0` as we have breaking changes. Doing this right now to be able to configure properly dependencies in `kiwix-tools` and `kiwix-desktop`.

Related to #1081