### PR TITLE
Two compilation fixes for FreeBSD

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,14 +4,40 @@ project('libkiwix', 'cpp',
   default_options : ['c_std=c11', 'cpp_std=c++17', 'werror=true'])
 
 compiler = meson.get_compiler('cpp')
-
 static_deps = get_option('static-linkage') or get_option('default_library') == 'static'
+extra_libs = []
 
-# See https://github.com/kiwix/libkiwix/issues/371
-if ['arm', 'mips', 'm68k', 'ppc', 'sh4'].contains(host_machine.cpu_family())
-  extra_libs = ['-latomic']
-else
-  extra_libs = []
+# Atomics as compiled by GCC or clang can lead to external references to
+# functions depending on the type size and the platform. LLVM provides them in
+# 'libcompiler_rt', which clang normally automatically links in, while GNU
+# provides them in 'libatomic', which GCC *does not* link in automatically (but
+# this is probably going to change, see
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81358). Regardless of the setup
+# of the compiler driver itself (GCC or clang), we can thus assume that if some
+# atomic references can't be resolved, then 'libatomic' is missing.
+atomics_program = '''
+#include <atomic>
+#include <cstdint>
+
+using namespace std;
+
+int main() {
+  volatile atomic_bool a_b = true;
+  volatile atomic_ullong a_ull = -1;
+  // Next two lines are to cover atomic<socket_t> from 'httplib.h'.
+  volatile atomic<uint32_t> a_u32 = -1;
+  volatile atomic<uint64_t> a_u64 = -1;
+
+  return atomic_load(&a_b) == false && atomic_load(&a_ull) == 0 &&
+    atomic_load(&a_u32) == 0 && atomic_load(&a_u64) == 0;
+}
+'''
+if not compiler.links(atomics_program,
+                      name: 'compiler driver readily supports atomics')
+  libatomic = compiler.find_library('atomic')
+  compiler.links(atomics_program, name: 'atomics work with libatomic',
+                 dependencies: libatomic, required: true)
+  extra_libs += ['-latomic']
 endif
 
 if (compiler.get_id() == 'gcc' and build_machine.system() == 'linux') or host_machine.system() == 'freebsd'

--- a/src/tools/networkTools.cpp
+++ b/src/tools/networkTools.cpp
@@ -42,6 +42,7 @@
 #include <arpa/inet.h>
 #include <ifaddrs.h>
 #include <sys/socket.h>
+#include <netinet/in.h>
 #include <net/if.h>
 #include <netdb.h>
 #endif


### PR DESCRIPTION
Note that in both cases we are not special-casing FreeBSD, as the first case is in fact Linux-specific, and the second case is just following what POSIX prescribes (the change works on Linux too).