### PR TITLE
If PDF viewer is not enabled PDFs are downloaded instead

### DIFF
--- a/static/skin/viewer.js
+++ b/static/skin/viewer.js
@@ -352,6 +352,10 @@ function linkShouldBeOpenedInANewWindow(linkElement, mouseEvent) {
       || mouseEvent.metaKey /* on Macs */;
 }
 
+function goingToOpenALinkToAnUndisplayableResource(url) {
+  return !navigator.pdfViewerEnabled && url.pathname.endsWith('.pdf');
+}
+
 function onClickEvent(e) {
   const iframeDocument = contentIframe.contentDocument;
   const target = matchingAncestorElement(e.target, iframeDocument, "a");
@@ -359,7 +363,8 @@ function onClickEvent(e) {
     const target_href = getRealHref(target);
     const target_url = new URL(target_href, iframeDocument.location);
     const isExternalAppUrl = urlMustBeHandledByAnExternalApp(target_url);
-    if ( isExternalAppUrl && !viewerSettings.linkBlockingEnabled ) {
+    if ( (isExternalAppUrl && !viewerSettings.linkBlockingEnabled)
+         || goingToOpenALinkToAnUndisplayableResource(target_url) ) {
         target.setAttribute("target", "_blank");
     }
 

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -75,7 +75,7 @@ const ResourceCollection resources200Compressible{
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/taskbar.css" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/taskbar.css?cacheid=80d56607" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/viewer.js" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=fdec37a7" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=787e61d4" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Poppins.ttf" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/fonts/Poppins.ttf?cacheid=af705837" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Roboto.ttf" },
@@ -327,7 +327,7 @@ R"EXPECTEDRESULT(    <link type="text/css" href="./skin/kiwix.css?cacheid=2158fa
     <script type="text/javascript" src="./skin/polyfills.js?cacheid=a0e0343d"></script>
     <script type="module" src="./skin/i18n.js?cacheid=071abc9a" defer></script>
     <script type="text/javascript" src="./skin/languages.js?cacheid=ee7d95b5" defer></script>
-    <script type="text/javascript" src="./skin/viewer.js?cacheid=fdec37a7" defer></script>
+    <script type="text/javascript" src="./skin/viewer.js?cacheid=787e61d4" defer></script>
     <script type="text/javascript" src="./skin/autoComplete/autoComplete.min.js?cacheid=1191aaaf"></script>
       const blankPageUrl = root + "/skin/blank.html?cacheid=6b1fa032";
           <label for="kiwix_button_show_toggle"><img src="./skin/caret.png?cacheid=22b942b4" alt=""></label>


### PR DESCRIPTION
Chrome on Android doesn't support displaying PDF documents inline so an attempt to load a PDF into the Kiwix viewer iframe fails in a way that may be confusing to the users. In such situations it is better to offer to the users to download the PDF file so that they can view it with a dedicated application. Making the link to open in a new tab/window achieves exactly that effect.

Fixes kiwix/kiwix-tools#670