### PR TITLE
favicon: improve PWA and cross-platform icon support

### DIFF
--- a/static/skin/favicon/site.webmanifest
+++ b/static/skin/favicon/site.webmanifest
@@ -1,19 +1,66 @@
 {
-    "name": "",
-    "short_name": "",
+    "name": "Kiwix",
+    "short_name": "Kiwix",
     "icons": [
+        {
+            "src": "favicon-16x16.png",
+            "sizes": "16x16",
+            "type": "image/png"
+        },
+        {
+            "src": "favicon-32x32.png",
+            "sizes": "32x32",
+            "type": "image/png"
+        },
+        {
+            "src": "mstile-70x70.png",
+            "sizes": "70x70",
+            "type": "image/png"
+        },
+        {
+            "src": "mstile-144x144.png",
+            "sizes": "144x144",
+            "type": "image/png"
+        },
+        {
+            "src": "mstile-150x150.png",
+            "sizes": "150x150",
+            "type": "image/png"
+        },
+        {
+            "src": "mstile-310x150.png",
+            "sizes": "310x150",
+            "type": "image/png"
+        },
+        {
+            "src": "mstile-310x310.png",
+            "sizes": "310x310",
+            "type": "image/png"
+        },
         {
             "src": "android-chrome-192x192.png",
             "sizes": "192x192",
-            "type": "image/png"
+            "type": "image/png",
+            "purpose": "any maskable"
         },
         {
             "src": "android-chrome-512x512.png",
             "sizes": "512x512",
+            "type": "image/png",
+            "purpose": "any maskable"
+        },
+        {
+            "src": "apple-touch-icon.png",
+            "sizes": "180x180",
             "type": "image/png"
         }
     ],
     "theme_color": "#ffffff",
     "background_color": "#ffffff",
-    "display": "standalone"
+    "display": "standalone",
+    "start_url": "/",
+    "description": "Kiwix lets you access free knowledge – even offline",
+    "orientation": "any",
+    "categories": ["education", "books", "reference"],
+    "lang": "en"
 }

--- a/static/templates/index.html
+++ b/static/templates/index.html
@@ -26,10 +26,13 @@
     <link rel="apple-touch-icon" sizes="180x180" href="{{root}}/skin/favicon/apple-touch-icon.png?KIWIXCACHEID">
     <link rel="icon" type="image/png" sizes="32x32" href="{{root}}/skin/favicon/favicon-32x32.png?KIWIXCACHEID">
     <link rel="icon" type="image/png" sizes="16x16" href="{{root}}/skin/favicon/favicon-16x16.png?KIWIXCACHEID">
-    <link rel="manifest" href="{{root}}/skin/favicon/site.webmanifest?KIWIXCACHEID">
+    <link rel="icon" type="image/png" sizes="192x192" href="{{root}}/skin/favicon/android-chrome-192x192.png?KIWIXCACHEID">
+    <link rel="icon" type="image/png" sizes="512x512" href="{{root}}/skin/favicon/android-chrome-512x512.png?KIWIXCACHEID">
+    <link rel="manifest" href="{{root}}/skin/favicon/site.webmanifest?KIWIXCACHEID" crossorigin="use-credentials" type="application/manifest+json">
     <link rel="mask-icon" href="{{root}}/skin/favicon/safari-pinned-tab.svg?KIWIXCACHEID" color="#5bbad5">
     <link rel="shortcut icon" href="{{root}}/skin/favicon/favicon.ico?KIWIXCACHEID">
     <meta name="msapplication-TileColor" content="#da532c">
+    <meta name="msapplication-TileImage" content="{{root}}/skin/favicon/mstile-144x144.png?KIWIXCACHEID">
     <meta name="msapplication-config" content="{{root}}/skin/favicon/browserconfig.xml?KIWIXCACHEID">
     <meta name="theme-color" content="#ffffff">
     <script type="text/javascript" src="./skin/polyfills.js?KIWIXCACHEID"></script>

