### PR TITLE
Replace multiple comma-separated languages with 'mul'

### DIFF
--- a/src/html_dumper.cpp
+++ b/src/html_dumper.cpp
@@ -27,6 +27,30 @@ std::string humanFriendlyTitle(std::string title)
   return humanFriendlyString;
 }
 
+kainjow::mustache::object getLangTag(const std::vector<std::string>& bookLanguages) {
+  std::string langShortString = "";
+  std::string langFullString = "???";
+  
+  //if more than 1 languages then show "mul" else show the language
+  if(bookLanguages.size() > 1) {
+    std::vector<std::string> mulLanguages;
+    langShortString = "mul";
+    for (const auto& lang : bookLanguages) {
+      const std::string fullLang = getLanguageSelfName(lang);
+      mulLanguages.push_back(fullLang);
+    }
+    langFullString = kiwix::join(mulLanguages, ",");
+  } else if(bookLanguages.size() == 1) {
+    langShortString = bookLanguages[0];
+    langFullString = getLanguageSelfName(langShortString);
+  }
+  
+  kainjow::mustache::object langTag;
+    langTag["langShortString"] = langShortString;
+    langTag["langFullString"] = langFullString;
+  return langTag;
+}
+
 kainjow::mustache::list getTagList(std::string tags)
 {
   const auto tagsList = kiwix::split(tags, ";", true, false);
@@ -72,17 +96,16 @@ std::string HTMLDumper::dumpPlainHTML(kiwix::Filter filter) const
       contentId = urlEncode(nameMapper->getNameForId(bookId));
     } catch (...) {}
     const auto bookDescription = bookObj.getDescription();
-    const auto langCode = bookObj.getCommaSeparatedLanguages();
     const auto bookIconUrl = rootLocation + "/catalog/v2/illustration/" + bookId +  "/?size=48";
     const auto tags = bookObj.getTags();
     const auto downloadAvailable = (bookObj.getUrl() != "");
+    const auto langTagObj = getLangTag(bookObj.getLanguages());
     std::string faviconAttr = "style=background-image:url(" + bookIconUrl + ")";
-
     booksData.push_back(kainjow::mustache::object{
       {"id", contentId},
       {"title", bookTitle},
       {"description", bookDescription},
-      {"langCode", langCode},
+      {"langTag", langTagObj},
       {"faviconAttr", faviconAttr},
       {"tagList", getTagList(tags)},
       {"downloadAvailable", downloadAvailable}

--- a/src/tools/stringTools.h
+++ b/src/tools/stringTools.h
@@ -66,6 +66,9 @@ std::string ucAll(const std::string& word);
 std::string lcAll(const std::string& word);
 std::string ucFirst(const std::string& word);
 std::string lcFirst(const std::string& word);
+
+/* This function is broken, related Github issue 
+ * https://github.com/kiwix/libkiwix/issues/1188 */ 
 std::string toTitle(const std::string& word);
 
 std::string normalize(const std::string& word);

--- a/static/templates/no_js_library_page.html
+++ b/static/templates/no_js_library_page.html
@@ -118,7 +118,7 @@
             </div>
             </a>
             <div class="book__meta">
-              <div class="book__languageTag" {{languageAttr}}>{{langCode}}</div>
+              <div class="book__languageTag" title="{{langTag.langFullString}}" aria-label="{{langTag.langFullString}}">{{langTag.langShortString}}</div>
               <div class="book__tags"><div class="book__tags--wrapper">
                   {{#tagList}}
                   <span class="tag__link" aria-label='{{tag}}' title='{{tag}}'>{{tag}}</span>

--- a/test/library_server.cpp
+++ b/test/library_server.cpp
@@ -1251,7 +1251,7 @@ TEST_F(LibraryServerTest, no_name_mapper_catalog_v2_individual_entry_access)
   "            </div>\n" \
   "            </a>\n" \
   "            <div class=\"book__meta\">\n" \
-  "              <div class=\"book__languageTag\" >fra</div>\n" \
+  "              <div class=\"book__languageTag\" title=\"français\" aria-label=\"français\">fra</div>\n" \
   "              <div class=\"book__tags\"><div class=\"book__tags--wrapper\">\n" \
   "                  <span class=\"tag__link\" aria-label='unittest' title='unittest'>unittest</span>\n" \
   "                  <span class=\"tag__link\" aria-label='wikipedia' title='wikipedia'>wikipedia</span>\n" \
@@ -1278,7 +1278,7 @@ TEST_F(LibraryServerTest, no_name_mapper_catalog_v2_individual_entry_access)
   "            </div>\n" \
   "            </a>\n" \
   "            <div class=\"book__meta\">\n" \
-  "              <div class=\"book__languageTag\" >eng</div>\n" \
+  "              <div class=\"book__languageTag\" title=\"English\" aria-label=\"English\">eng</div>\n" \
   "              <div class=\"book__tags\"><div class=\"book__tags--wrapper\">\n" \
   "                  <span class=\"tag__link\" aria-label='public_tag_without_a_value' title='public_tag_without_a_value'>public_tag_without_a_value</span>\n" \
   "                  <span class=\"tag__link\" aria-label='wikipedia' title='wikipedia'>wikipedia</span>\n" \
@@ -1305,7 +1305,7 @@ TEST_F(LibraryServerTest, no_name_mapper_catalog_v2_individual_entry_access)
   "            </div>\n" \
   "            </a>\n" \
   "            <div class=\"book__meta\">\n" \
-  "              <div class=\"book__languageTag\" >rus,eng</div>\n" \
+  "              <div class=\"book__languageTag\" title=\"русский,English\" aria-label=\"русский,English\">mul</div>\n" \
   "              <div class=\"book__tags\"><div class=\"book__tags--wrapper\">\n" \
   "                  <span class=\"tag__link\" aria-label='public_tag_with_a_value:value_of_a_public_tag' title='public_tag_with_a_value:value_of_a_public_tag'>public_tag_with_a_value:value_of_a_public_tag</span>\n" \
   "                  <span class=\"tag__link\" aria-label='wikipedia' title='wikipedia'>wikipedia</span>\n" \


### PR DESCRIPTION
Fixes [#724](https://github.com/kiwix/kiwix-tools/issues/724)

- Refactored language code handling to replace multiple comma-separated values with 'mul'.
- Single-language entries remain unchanged.
- Improved consistency in language representation.

---

#### Testing


```
/usr/local/bin/kiwix-serve --port=8080 --library /tmp/zimlibrary/linux_library.xml
```

Used this command to start the server locally. I ensured that the ZIM library have at least one book with multiple language codes.
Please check the image below to verify that it's working fine.

![Screenshot 2025-02-23 002830](https://github.com/user-attachments/assets/4bb02459-bf2f-4e52-be77-d6265f0e2860)
![Screenshot 2025-02-23 002732](https://github.com/user-attachments/assets/1c9bf81a-520d-44d3-9d43-3cc48f874ad2)





