### PR TITLE
magnetLink queryString to start with ? and not ?&

### DIFF
--- a/static/skin/index.js
+++ b/static/skin/index.js
@@ -238,7 +238,8 @@
             let finalValue = (keysToURIEncode.indexOf(key) >= 0) ? encodeURIComponent(value) : value;
             output += `&${key}=${finalValue}`;
         }
-        return output;
+        // exclude first char so the first params are not prefixed with &
+        return output.substring(1);
     }
 
     /* hack for library.kiwix.org magnet links (created by MirrorBrain)


### PR DESCRIPTION
In #1001, we've introduced a mechanism to rewrite the magnet link that mirrobrain generates: we extend it for better webseed support and we fix the urlencoding.

Given the magnet is a URI (scheme and queryString) and given it worked where I tested, lazyness had me build the querystring as a joined list of `&key=value`.

Actualy the spec says the `&` is a separator and thus starting with `&` is equivalent to having an empty part. Some clients (at least qbittorrent) are not happy with it.

This fixes it by removing the first char of the built string in the helper function. It's safe on empty strings as well.

Fixes #1157