--- a/static/templates/no_js_library_page.html
+++ b/static/templates/no_js_library_page.html
@@ -18,10 +18,13 @@
     <link rel="apple-touch-icon" sizes="180x180" href="{{root}}/skin/favicon/apple-touch-icon.png?KIWIXCACHEID">
     <link rel="icon" type="image/png" sizes="32x32" href="{{root}}/skin/favicon/favicon-32x32.png?KIWIXCACHEID">
     <link rel="icon" type="image/png" sizes="16x16" href="{{root}}/skin/favicon/favicon-16x16.png?KIWIXCACHEID">
-    <link rel="manifest" href="{{root}}/skin/favicon/site.webmanifest?KIWIXCACHEID">
+    <link rel="icon" type="image/png" sizes="192x192" href="{{root}}/skin/favicon/android-chrome-192x192.png?KIWIXCACHEID">
+    <link rel="icon" type="image/png" sizes="512x512" href="{{root}}/skin/favicon/android-chrome-512x512.png?KIWIXCACHEID">
+    <link rel="manifest" href="{{root}}/skin/favicon/site.webmanifest?KIWIXCACHEID" crossorigin="use-credentials" type="application/manifest+json">
     <link rel="mask-icon" href="{{root}}/skin/favicon/safari-pinned-tab.svg?KIWIXCACHEID" color="#5bbad5">
     <link rel="shortcut icon" href="{{root}}/skin/favicon/favicon.ico?KIWIXCACHEID">
     <meta name="msapplication-TileColor" content="#da532c">
+    <meta name="msapplication-TileImage" content="{{root}}/skin/favicon/mstile-144x144.png?KIWIXCACHEID">
     <meta name="msapplication-config" content="{{root}}/skin/favicon/browserconfig.xml?KIWIXCACHEID">
     <meta name="theme-color" content="#ffffff">
     <style>

--- a/test/library_server.cpp
+++ b/test/library_server.cpp
@@ -1200,10 +1200,13 @@ TEST_F(LibraryServerTest, no_name_mapper_catalog_v2_individual_entry_access)
   "    <link rel=\"apple-touch-icon\" sizes=\"180x180\" href=\"/ROOT%23%3F/skin/favicon/apple-touch-icon.png?cacheid=f86f8df3\">\n" \
   "    <link rel=\"icon\" type=\"image/png\" sizes=\"32x32\" href=\"/ROOT%23%3F/skin/favicon/favicon-32x32.png?cacheid=79ded625\">\n" \
   "    <link rel=\"icon\" type=\"image/png\" sizes=\"16x16\" href=\"/ROOT%23%3F/skin/favicon/favicon-16x16.png?cacheid=a986fedc\">\n" \
-  "    <link rel=\"manifest\" href=\"/ROOT%23%3F/skin/favicon/site.webmanifest?cacheid=bc396efb\">\n" \
+  "    <link rel=\"icon\" type=\"image/png\" sizes=\"192x192\" href=\"/ROOT%23%3F/skin/favicon/android-chrome-192x192.png?cacheid=bfac158b\">\n" \
+  "    <link rel=\"icon\" type=\"image/png\" sizes=\"512x512\" href=\"/ROOT%23%3F/skin/favicon/android-chrome-512x512.png?cacheid=380c3653\">\n" \
+  "    <link rel=\"manifest\" href=\"/ROOT%23%3F/skin/favicon/site.webmanifest?cacheid=4192804f\" crossorigin=\"use-credentials\" type=\"application/manifest+json\">\n" \
   "    <link rel=\"mask-icon\" href=\"/ROOT%23%3F/skin/favicon/safari-pinned-tab.svg?cacheid=8d487e95\" color=\"#5bbad5\">\n" \
   "    <link rel=\"shortcut icon\" href=\"/ROOT%23%3F/skin/favicon/favicon.ico?cacheid=92663314\">\n" \
   "    <meta name=\"msapplication-TileColor\" content=\"#da532c\">\n" \
