### PR TITLE
removed temp hack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,6 @@ jobs:
       - name: Install packages
         run: |
           brew update
-          brew unlink python3
-          # upgrade from python@3.12 to python@3.12.2 fails to overwrite those
-          rm -f /usr/local/bin/2to3 /usr/local/bin/2to3-3.12 /usr/local/bin/idle3 /usr/local/bin/idle3.12 /usr/local/bin/pydoc3 /usr/local/bin/pydoc3.12 /usr/local/bin/python3 /usr/local/bin/python3-config /usr/local/bin/python3.12 /usr/local/bin/python3.12-config
           brew install pkg-config ninja meson
         env:
           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1


### PR DESCRIPTION
[Last year](https://github.com/kiwix/libkiwix/commit/f6f7214c991bbdf6fc8c72d65e8447c9c350fc35) we had to add a tweak to circumvent a brew issue.

It had not been removed and is now causing issue.

Removing it fixes the CI on macos13