### PR TITLE
Add support for accessing books using a metadata-based ID 

### DIFF
--- a/include/library.h
+++ b/include/library.h
@@ -79,6 +79,7 @@ class Filter {
     uint64_t activeFilters;
     Tags _acceptTags;
     Tags _rejectTags;
+    std::string _id;
     std::string _category;
     std::string _lang;
     std::string _publisher;
@@ -141,7 +142,7 @@ class Filter {
      *  which case a book in any of those languages will match).
      */
     Filter& lang(std::string lang);
-
+    Filter& id(std::string id);
     Filter& publisher(std::string publisher);
     Filter& creator(std::string creator);
     Filter& maxSize(size_t size);
@@ -154,7 +155,8 @@ class Filter {
     bool hasQuery() const;
     const std::string& getQuery() const { return _query; }
     bool queryIsPartial() const { return _queryIsPartial; }
-
+    bool hasId() const;
+    const std::string& getId() const { return _id; }
     bool hasName() const;
     const std::string& getName() const { return _name; }
 

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -686,7 +686,10 @@ Xapian::Query langQuery(const std::string& commaSeparatedLanguageList)
 {
   return multipleParamQuery(commaSeparatedLanguageList, "L");
 }
-
+Xapian::Query idQuery(const std::string& commaSeparatedIdList)
+{
+  return multipleParamQuery(commaSeparatedIdList, "Q");
+}
 Xapian::Query publisherQuery(const std::string& publisher)
 {
   Xapian::QueryParser queryParser;
@@ -742,6 +745,9 @@ Xapian::Query buildXapianQuery(const Filter& filter)
   }
   if ( filter.hasCreator() ) {
     q = Xapian::Query(Xapian::Query::OP_AND, q, creatorQuery(filter.getCreator()));
+  }
+  if (filter.hasId()) {
+    q = Xapian::Query(Xapian::Query::OP_AND, q, idQuery(filter.getId()));
   }
   if ( !filter.getAcceptTags().empty() || !filter.getRejectTags().empty() ) {
     const auto tq = tagsQuery(filter.getAcceptTags(), filter.getRejectTags());
@@ -897,6 +903,7 @@ enum filterTypes {
   NAME = FLAG(13),
   CATEGORY = FLAG(14),
   FLAVOUR = FLAG(15),
+  ID = FLAG(16)
 };
 
 Filter& Filter::local(bool accept)
@@ -962,7 +969,12 @@ Filter& Filter::lang(std::string lang)
   activeFilters |= LANG;
   return *this;
 }
-
+Filter& Filter::id(std::string id)
+{
+  _id = id;
+  activeFilters |= ID;
+  return *this;
+}
 Filter& Filter::publisher(std::string publisher)
 {
   _publisher = publisher;
@@ -1038,6 +1050,11 @@ bool Filter::hasCategory() const
 bool Filter::hasLang() const
 {
   return ACTIVE(LANG);
+}
+
+bool Filter::hasId() const
+{
+  return ACTIVE(ID);
 }
 
 bool Filter::hasPublisher() const

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -77,7 +77,7 @@ const ResourceCollection resources200Compressible{
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/taskbar.css" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/taskbar.css?cacheid=42e90cb9" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/viewer.js" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=3208c3ed" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=a754e1ec" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Poppins.ttf" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/fonts/Poppins.ttf?cacheid=af705837" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Roboto.ttf" },
@@ -242,7 +242,8 @@ TEST_F(ServerTest, 200)
 
 TEST_F(ServerTest, 200_IdNameMapper)
 {
-  EXPECT_EQ(404, zfs1_->GET("/ROOT%23%3F/content/6f1d19d0-633f-087b-fb55-7ac324ff9baf/A/index")->status);
+  //both uuid and name should work but after NO_NAME_MAPPER only uuid should work
+  EXPECT_EQ(200, zfs1_->GET("/ROOT%23%3F/content/6f1d19d0-633f-087b-fb55-7ac324ff9baf/A/index")->status);
   EXPECT_EQ(200, zfs1_->GET("/ROOT%23%3F/content/zimfile/A/index")->status);
   resetServer(ZimFileServer::NO_NAME_MAPPER);
   EXPECT_EQ(200, zfs1_->GET("/ROOT%23%3F/content/6f1d19d0-633f-087b-fb55-7ac324ff9baf/A/index")->status);
@@ -338,7 +339,7 @@ R"EXPECTEDRESULT(    <link type="text/css" href="./skin/kiwix.css?cacheid=b4e29e
     <script type="text/javascript" src="./skin/polyfills.js?cacheid=a0e0343d"></script>
     <script type="module" src="./skin/i18n.js?cacheid=e9a10ac1" defer></script>
     <script type="text/javascript" src="./skin/languages.js?cacheid=08955948" defer></script>
-    <script type="text/javascript" src="./skin/viewer.js?cacheid=3208c3ed" defer></script>
+    <script type="text/javascript" src="./skin/viewer.js?cacheid=a754e1ec" defer></script>
     <script type="text/javascript" src="./skin/autoComplete/autoComplete.min.js?cacheid=1191aaaf"></script>
       const blankPageUrl = root + "/skin/blank.html?cacheid=6b1fa032";
           <label for="kiwix_button_show_toggle"><img src="./skin/caret.png?cacheid=22b942b4" alt=""></label>


### PR DESCRIPTION
Fixes #1057 

Changes:
* Added a filter to the catalog endpoint catalog/v2/entries?id="id", allows to filter based on uuid
* On the viewer endpoint added a check if supplied arg looks like a uuid using [regex](https://stackoverflow.com/questions/136505/searching-for-uuids-in-text-with-regex) and then fetched the bookName from the catalog endpoint and kept the rest same after that.
* `handle_location_hash_change()`made async (I dont think it will but comments will be helpful)
* On the `/content` endpoint, same check as viewer endpoint to see if it looks like a uuid, but this endpoint was handled in the server so just used a function to convert id to name and name to id.

Please do tell if i missed something! I would love to rectify it.

Also i just wanted to ask if there is a reason why /viewer is handled in client-side js while /content on server-side? I am just a little curious.