### PR TITLE
Avoid interpretation of content coming from zim by mustache

### DIFF
--- a/static/templates/search_result.html
+++ b/static/templates/search_result.html
@@ -117,7 +117,7 @@
               {{title}}
             </a>
             {{#snippet}}
-              <cite>{{>snippet}}...</cite>
+              <cite>{{{snippet}}}...</cite>
             {{/snippet}}
             {{#bookInfo}}
               <div class="book-title">{{{bookInfo}}}</div>

--- a/static/templates/search_result.xml
+++ b/static/templates/search_result.xml
@@ -21,7 +21,7 @@
       <title>{{title}}</title>
       <link>{{absolutePath}}</link>
       {{#snippet}}
-        <description>{{>snippet}}...</description>
+        <description>{{{snippet}}}...</description>
       {{/snippet}}
       {{#bookTitle}}
         <book>


### PR DESCRIPTION
Fixes https://github.com/kiwix/kiwix-desktop/issues/1365

While reproducing please use superuser.com_en_all_2024-10.zim(2024 version not 2025)(present on  web.archive.org)
This crash occurs because mustache is interpreting {{ as a tag which is present in a answer to a question.
mustache does not have a built in thing to stop it from doing that
The solution is to replace {{>snippet}} to {{{snippet}}}.

{{> }} interprets the content and renders it (does no escaping)
https://mustache.github.io/mustache.5.html ( Please look at the example given in the partials section)
{{{ }}} does no escaping and just returns the raw content.

So there should be no inconveniences by changing them!