### PR TITLE
Handling of external links with target="_blank"

### DIFF
--- a/static/skin/viewer.js
+++ b/static/skin/viewer.js
@@ -345,6 +345,13 @@ function setHrefAvoidingWombatRewriting(target, url) {
   target._no_rewrite = old_no_rewrite;
 }
 
+function linkShouldBeOpenedInANewWindow(linkElement, mouseEvent) {
+  return linkElement.getAttribute("target") == "_blank"
+      || mouseEvent.ctrlKey
+      || mouseEvent.shiftKey
+      || mouseEvent.metaKey /* on Macs */;
+}
+
 function onClickEvent(e) {
   const iframeDocument = contentIframe.contentDocument;
   const target = matchingAncestorElement(e.target, iframeDocument, "a");
@@ -358,7 +365,7 @@ function onClickEvent(e) {
 
     if (isExternalAppUrl || isExternalUrl(target_href)) {
       const possiblyBlockedLink = blockLink(target_href);
-      if ( e.ctrlKey || e.shiftKey ) {
+      if ( linkShouldBeOpenedInANewWindow(target, e) ) {
         // The link will be loaded in a new tab/window - update the link
         // and let the browser handle the rest.
         setHrefAvoidingWombatRewriting(target, possiblyBlockedLink);

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -75,7 +75,7 @@ const ResourceCollection resources200Compressible{
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/taskbar.css" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/taskbar.css?cacheid=80d56607" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/viewer.js" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=8ca16f13" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=fdec37a7" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Poppins.ttf" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/fonts/Poppins.ttf?cacheid=af705837" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Roboto.ttf" },
@@ -327,7 +327,7 @@ R"EXPECTEDRESULT(    <link type="text/css" href="./skin/kiwix.css?cacheid=2158fa
     <script type="text/javascript" src="./skin/polyfills.js?cacheid=a0e0343d"></script>
     <script type="module" src="./skin/i18n.js?cacheid=071abc9a" defer></script>
     <script type="text/javascript" src="./skin/languages.js?cacheid=ee7d95b5" defer></script>
-    <script type="text/javascript" src="./skin/viewer.js?cacheid=8ca16f13" defer></script>
+    <script type="text/javascript" src="./skin/viewer.js?cacheid=fdec37a7" defer></script>
     <script type="text/javascript" src="./skin/autoComplete/autoComplete.min.js?cacheid=1191aaaf"></script>
       const blankPageUrl = root + "/skin/blank.html?cacheid=6b1fa032";
           <label for="kiwix_button_show_toggle"><img src="./skin/caret.png?cacheid=22b942b4" alt=""></label>


### PR DESCRIPTION
Fixes kiwix/kiwix-tools#678

External links with `target="_blank"` attribute are opened in a new tab/window.

