### PR TITLE
Empty urlRootLocation doesn't disable book preview links

### DIFF
--- a/src/html_dumper.cpp
+++ b/src/html_dumper.cpp
@@ -130,7 +130,7 @@ std::string HTMLDumper::dumpPlainHTML(kiwix::Filter filter) const
              RESOURCE::templates::no_js_library_page_html,
              kainjow::mustache::object{
                {"root", rootLocation},
-               {"contentServerUrl", onlyAsNonEmptyMustacheValue(contentServerUrl)},
+               {"contentAccessUrl", onlyAsNonEmptyMustacheValue(contentAccessUrl)},
                {"books", booksData },
                {"searchQuery", searchQuery},
                {"languages", languages},

--- a/src/library_dumper.h
+++ b/src/library_dumper.h
@@ -51,11 +51,11 @@ class LibraryDumper
   void setRootLocation(const std::string& rootLocation) { this->rootLocation = rootLocation; }
 
   /**
-   * Set the URL of the content server.
+   * Set the URL for accessing book content
    *
-   * @param url the URL of the content server to use.
+   * @param url the URL of the /content endpoint of the content server
    */
-  void setContentServerUrl(const std::string& url) { this->contentServerUrl = url; }
+  void setContentAccessUrl(const std::string& url) { this->contentAccessUrl = url; }
 
   /**
    * Set some informations about the search results.
@@ -88,7 +88,7 @@ class LibraryDumper
   const kiwix::NameMapper* const nameMapper;
   std::string libraryId;
   std::string rootLocation;
-  std::string contentServerUrl;
+  std::string contentAccessUrl;
   std::string m_userLang;
   int m_totalResults;
   int m_startIndex;

--- a/src/opds_dumper.cpp
+++ b/src/opds_dumper.cpp
@@ -64,13 +64,13 @@ IllustrationInfo getBookIllustrationInfo(const Book& book)
 
 std::string fullEntryXML(const Book& book,
                          const std::string& rootLocation,
-                         const std::string& contentServerUrl,
+                         const std::string& contentAccessUrl,
                          const std::string& contentId)
 {
     const auto bookDate = book.getDate() + "T00:00:00Z";
     const kainjow::mustache::object data{
       {"root",  rootLocation},
-      {"contentServerUrl",  onlyAsNonEmptyMustacheValue(contentServerUrl)},
+      {"contentAccessUrl",  onlyAsNonEmptyMustacheValue(contentAccessUrl)},
       {"id", book.getId()},
       {"name", book.getName()},
       {"title", book.getTitle()},
@@ -111,7 +111,7 @@ BooksData getBooksData(const Library* library,
                        const NameMapper* nameMapper,
                        const std::vector<std::string>& bookIds,
                        const std::string& rootLocation,
-                       const std::string& contentServerUrl,
+                       const std::string& contentAccessUrl,
                        bool partial)
 {
   BooksData booksData;
@@ -121,7 +121,7 @@ BooksData getBooksData(const Library* library,
       const std::string contentId = nameMapper->getNameForId(bookId);
       const auto entryXML = partial
                           ? partialEntryXML(book, rootLocation)
-                          : fullEntryXML(book, rootLocation, contentServerUrl, contentId);
+                          : fullEntryXML(book, rootLocation, contentAccessUrl, contentId);
       booksData.push_back(kainjow::mustache::object{ {"entry", entryXML} });
     } catch ( const std::out_of_range& ) {
       // the book was removed from the library since its id was obtained
@@ -136,7 +136,7 @@ BooksData getBooksData(const Library* library,
 
 string OPDSDumper::dumpOPDSFeed(const std::vector<std::string>& bookIds, const std::string& query) const
 {
-  const auto booksData = getBooksData(library, nameMapper, bookIds, rootLocation, contentServerUrl, false);
+  const auto booksData = getBooksData(library, nameMapper, bookIds, rootLocation, contentAccessUrl, false);
   const kainjow::mustache::object template_data{
      {"date", gen_date_str()},
      {"root", rootLocation},
@@ -154,7 +154,7 @@ string OPDSDumper::dumpOPDSFeed(const std::vector<std::string>& bookIds, const s
 string OPDSDumper::dumpOPDSFeedV2(const std::vector<std::string>& bookIds, const std::string& query, bool partial) const
 {
   const auto endpointRoot = rootLocation + "/catalog/v2";
-  const auto booksData = getBooksData(library, nameMapper, bookIds, rootLocation, contentServerUrl, partial);
+  const auto booksData = getBooksData(library, nameMapper, bookIds, rootLocation, contentAccessUrl, partial);
 
   const char* const endpoint = partial ? "/partial_entries" : "/entries";
   const std::string url = endpoint + (query.empty() ? "" : "?" + query);
@@ -179,7 +179,7 @@ std::string OPDSDumper::dumpOPDSCompleteEntry(const std::string& bookId) const
   const std::string contentId = nameMapper->getNameForId(bookId);
   return XML_HEADER
          + "\n"
-         + fullEntryXML(book, rootLocation, contentServerUrl, contentId);
+         + fullEntryXML(book, rootLocation, contentAccessUrl, contentId);
 }
 
 std::string OPDSDumper::categoriesOPDSFeed() const

--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -858,9 +858,9 @@ std::unique_ptr<Response> InternalServer::handle_no_js(const RequestContext& req
   htmlDumper.setRootLocation(m_root);
   htmlDumper.setLibraryId(getLibraryId());
   if ( !m_contentServerUrl.empty() ) {
-    htmlDumper.setContentServerUrl(m_contentServerUrl + "/content");
+    htmlDumper.setContentAccessUrl(m_contentServerUrl + "/content");
   } else if ( !m_catalogOnlyMode ) {
-    htmlDumper.setContentServerUrl(m_root + "/content");
+    htmlDumper.setContentAccessUrl(m_root + "/content");
   }
   auto userLang = request.get_user_language();
   htmlDumper.setUserLanguage(userLang);

--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -858,9 +858,9 @@ std::unique_ptr<Response> InternalServer::handle_no_js(const RequestContext& req
   htmlDumper.setRootLocation(m_root);
   htmlDumper.setLibraryId(getLibraryId());
   if ( !m_contentServerUrl.empty() ) {
-    htmlDumper.setContentServerUrl(m_contentServerUrl);
+    htmlDumper.setContentServerUrl(m_contentServerUrl + "/content");
   } else if ( !m_catalogOnlyMode ) {
-    htmlDumper.setContentServerUrl(m_root);
+    htmlDumper.setContentServerUrl(m_root + "/content");
   }
   auto userLang = request.get_user_language();
   htmlDumper.setUserLanguage(userLang);

--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -850,6 +850,15 @@ std::string InternalServer::getNoJSDownloadPageHTML(const std::string& bookId, c
   );
 }
 
+void InternalServer::setContentAccessUrl(LibraryDumper& libDumper) const
+{
+  if ( !m_contentServerUrl.empty() ) {
+    libDumper.setContentAccessUrl(m_contentServerUrl + "/content");
+  } else if ( !m_catalogOnlyMode ) {
+    libDumper.setContentAccessUrl(m_root + "/content");
+  }
+}
+
 std::unique_ptr<Response> InternalServer::handle_no_js(const RequestContext& request)
 {
   const auto url = request.get_url();
@@ -857,11 +866,7 @@ std::unique_ptr<Response> InternalServer::handle_no_js(const RequestContext& req
   HTMLDumper htmlDumper(mp_library.get(), mp_nameMapper.get());
   htmlDumper.setRootLocation(m_root);
   htmlDumper.setLibraryId(getLibraryId());
-  if ( !m_contentServerUrl.empty() ) {
-    htmlDumper.setContentAccessUrl(m_contentServerUrl + "/content");
-  } else if ( !m_catalogOnlyMode ) {
-    htmlDumper.setContentAccessUrl(m_root + "/content");
-  }
+  setContentAccessUrl(htmlDumper);
   auto userLang = request.get_user_language();
   htmlDumper.setUserLanguage(userLang);
   std::string content;

--- a/src/server/internalServer.h
+++ b/src/server/internalServer.h
@@ -90,6 +90,7 @@ class SearchInfo {
 
 typedef kainjow::mustache::data MustacheData;
 class OPDSDumper;
+class LibraryDumper;
 
 class InternalServer {
   public:
@@ -163,6 +164,7 @@ class InternalServer {
 
     std::string getNoJSDownloadPageHTML(const std::string& bookId, const std::string& userLang) const;
     OPDSDumper getOPDSDumper() const;
+    void setContentAccessUrl(LibraryDumper& libDumper) const;
 
   private: // types
     class LockableSuggestionSearcher;

--- a/src/server/internalServer_catalog.cpp
+++ b/src/server/internalServer_catalog.cpp
@@ -56,11 +56,7 @@ OPDSDumper InternalServer::getOPDSDumper() const
   kiwix::OPDSDumper opdsDumper(mp_library.get(), mp_nameMapper.get());
   opdsDumper.setRootLocation(m_root);
   opdsDumper.setLibraryId(getLibraryId());
-  if ( !m_contentServerUrl.empty() ) {
-    opdsDumper.setContentAccessUrl(m_contentServerUrl + "/content");
-  } else if ( !m_catalogOnlyMode ) {
-    opdsDumper.setContentAccessUrl(m_root + "/content");
-  }
+  setContentAccessUrl(opdsDumper);
   return opdsDumper;
 }
 

--- a/src/server/internalServer_catalog.cpp
+++ b/src/server/internalServer_catalog.cpp
@@ -57,9 +57,9 @@ OPDSDumper InternalServer::getOPDSDumper() const
   opdsDumper.setRootLocation(m_root);
   opdsDumper.setLibraryId(getLibraryId());
   if ( !m_contentServerUrl.empty() ) {
-    opdsDumper.setContentServerUrl(m_contentServerUrl);
+    opdsDumper.setContentServerUrl(m_contentServerUrl + "/content");
   } else if ( !m_catalogOnlyMode ) {
-    opdsDumper.setContentServerUrl(m_root);
+    opdsDumper.setContentServerUrl(m_root + "/content");
   }
   return opdsDumper;
 }

--- a/src/server/internalServer_catalog.cpp
+++ b/src/server/internalServer_catalog.cpp
@@ -57,9 +57,9 @@ OPDSDumper InternalServer::getOPDSDumper() const
   opdsDumper.setRootLocation(m_root);
   opdsDumper.setLibraryId(getLibraryId());
   if ( !m_contentServerUrl.empty() ) {
-    opdsDumper.setContentServerUrl(m_contentServerUrl + "/content");
+    opdsDumper.setContentAccessUrl(m_contentServerUrl + "/content");
   } else if ( !m_catalogOnlyMode ) {
-    opdsDumper.setContentServerUrl(m_root + "/content");
+    opdsDumper.setContentAccessUrl(m_root + "/content");
   }
   return opdsDumper;
 }

--- a/static/templates/catalog_v2_entry.xml
+++ b/static/templates/catalog_v2_entry.xml
@@ -13,8 +13,8 @@
     {{#icons}}<link rel="http://opds-spec.org/image/thumbnail"
           href="{{root}}/catalog/v2/illustration/{{{id}}}/?size={{icon_size}}"
           type="{{icon_mimetype}};width={{icon_size}};height={{icon_size}};scale=1"/>
-    {{/icons}}{{#contentServerUrl}}<link type="text/html" href="{{contentServerUrl}}/{{{content_id}}}" />
-    {{/contentServerUrl}}
+    {{/icons}}{{#contentAccessUrl}}<link type="text/html" href="{{contentAccessUrl}}/{{{content_id}}}" />
+    {{/contentAccessUrl}}
     <author>
       <name>{{author_name}}</name>
     </author>

--- a/static/templates/catalog_v2_entry.xml
+++ b/static/templates/catalog_v2_entry.xml
@@ -13,7 +13,7 @@
     {{#icons}}<link rel="http://opds-spec.org/image/thumbnail"
           href="{{root}}/catalog/v2/illustration/{{{id}}}/?size={{icon_size}}"
           type="{{icon_mimetype}};width={{icon_size}};height={{icon_size}};scale=1"/>
-    {{/icons}}{{#contentServerUrl}}<link type="text/html" href="{{contentServerUrl}}/content/{{{content_id}}}" />
+    {{/icons}}{{#contentServerUrl}}<link type="text/html" href="{{contentServerUrl}}/{{{content_id}}}" />
     {{/contentServerUrl}}
     <author>
       <name>{{author_name}}</name>

--- a/static/templates/no_js_library_page.html
+++ b/static/templates/no_js_library_page.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <link type="root" href="{{root}}">
     <title>{{translations.welcome-to-kiwix-server}}</title>
     <link
       type="text/css"
@@ -108,7 +107,7 @@
         <h3 class="kiwixHomeBody__results">{{translations.count-of-matching-books}}</h3>
         {{#books}}
         <div class="book__wrapper">
-            {{#contentServerUrl}}<a class="book__link" href="{{contentServerUrl}}/content/{{id}}" title="{{translations.preview-book}}" aria-label="{{translations.preview-book}}">{{/contentServerUrl}}
+            {{#contentServerUrl}}<a class="book__link" href="{{contentServerUrl}}/{{id}}" title="{{translations.preview-book}}" aria-label="{{translations.preview-book}}">{{/contentServerUrl}}
             <div class="book__link__wrapper">
             <div class="book__icon" {{faviconAttr}}></div>
             <div class="book__header">

--- a/static/templates/no_js_library_page.html
+++ b/static/templates/no_js_library_page.html
@@ -107,7 +107,7 @@
         <h3 class="kiwixHomeBody__results">{{translations.count-of-matching-books}}</h3>
         {{#books}}
         <div class="book__wrapper">
-            {{#contentServerUrl}}<a class="book__link" href="{{contentServerUrl}}/{{id}}" title="{{translations.preview-book}}" aria-label="{{translations.preview-book}}">{{/contentServerUrl}}
+            {{#contentAccessUrl}}<a class="book__link" href="{{contentAccessUrl}}/{{id}}" title="{{translations.preview-book}}" aria-label="{{translations.preview-book}}">{{/contentAccessUrl}}
             <div class="book__link__wrapper">
             <div class="book__icon" {{faviconAttr}}></div>
             <div class="book__header">
@@ -115,7 +115,7 @@
             </div>
             <div class="book__description" title="{{description}}">{{description}}</div>
             </div>
-            {{#contentServerUrl}}</a>{{/contentServerUrl}}
+            {{#contentAccessUrl}}</a>{{/contentAccessUrl}}
             <div class="book__meta">
               <div class="book__languageTag" title="{{langTag.langFullString}}" aria-label="{{langTag.langFullString}}">{{langTag.langShortString}}</div>
               <div class="book__tags"><div class="book__tags--wrapper">


### PR DESCRIPTION
Fixes kiwix/kiwix-tools#761

In our testing we put more emphasis on non-empty `--urlRootLocation` setting of `kiwix-serve` (because forgetting to account for it has bean a reason for a couple of bug reports in the past). As a result #1219 broke the more important case of empty `urlRootLocation`. We don't recognize the right of that newborn bug for existence and/or reappearance. This PR is a proof that we not merely condemn the bug for having slipped into our code base, but are ready to take adequate measures to eliminate it.