### PR TITLE
Kiwix Server OPDS feed links should not be paginated (with all results)

### DIFF
--- a/src/search_renderer.cpp
+++ b/src/search_renderer.cpp
@@ -121,9 +121,8 @@ kainjow::mustache::data buildQueryData
   query.set("pattern", kiwix::encodeDiples(pattern));
   std::ostringstream ss;
   ss << searchProtocolPrefix << "?pattern=" << urlEncode(pattern);
-  ss << "&" << bookQuery;
- // fixed the Issue #795: Force feed to return all items (no pagination)
-  query.set("unpaginatedQuery", ss.str() + "&count=-1");
+  ss << "&" << bookQuery << "&count=-1";
+  query.set("unpaginatedQuery", ss.str());
   auto lang = extractValueFromQuery(bookQuery, "books.filter.lang");
   if(!lang.empty()) {
     query.set("lang", lang);


### PR DESCRIPTION
Fixes kiwix/kiwix-tools#795.

This PR appends `&count=-1` to the unpaginated querystring in search_renderer.cpp. This ensures that Atom feeds return all items instead of the default page limit.