### PR TITLE
Disable IPV6_ONLY to fix kiwix-serve on Windows

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -75,9 +75,11 @@ void Server::setRoot(const std::string& root)
   }
 }
 
-// FIXME: this method is implemented under the assumption that it is invoked only once (per object).
 void Server::setAddress(const std::string& addr)
 {
+  m_addr.addr.clear();
+  m_addr.addr6.clear();
+
   if (addr.empty()) return;
 
   if (addr.find(':') != std::string::npos) { // IPv6

--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -529,6 +529,12 @@ bool InternalServer::start() {
       closesocket(sock);
       return false;
     }
+
+    if (::bind(sock, (struct sockaddr*)&sockAddr6, sizeof(sockAddr6)) == SOCKET_ERROR) {
+      std::cerr << "ERROR: Failed to bind IPv6 socket" << std::endl;
+      closesocket(sock);
+      return false;
+    }
   }
 #endif
   mp_daemon = MHD_start_daemon(flags,

--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -544,9 +544,10 @@ bool InternalServer::start() {
                             MHD_OPTION_THREAD_POOL_SIZE, m_nbThreads,
                             MHD_OPTION_PER_IP_CONNECTION_LIMIT, m_ipConnectionLimit,
                             MHD_OPTION_END);
+
   if (mp_daemon == nullptr) {
-    std::cerr << "Unable to instantiate the HTTP daemon. The port " << m_port
-              << " is maybe already occupied or need more permissions to be open. "
+    std::cerr << "ERROR: Unable to instantiate the HTTP daemon. The port " << m_port
+              << " may already be in use, or more permissions are required to open it. "
                  "Please try as root or with a port number higher or equal to 1024."
               << std::endl;
 #ifdef _WIN32


### PR DESCRIPTION
This fixes support of IPv6 for kiwix-serve on Windows by disabling IPV6_ONLY. By default Linux systems seem to do this internally, so the issue became Windows specific.

Fixes #1144 