### PR TITLE
Check versus minor version of dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Maintainer: Kiwix team <kiwix@kiwix.org>
 Build-Depends: debhelper-compat (= 13),
  meson,
  pkgconf,
- libzim-dev (>= 9.0.0), libzim-dev (<< 10.0.0),
+ libzim-dev (>= 9.0), libzim-dev (<< 10.0),
  libcurl4-gnutls-dev,
  libicu-dev,
  libgtest-dev,
@@ -22,7 +22,7 @@ Section: libdevel
 Architecture: any
 Multi-Arch: same
 Depends: libkiwix14 (= ${binary:Version}), ${misc:Depends}, python3,
- libzim-dev (>= 9.0.0), libzim-dev (<< 10.0.0),
+ libzim-dev (>= 9.0), libzim-dev (<< 10.0),
  libicu-dev,
  libpugixml-dev,
  libcurl4-gnutls-dev,


### PR DESCRIPTION
Looks like the `deb/control` file can not deal properly with patch version numbers. See https://github.com/kiwix/kiwix-desktop/issues/1285