### PR TITLE
Fix Search Bar Placeholder Text Overflow.

### DIFF
--- a/static/skin/taskbar.css
+++ b/static/skin/taskbar.css
@@ -34,6 +34,12 @@
     width: 20em;
 }
 
+#kiwixsearchbox {
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+}
+
 #kiwix_serve_taskbar_home_button button {
     overflow: hidden;
     text-overflow: ellipsis;

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -75,7 +75,7 @@ const ResourceCollection resources200Compressible{
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/mustache.min.js" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/mustache.min.js?cacheid=bd23c4fb" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/taskbar.css" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/taskbar.css?cacheid=80d56607" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/taskbar.css?cacheid=42e90cb9" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/viewer.js" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=7f05bf6c" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Poppins.ttf" },
@@ -330,7 +330,7 @@ R"EXPECTEDRESULT(                  <img src="${root}/skin/download-white.svg?cac
     {
       /* url */ "/ROOT%23%3F/viewer",
 R"EXPECTEDRESULT(    <link type="text/css" href="./skin/kiwix.css?cacheid=3948b846" rel="Stylesheet" />
-    <link type="text/css" href="./skin/taskbar.css?cacheid=80d56607" rel="Stylesheet" />
+    <link type="text/css" href="./skin/taskbar.css?cacheid=42e90cb9" rel="Stylesheet" />
     <link type="text/css" href="./skin/autoComplete/css/autoComplete.css?cacheid=f2d376c4" rel="Stylesheet" />
     <script type="text/javascript" src="./skin/polyfills.js?cacheid=a0e0343d"></script>
     <script type="module" src="./skin/i18n.js?cacheid=e9a10ac1" defer></script>


### PR DESCRIPTION
Fixes #1184

This PR fixes the issue where the placeholder text in the search bar was overflowing beyond the input field’s width. The fix ensures that the placeholder text stays within the search bar.

**Screenshot including the fix:-**


![Screenshot 2025-03-06 at 1 09 14 AM](https://github.com/user-attachments/assets/bef27ef1-4a52-4c50-88aa-8e327827493e)
