### PR TITLE
Deprived pseudolang mul of a self-name

### DIFF
--- a/src/tools/languageTools.cpp
+++ b/src/tools/languageTools.cpp
@@ -68,6 +68,7 @@ void fillLanguagesMap()
         const kiwix::ICULanguageInfo lang(*icuLangPtr);
         iso639_3.insert({lang.iso3Code(), lang.selfName()});
     }
+    iso639_3.erase("mul");
 }
 
 } // unnamed namespace


### PR DESCRIPTION
Fixes #1098

ICU package contains a special code "mul" with a self-name of "multiple languages". libkiwix now suppresses that. As a result the self-name of "mul" (like for any other unknown language code) is the code itself (i.e. "mul").

The most prominent user-visible effect of this change is that the language filter in the library page no longer contains a "Multiple languages" entry if there is a legacy ZIM file with the language set to "mul" - that entry now shows up as "Mul".