### PR TITLE
Viewer detects & tracks intrapage navigation too

### DIFF
--- a/static/skin/viewer.js
+++ b/static/skin/viewer.js
@@ -267,8 +267,15 @@ function translateErrorPageIfNeeded() {
   translatePageInWindow(contentIframe.contentWindow);
 }
 
+
+let iframeLocationHref = null;
+
 function handle_content_url_change() {
+  if ( iframeLocationHref == contentIframe.contentWindow.location.href )
+    return;
+
   const iframeLocation = contentIframe.contentWindow.location;
+  iframeLocationHref = iframeLocation.href;
   console.log('handle_content_url_change: ' + iframeLocation.href);
   document.title = contentIframe.contentDocument.title;
   const iframeContentUrl = iframeLocation.pathname + iframeLocation.hash;
@@ -432,9 +439,7 @@ function on_content_load() {
   contentIframe.classList.remove("hidden");
   loader.style.display = "none";
   contentIframe.contentWindow.onhashchange = handle_content_url_change;
-  if ( viewerSetupComplete ) {
-    handle_content_url_change();
-  }
+  setInterval(handle_content_url_change, 100);
   setup_chaperon_mode();
 }
 

--- a/static/skin/viewer.js
+++ b/static/skin/viewer.js
@@ -271,7 +271,7 @@ function handle_content_url_change() {
   const iframeLocation = contentIframe.contentWindow.location;
   console.log('handle_content_url_change: ' + iframeLocation.href);
   document.title = contentIframe.contentDocument.title;
-  const iframeContentUrl = iframeLocation.pathname;
+  const iframeContentUrl = iframeLocation.pathname + iframeLocation.hash;
   const iframeContentQuery = iframeLocation.search;
   const newHash = iframeUrl2UserUrl(iframeContentUrl, iframeContentQuery);
   history.replaceState(viewerState, null, makeURL(location.search, newHash));
@@ -431,6 +431,7 @@ function on_content_load() {
 
   contentIframe.classList.remove("hidden");
   loader.style.display = "none";
+  contentIframe.contentWindow.onhashchange = handle_content_url_change;
   if ( viewerSetupComplete ) {
     handle_content_url_change();
   }

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -77,7 +77,7 @@ const ResourceCollection resources200Compressible{
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/taskbar.css" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/taskbar.css?cacheid=42e90cb9" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/viewer.js" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=05ef466b" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=580d9826" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Poppins.ttf" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/fonts/Poppins.ttf?cacheid=af705837" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Roboto.ttf" },
@@ -338,7 +338,7 @@ R"EXPECTEDRESULT(    <link type="text/css" href="./skin/kiwix.css?cacheid=b4e29e
     <script type="text/javascript" src="./skin/polyfills.js?cacheid=a0e0343d"></script>
     <script type="module" src="./skin/i18n.js?cacheid=e9a10ac1" defer></script>
     <script type="text/javascript" src="./skin/languages.js?cacheid=08955948" defer></script>
-    <script type="text/javascript" src="./skin/viewer.js?cacheid=05ef466b" defer></script>
+    <script type="text/javascript" src="./skin/viewer.js?cacheid=580d9826" defer></script>
     <script type="text/javascript" src="./skin/autoComplete/autoComplete.min.js?cacheid=1191aaaf"></script>
       const blankPageUrl = root + "/skin/blank.html?cacheid=6b1fa032";
           <label for="kiwix_button_show_toggle"><img src="./skin/caret.png?cacheid=22b942b4" alt=""></label>

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -77,7 +77,7 @@ const ResourceCollection resources200Compressible{
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/taskbar.css" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/taskbar.css?cacheid=42e90cb9" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/viewer.js" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=580d9826" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=3208c3ed" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Poppins.ttf" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/fonts/Poppins.ttf?cacheid=af705837" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Roboto.ttf" },
@@ -338,7 +338,7 @@ R"EXPECTEDRESULT(    <link type="text/css" href="./skin/kiwix.css?cacheid=b4e29e
     <script type="text/javascript" src="./skin/polyfills.js?cacheid=a0e0343d"></script>
     <script type="module" src="./skin/i18n.js?cacheid=e9a10ac1" defer></script>
     <script type="text/javascript" src="./skin/languages.js?cacheid=08955948" defer></script>
-    <script type="text/javascript" src="./skin/viewer.js?cacheid=580d9826" defer></script>
+    <script type="text/javascript" src="./skin/viewer.js?cacheid=3208c3ed" defer></script>
     <script type="text/javascript" src="./skin/autoComplete/autoComplete.min.js?cacheid=1191aaaf"></script>
       const blankPageUrl = root + "/skin/blank.html?cacheid=6b1fa032";
           <label for="kiwix_button_show_toggle"><img src="./skin/caret.png?cacheid=22b942b4" alt=""></label>


### PR DESCRIPTION
Fixes #1120 

Clicking intrapage links (of the form `<a href="#anchor">`) inside the viewer iframe is detected by the viewer and reflected in the URL in the address bar.