### PR TITLE
Upgraded Linux CI runner to ubuntu-22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
             coverage: false
     env:
       HOME: /home/runner
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
       image: "ghcr.io/kiwix/kiwix-build_ci_${{matrix.image_variant}}:38"
     steps:


### PR DESCRIPTION
We are quite late with this change and were simply forced to make it because ubuntu-20.04 has been phased out in GitHub Workflows (see, for example, the cancelled jobs in https://github.com/kiwix/libkiwix/actions/runs/14945523696?pr=1179).