### PR TITLE
Fix Server::setAddress

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -75,9 +75,11 @@ void Server::setRoot(const std::string& root)
   }
 }
 
-// FIXME: this method is implemented under the assumption that it is invoked only once (per object).
 void Server::setAddress(const std::string& addr)
 {
+  m_addr.addr.clear();
+  m_addr.addr6.clear();
+
   if (addr.empty()) return;
 
   if (addr.find(':') != std::string::npos) { // IPv6


### PR DESCRIPTION
This brings a change from the closed #1147 that fixes multiple uses of Server::setAddress.

Now the `m_addr` field is cleared before setting a new ip.

Helps a lot especially in kiwix-desktop local server, when multiple servers may be started.

Fixes #1150 