### PR TITLE
Switched to the new illustrations API

### DIFF
--- a/src/book.cpp
+++ b/src/book.cpp
@@ -82,10 +82,11 @@ void Book::update(const zim::Archive& archive) {
   m_size = static_cast<uint64_t>(getArchiveFileSize(archive)) << 10;
 
   m_illustrations.clear();
-  for ( const auto illustrationSize : archive.getIllustrationSizes() ) {
+  for ( const auto& illustrationInfo : archive.getIllustrationInfos() ) {
     const auto illustration = std::make_shared<Illustration>();
-    const zim::Item illustrationItem = archive.getIllustrationItem(illustrationSize);
-    illustration->width = illustration->height = illustrationSize;
+    const zim::Item illustrationItem = archive.getIllustrationItem(illustrationInfo);
+    illustration->width = illustrationInfo.width;
+    illustration->height = illustrationInfo.height;
     illustration->mimeType = illustrationItem.getMimetype();
     illustration->data = illustrationItem.getData();
     // NOTE: illustration->url is left uninitialized


### PR DESCRIPTION
Fixes #1225

This PR only fixes the broken build of `libkiwix`. The illustration API enhancement in `libzim` isn't propagated to `libkiwix`.