### PR TITLE
Viewer chaperon mode

### DIFF
--- a/test/server.cpp
+++ b/test/server.cpp
@@ -77,7 +77,7 @@ const ResourceCollection resources200Compressible{
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/taskbar.css" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/taskbar.css?cacheid=42e90cb9" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/viewer.js" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=7f05bf6c" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=05ef466b" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Poppins.ttf" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/fonts/Poppins.ttf?cacheid=af705837" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Roboto.ttf" },
@@ -338,7 +338,7 @@ R"EXPECTEDRESULT(    <link type="text/css" href="./skin/kiwix.css?cacheid=b4e29e
     <script type="text/javascript" src="./skin/polyfills.js?cacheid=a0e0343d"></script>
     <script type="module" src="./skin/i18n.js?cacheid=e9a10ac1" defer></script>
     <script type="text/javascript" src="./skin/languages.js?cacheid=08955948" defer></script>
-    <script type="text/javascript" src="./skin/viewer.js?cacheid=7f05bf6c" defer></script>
+    <script type="text/javascript" src="./skin/viewer.js?cacheid=05ef466b" defer></script>
     <script type="text/javascript" src="./skin/autoComplete/autoComplete.min.js?cacheid=1191aaaf"></script>
       const blankPageUrl = root + "/skin/blank.html?cacheid=6b1fa032";
           <label for="kiwix_button_show_toggle"><img src="./skin/caret.png?cacheid=22b942b4" alt=""></label>


### PR DESCRIPTION
Fixes kiwix/kiwix-tools#591

Viewer now rewrites internal links so that opening them in a new tab/window keeps the viewer around. Thus the viewer acts as a chaperon for the users preventing them from finding themselves out of the viewer's supervision. Of course there are ways to circumvent such oversight, however it has always been the case with chaperons in all cultures in all epochs.

I seem to have ended up with a somewhat simpler solution than described in https://github.com/kiwix/kiwix-tools/issues/591#issuecomment-1525787724, however it should have [the same shortcomings](https://github.com/kiwix/kiwix-tools/issues/591#issuecomment-3057492750). In particular, the fix may have the following negative effects:

- link preview functionality (if the page contains such a feature) should be broken
- the fix may interfere with other click event handlers installed on internal links

Also note that this change hasn't been tested on
- ~Zimit 2 ZIM files (where wombat also meddles with the links)~ (it turns out that the potential problem with wombat is behind a barrier - warc2zim uses an iframe of its own, and this fix only goes after links in the top frame).
- the various scenarios with PDFs for which there have been a number of issues reported before
- ~links with non-empty fragment component (e.g. (`./otherpage#subsection1`)~ (any problems with `#anchor` links should be fixed by #1213)

Above list was compiled while considering potential negative effects of the fix and may be incomplete. Even after those scenarios are tested and any discovered problems happen to be easy to fix, there is still a possibility that this change introduces a regression on something else that was omitted from the analysis.

Therefore I propose to make this feature optional (controllable from the command line of `kiwix-serve`).