### PR TITLE
Carriage return after error

### DIFF
--- a/src/book.cpp
+++ b/src/book.cpp
@@ -242,7 +242,7 @@ const std::string& Book::Illustration::getData() const
       try {
         data = download(url);
       } catch(...) {
-        std::cerr << "Cannot download favicon from " << url;
+        std::cerr << "Cannot download favicon from " << url << std::endl;
       }
     }
   }


### PR DESCRIPTION
Otherwise I get all the error messages on one line, like here:
```
Cannot download favicon from https://opds.library.kiwix.org/catalog/v2/illustration/fa325c08-33ed-e28f-a31d-685efdfa1ae2/?size=48Cannot download favicon from https://opds.library.kiwix.org/catalog/v2/illustration/fa325c08-33ed-e28f-a31d-685efdfa1ae2/?size=48Cannot download favicon from https://opds.library.kiwix.org/catalog/v2/illustration/fa325c08-33ed-e28f-a31d-685efdfa1ae2/?size=48Cannot download favicon from https://opds.library.kiwix.org/catalog/v2/illustration/fa325c08-33ed-e28f-a31d-685efdfa1ae2/?size=48Cannot download favicon from https://opds.library.kiwix.org/catalog/v2/illustration/fa325c08-33ed-e28f-a31d-685efdfa1ae2/?size=48Cannot download favicon from https://opds.library.kiwix.org/catalog/v2/illustration/fa325c08-33ed-e28f-a31d-685efdfa1ae2/?size=48Cannot download favicon from https://opds.library.kiwix.org/catalog/v2/illustration/fa325c08-33ed-e28f-a31d-685efdfa1ae2/?size=48Cannot download favicon from https://opds.library.kiwix.org/catalog/v2/illustration/fa325c08-33ed-e28f-a31d-685efdfa1ae2/?size=48No text-to-speech plug-ins were found.
```