+  "    <meta name=\"msapplication-TileImage\" content=\"/ROOT%23%3F/skin/favicon/mstile-144x144.png?cacheid=c25a7641\">\n" \
   "    <meta name=\"msapplication-config\" content=\"/ROOT%23%3F/skin/favicon/browserconfig.xml?cacheid=f29a7c4a\">\n" \
   "    <meta name=\"theme-color\" content=\"#ffffff\">\n" \
   "    <style>\n" \

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -88,6 +88,9 @@ const ResourceCollection resources200Compressible{
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/languages.js" },
   { STATIC_CONTENT, "/ROOT%23%3F/skin/languages.js?cacheid=a83f0e13" },
 
+  { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/favicon/site.webmanifest" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/favicon/site.webmanifest?cacheid=4192804f" },
+  
   { DYNAMIC_CONTENT, "/ROOT%23%3F/catalog/search" },
 
   { DYNAMIC_CONTENT, "/ROOT%23%3F/catalog/v2/root.xml" },
@@ -152,8 +155,6 @@ const ResourceCollection resources200Uncompressible{
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/favicon/mstile-70x70.png?cacheid=64ffd9dc" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/favicon/safari-pinned-tab.svg" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/favicon/safari-pinned-tab.svg?cacheid=8d487e95" },
-  { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/favicon/site.webmanifest" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/favicon/site.webmanifest?cacheid=bc396efb" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/hash.png" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/hash.png?cacheid=f836e872" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/magnet.png" },
@@ -293,9 +294,12 @@ R"EXPECTEDRESULT(      href="/ROOT%23%3F/skin/kiwix.css?cacheid=3948b846"
     <link rel="apple-touch-icon" sizes="180x180" href="/ROOT%23%3F/skin/favicon/apple-touch-icon.png?cacheid=f86f8df3">
     <link rel="icon" type="image/png" sizes="32x32" href="/ROOT%23%3F/skin/favicon/favicon-32x32.png?cacheid=79ded625">
     <link rel="icon" type="image/png" sizes="16x16" href="/ROOT%23%3F/skin/favicon/favicon-16x16.png?cacheid=a986fedc">
-    <link rel="manifest" href="/ROOT%23%3F/skin/favicon/site.webmanifest?cacheid=bc396efb">
+    <link rel="icon" type="image/png" sizes="192x192" href="/ROOT%23%3F/skin/favicon/android-chrome-192x192.png?cacheid=bfac158b">
+    <link rel="icon" type="image/png" sizes="512x512" href="/ROOT%23%3F/skin/favicon/android-chrome-512x512.png?cacheid=380c3653">
+    <link rel="manifest" href="/ROOT%23%3F/skin/favicon/site.webmanifest?cacheid=4192804f" crossorigin="use-credentials" type="application/manifest+json">
     <link rel="mask-icon" href="/ROOT%23%3F/skin/favicon/safari-pinned-tab.svg?cacheid=8d487e95" color="#5bbad5">
     <link rel="shortcut icon" href="/ROOT%23%3F/skin/favicon/favicon.ico?cacheid=92663314">
+    <meta name="msapplication-TileImage" content="/ROOT%23%3F/skin/favicon/mstile-144x144.png?cacheid=c25a7641">
     <meta name="msapplication-config" content="/ROOT%23%3F/skin/favicon/browserconfig.xml?cacheid=f29a7c4a">
     <script type="text/javascript" src="./skin/polyfills.js?cacheid=a0e0343d"></script>
     <script type="module" src="/ROOT%23%3F/skin/i18n.js?cacheid=e9a10ac1" defer></script>


### PR DESCRIPTION
Fixes: #1189

Add proper configuration for Progressive Web App (PWA) and platform-specific icons across the application. Changes include:

- Update site.webmanifest with correct icon purposes for PWA
- Add Android Chrome icons (192x192, 512x512) to HTML
- Add Windows tile image configuration
- Ensure consistency between JS and no-JS pages

This ensures proper icon display across all platforms while following platform-specific best practices for icon implementation.