### PR TITLE
Better check libzim version

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -23,7 +23,7 @@ Section: libdevel
 Architecture: any
 Multi-Arch: same
 Depends: libkiwix14 (= ${binary:Version}), ${misc:Depends}, python3,
- libzim-dev (>= 9.0.0~),
+ libzim-dev (>= 9.0.0), libzim-dev (<< 10.0.0),
  libicu-dev,
  libpugixml-dev,
  libcurl4-gnutls-dev,

--- a/meson.build
+++ b/meson.build
@@ -35,7 +35,9 @@ else
   error('Cannot found header mustache.hpp')
 endif
 
-libzim_dep = dependency('libzim', version : '>=9.0.0', static:static_deps)
+libzim_dep = dependency('libzim', version:'>=9.0.0', static:static_deps)
+libzim_dep = dependency('libzim', version:'<10.0.0', static:static_deps)
+
 if not compiler.has_header_symbol('zim/zim.h', 'LIBZIM_WITH_XAPIAN', dependencies: libzim_dep)
   error('Libzim seems to be compiled without xapian. Xapian support is mandatory.')
 endif


### PR DESCRIPTION
We check maximum version of libzim to avoid linking against a version which might have breaking changes.