### PR TITLE
Fix for kiwix-serve --nosearchbar

### DIFF
--- a/static/skin/viewer.js
+++ b/static/skin/viewer.js
@@ -588,6 +588,7 @@ function setupViewer() {
 
   const kiwixToolBarWrapper = document.getElementById('kiwixtoolbarwrapper');
   if ( ! viewerSettings.toolbarEnabled ) {
+    finishViewerSetup();
     return;
   }
 
@@ -636,6 +637,11 @@ function updateUIText() {
 function finishViewerSetupOnceTranslationsAreLoaded()
 {
   updateUIText();
+  finishViewerSetup();
+}
+
+function finishViewerSetup()
+{
   handle_location_hash_change();
 
   window.onhashchange = handle_location_hash_change;

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -77,7 +77,7 @@ const ResourceCollection resources200Compressible{
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/taskbar.css" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/taskbar.css?cacheid=42e90cb9" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/viewer.js" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=914d363c" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=00e0fdf3" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Poppins.ttf" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/fonts/Poppins.ttf?cacheid=af705837" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Roboto.ttf" },
@@ -338,7 +338,7 @@ R"EXPECTEDRESULT(    <link type="text/css" href="./skin/kiwix.css?cacheid=b4e29e
     <script type="text/javascript" src="./skin/polyfills.js?cacheid=a0e0343d"></script>
     <script type="module" src="./skin/i18n.js?cacheid=e9a10ac1" defer></script>
     <script type="text/javascript" src="./skin/languages.js?cacheid=08955948" defer></script>
-    <script type="text/javascript" src="./skin/viewer.js?cacheid=914d363c" defer></script>
+    <script type="text/javascript" src="./skin/viewer.js?cacheid=00e0fdf3" defer></script>
     <script type="text/javascript" src="./skin/autoComplete/autoComplete.min.js?cacheid=1191aaaf"></script>
       const blankPageUrl = root + "/skin/blank.html?cacheid=6b1fa032";
           <label for="kiwix_button_show_toggle"><img src="./skin/caret.png?cacheid=22b942b4" alt=""></label>


### PR DESCRIPTION
Fixes kiwix/kiwix-tools#778

In `kiwix-serve --nosearchbar` mode the viewer is still engaged and its setup must completed appropriately, otherwise the content requested via the URL is not loaded.
