### PR TITLE
Made atomics check work with old compilers

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -22,11 +22,11 @@ atomics_program = '''
 using namespace std;
 
 int main() {
-  volatile atomic_bool a_b = true;
-  volatile atomic_ullong a_ull = -1;
+  volatile atomic_bool a_b(true);
+  volatile atomic_ullong a_ull(-1);
   // Next two lines are to cover atomic<socket_t> from 'httplib.h'.
-  volatile atomic<uint32_t> a_u32 = -1;
-  volatile atomic<uint64_t> a_u64 = -1;
+  volatile atomic<uint32_t> a_u32(-1);
+  volatile atomic<uint64_t> a_u64(-1);
 
   return atomic_load(&a_b) == false && atomic_load(&a_ull) == 0 &&
     atomic_load(&a_u32) == 0 && atomic_load(&a_u64) == 0;


### PR DESCRIPTION
kiwix-build CI/CD [was broken on aarch64](https://github.com/kiwix/kiwix-build/actions/runs/12701564138/job/35406286679) by #1173 because gcc used for that platform is quite old (6.3.0) and it was confused by the code of the test program intended to find out if libatomics must be explicitly passed to the linker. The compiler was not happy with what it perceived as reliance on (deleted) copy constructor:

```
atomics_test.cpp:7:30: error: use of deleted function ‘std::atomic<bool>::atomic(const std::atomic<bool>&)’
   volatile atomic_bool a_b = true;
                              ^~~~
In file included from atomics_test.cpp:1:0:
.../aarch64/aarch64-linux-gnu/include/c++/6.3.0/atomic:66:5: note: declared here
     atomic(const atomic&) = delete;
     ^~~~~~
.../aarch64/aarch64-linux-gnu/include/c++/6.3.0/atomic:70:15: note:   after user-defined conversion: constexpr std::atomic<bool>::atomic(bool)
     constexpr atomic(bool __i) noexcept : _M_base(__i) { }
               ^~~~~~
```

This PR should fix that problem.