### PR TITLE
Handling of external app links in the viewer

### DIFF
--- a/static/skin/viewer.js
+++ b/static/skin/viewer.js
@@ -335,6 +335,13 @@ function getRealHref(target) {
   return target_href;
 }
 
+function setHrefAvoidingWombatRewriting(target, url) {
+  const old_no_rewrite = target._no_rewrite;
+  target._no_rewrite = true;
+  target.setAttribute("href", url);
+  target._no_rewrite = old_no_rewrite;
+}
+
 function onClickEvent(e) {
   const iframeDocument = contentIframe.contentDocument;
   const target = matchingAncestorElement(e.target, iframeDocument, "a");
@@ -351,7 +358,7 @@ function onClickEvent(e) {
       if ( e.ctrlKey || e.shiftKey ) {
         // The link will be loaded in a new tab/window - update the link
         // and let the browser handle the rest.
-        target.setAttribute("href", possiblyBlockedLink);
+        setHrefAvoidingWombatRewriting(target, possiblyBlockedLink);
       } else {
         // Load the external URL in the viewer window (rather than iframe)
         contentIframe.contentWindow.parent.location = possiblyBlockedLink;

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -75,7 +75,7 @@ const ResourceCollection resources200Compressible{
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/taskbar.css" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/taskbar.css?cacheid=80d56607" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/viewer.js" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=5fc4badf" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=215635fd" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Poppins.ttf" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/fonts/Poppins.ttf?cacheid=af705837" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Roboto.ttf" },
@@ -324,7 +324,7 @@ R"EXPECTEDRESULT(    <link type="text/css" href="./skin/kiwix.css?cacheid=2158fa
     <script type="text/javascript" src="./skin/polyfills.js?cacheid=a0e0343d"></script>
     <script type="module" src="./skin/i18n.js?cacheid=071abc9a" defer></script>
     <script type="text/javascript" src="./skin/languages.js?cacheid=ee7d95b5" defer></script>
-    <script type="text/javascript" src="./skin/viewer.js?cacheid=5fc4badf" defer></script>
+    <script type="text/javascript" src="./skin/viewer.js?cacheid=215635fd" defer></script>
     <script type="text/javascript" src="./skin/autoComplete/autoComplete.min.js?cacheid=1191aaaf"></script>
       const blankPageUrl = root + "/skin/blank.html?cacheid=6b1fa032";
           <label for="kiwix_button_show_toggle"><img src="./skin/caret.png?cacheid=22b942b4" alt=""></label>

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -75,7 +75,7 @@ const ResourceCollection resources200Compressible{
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/taskbar.css" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/taskbar.css?cacheid=80d56607" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/viewer.js" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=215635fd" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=aca897b0" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Poppins.ttf" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/fonts/Poppins.ttf?cacheid=af705837" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Roboto.ttf" },
@@ -324,7 +324,7 @@ R"EXPECTEDRESULT(    <link type="text/css" href="./skin/kiwix.css?cacheid=2158fa
     <script type="text/javascript" src="./skin/polyfills.js?cacheid=a0e0343d"></script>
     <script type="module" src="./skin/i18n.js?cacheid=071abc9a" defer></script>
     <script type="text/javascript" src="./skin/languages.js?cacheid=ee7d95b5" defer></script>
-    <script type="text/javascript" src="./skin/viewer.js?cacheid=215635fd" defer></script>
+    <script type="text/javascript" src="./skin/viewer.js?cacheid=aca897b0" defer></script>
     <script type="text/javascript" src="./skin/autoComplete/autoComplete.min.js?cacheid=1191aaaf"></script>
       const blankPageUrl = root + "/skin/blank.html?cacheid=6b1fa032";
           <label for="kiwix_button_show_toggle"><img src="./skin/caret.png?cacheid=22b942b4" alt=""></label>


### PR DESCRIPTION
Fixes kiwix/kiwix-tools#680 
Also closes #1090, but not as requested in the title & description of that issue because I couldn't make it work and chose the general approach proposed in an [afterthought](https://github.com/kiwix/libkiwix/issues/1090#issuecomment-2147755667) that was initially [posted](https://github.com/kiwix/kiwix-tools/issues/680#issuecomment-2147208056) in #680.

Links that should be handled/opened by external applications - such as email addresses (`mailto:`), phone numbers (`tel:`), etc - are opened by the viewer in a new tab/window, thus avoiding any issues with content security policy.