### PR TITLE
add-download-button-funtionality

### DIFF
--- a/static/resources_list.txt
+++ b/static/resources_list.txt
@@ -13,6 +13,7 @@ skin/search-icon.svg
 skin/iso6391To3.js
 skin/isotope.pkgd.min.js
 skin/index.js
+skin/lib.js
 skin/autoComplete/autoComplete.min.js
 skin/error.css
 skin/print.css

--- a/static/skin/index.js
+++ b/static/skin/index.js
@@ -688,6 +688,8 @@
         setInterval(updateNavVisibilityState, 250);
     };
 
+    window.getMagnetLink=getMagnetLink;
+    window.getFixedMirrorbrainMagnet=getFixedMirrorbrainMagnet;
     window.onload = () => { setUserLanguage(getUserLanguage(), onload); }
 })();
 

--- a/static/skin/index.js
+++ b/static/skin/index.js
@@ -139,9 +139,6 @@
         return spanElement.outerHTML;
     }
 
-    function downloadButtonText(zimSize) {
-      return $t("download") + (zimSize ? ` - ${zimSize}`: '');
-    }
 
     function downloadButtonHtml(url, zimSize) {
         return url
@@ -242,132 +239,6 @@
             footer.style.display = 'none';
             fadeOutDiv.style.display = 'block';
         }
-    }
-
-    function makeURLSearchString(params, keysToURIEncode) {
-        let output = '';
-        for (const [key, value] of params.entries()) {
-            let finalValue = (keysToURIEncode.indexOf(key) >= 0) ? encodeURIComponent(value) : value;
-            output += `&${key}=${finalValue}`;
-        }
-        // exclude first char so the first params are not prefixed with &
-        return output.substring(1);
-    }
-
-    /* hack for library.kiwix.org magnet links (created by MirrorBrain)
-        See https://github.com/kiwix/container-images/issues/242 */
-    async function getFixedMirrorbrainMagnet(magnetLink) {
-        // parse as query parameters
-        const params = new URLSearchParams(
-            magnetLink.replaceAll('&amp;', '&').replace(/^magnet:/, ''));
-
-        const zimUrl = params.get('as'); // as= is fallback URL
-        // download metalink to build list of mirrored URLs
-        let mirrorUrls = [];
-
-        const metalink = await fetch(`${zimUrl}.meta4`).then(response => {
-            return response.ok ? response.text() : '';
-        }).catch((_error) => '');
-        if (metalink) {
-            try {
-                const parser = new DOMParser();
-                const doc = parser.parseFromString(metalink, "application/xml");
-                doc.querySelectorAll("url").forEach((node) => {
-                    if (node.hasAttribute("priority")) { // ensures its a mirror link
-                        mirrorUrls.push(node.innerHTML);
-                    }
-                });
-            } catch (err) {
-                // not a big deal, magnet will only contain primary URL
-                console.debug(`Failed to parse mirror links for ${zimUrl}`);
-            }
-        }
-
-        // set webseed (ws=) URL to primary download URL (redirects to mirror)
-        params.set('ws', zimUrl);
-        // if we got metalink mirror URLs, append them all
-        if (mirrorUrls) {
-            mirrorUrls.forEach((url) => {
-                params.append('ws', url);
-            });
-        }
-
-        params.set('xs', `${zimUrl}.torrent`);  // adding xs= to point to torrent URL
-
-        return 'magnet:?' + makeURLSearchString(params, ['ws', 'as', 'dn', 'xs', 'tr']);
-    }
-
-    async function getMagnetLink(downloadLink) {
-        const magnetUrl = downloadLink + '.magnet';
-        const controller = new AbortController();
-        setTimeout(() => controller.abort(), 5000);
-        const magnetLink = await fetch(magnetUrl, { signal: controller.signal }).then(response => {
-            return response.ok ? response.text() : '';
-        }).catch((_error) => '');
-        if (magnetLink) {
-            return await getFixedMirrorbrainMagnet(magnetLink);
-        }
-        return magnetLink;
-    }
-
-    function insertModal(button) {
-        const downloadSize = button.getAttribute('data-size');
-        const downloadLink = button.getAttribute('data-link');
-        button.addEventListener('click', async (event) => {
-            event.preventDefault();
-            const magnetLink = await getMagnetLink(downloadLink);
-            document.body.insertAdjacentHTML('beforeend', `<div class="modal-wrapper">
-                <div class="modal">
-                    <div class="modal-heading">
-                        <div class="modal-title">
-                            <div>
-                                ${downloadButtonText(downloadSize)}
-                            </div>
-                        </div>
-                        <div onclick="closeModal()" class="modal-close-button">
-                            <div>
-                                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 14 14" fill="none">
-                                    <path fill-rule="evenodd" clip-rule="evenodd" d="M13.7071 1.70711C14.0976 1.31658 14.0976
-                                    0.683417 13.7071 0.292893C13.3166 -0.0976311 12.6834 -0.0976311 12.2929 0.292893L7 5.58579L1.70711
-                                    0.292893C1.31658 -0.0976311 0.683417 -0.0976311 0.292893 0.292893C-0.0976311 0.683417
-                                    -0.0976311 1.31658 0.292893 1.70711L5.58579 7L0.292893 12.2929C-0.0976311 12.6834
-                                    -0.0976311 13.3166 0.292893 13.7071C0.683417 14.0976 1.31658 14.0976 1.70711 13.7071L7
-                                    8.41421L12.2929 13.7071C12.6834 14.0976 13.3166 14.0976 13.7071 13.7071C14.0976 13.3166
-                                    14.0976 12.6834 13.7071 12.2929L8.41421 7L13.7071 1.70711Z" fill="black" />
-                                </svg>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="modal-content">
-                        <div class="modal-regular-download">
-                            <a href="${downloadLink}" download>
-                                <img src="${root}/skin/download.png?KIWIXCACHEID" alt="${$t("direct-download-alt-text")}" />
-                                <div>${$t("direct-download-link-text")}</div>
-                            </a>
-                        </div>
-                        <div class="modal-regular-download">
-                            <a href="${downloadLink}.sha256" download>
-                                <img src="${root}/skin/hash.png?KIWIXCACHEID" alt="${$t("hash-download-alt-text")}" />
-                                <div>${$t("hash-download-link-text")}</div>
-                            </a>
-                        </div>
-                        ${magnetLink ?
-                        `<div class="modal-regular-download">
-                            <a href="${magnetLink}" target="_blank">
-                                <img src="${root}/skin/magnet.png?KIWIXCACHEID" alt="${$t("magnet-alt-text")}" />
-                                <div>${$t("magnet-link-text")}</div>
-                            </a>
-                        </div>` : ``}
-                        <div class="modal-regular-download">
-                            <a href="${downloadLink}.torrent" download>
-                                <img src="${root}/skin/bittorrent.png?KIWIXCACHEID" alt="${$t("torrent-download-alt-text")}" />
-                                <div>${$t("torrent-download-link-text")}</div>
-                            </a>
-                        </div>
-                    </div>
-                </div>
-            </div>`);
-        })
     }
 
     async function getBookCount(query) {
@@ -687,9 +558,7 @@
         setCookie(filterCookieName, params.toString(), oneDayDelta);
         setInterval(updateNavVisibilityState, 250);
     };
-
-    window.getMagnetLink=getMagnetLink;
-    window.getFixedMirrorbrainMagnet=getFixedMirrorbrainMagnet;
+    
     window.onload = () => { setUserLanguage(getUserLanguage(), onload); }
 })();
 

--- a/static/skin/kiwix.css
+++ b/static/skin/kiwix.css
@@ -155,8 +155,6 @@ body {
 
 #uiDownloadButton{
   float: right;
-  cursor: pointer;
-  height: 24px;
   box-sizing: border-box !important;
   height: 30px !important;
   line-height: 20px !important;

--- a/static/skin/kiwix.css
+++ b/static/skin/kiwix.css
@@ -72,6 +72,7 @@ body {
     background-color: #f7f7f7;
     border: 1px solid #ececec;
     border-radius: 3px;
+    font-size: 14px;
 }
 
 .modal-heading {
@@ -100,6 +101,28 @@ body {
 
 .modal-content {
     padding: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    text-decoration: none;
+}
+
+.modal-content img{
+  height: 30px;
+  width: 30px;
+}
+ 
+.modal-content a{
+  display: flex;
+  align-items: center;
+  align-content: space-between;
+  gap: 15px;
+}
+
+.modal-content a div{
+  font-size: 16px;
+  text-decoration: none;
+  color: #444343;
 }
 
 #content_iframe {
@@ -128,6 +151,24 @@ body {
   float: right;
   cursor: pointer;
   height: 30px;
+}
+
+#uiDownloadButton{
+  float: right;
+  cursor: pointer;
+  height: 24px;
+  box-sizing: border-box !important;
+  height: 30px !important;
+  line-height: 20px !important;
+  margin-right: 5px !important;
+  padding: 2px 6px !important;
+  border: 1px solid #b5b2b2 !important;
+  border-radius: 3px !important;
+  background-color: #ededed !important;
+  font-weight: normal !important;
+  cursor: pointer !important;
+  font-size: 16px !important;
+  margin-bottom: -9px;
 }
 
 @keyframes spin {

--- a/static/skin/lib.js
+++ b/static/skin/lib.js
@@ -1,0 +1,153 @@
+function getRoot() {
+  const rootlink = document.querySelector("link[type='root']");
+  if (rootlink) {
+    return rootlink.getAttribute("href");
+  }
+  if (typeof getRootLocation === "function") {
+    return getRootLocation();
+  }
+  return "";
+}
+
+function closeModal() {
+  for (modal of document.getElementsByClassName("modal-wrapper")) {
+    if (modal.id == "uiLanguageSelector") {
+      window.modalUILanguageSelector.close();
+    } else {
+      modal.remove();
+    }
+  }
+}
+
+function makeURLSearchString(params, keysToURIEncode) {
+  let output = "";
+  for (const [key, value] of params.entries()) {
+    let finalValue =
+      keysToURIEncode.indexOf(key) >= 0 ? encodeURIComponent(value) : value;
+    output += `&${key}=${finalValue}`;
+  }
+  // exclude first char so the first params are not prefixed with &
+  return output.substring(1);
+}
+
+async function getMagnetLink(downloadLink) {
+  const magnetUrl = downloadLink + ".magnet";
+  const controller = new AbortController();
+  setTimeout(() => controller.abort(), 5000);
+  const magnetLink = await fetch(magnetUrl, { signal: controller.signal })
+    .then((response) => {
+      return response.ok ? response.text() : "";
+    })
+    .catch((_error) => "");
+  if (magnetLink) {
+    return await getFixedMirrorbrainMagnet(magnetLink);
+  }
+  return magnetLink;
+}
+
+function downloadButtonText(zimSize) {
+  return $t("download") + (zimSize ? ` - ${zimSize}` : "");
+}
+
+function insertModal(button) {
+  const root = getRoot();
+  const downloadSize = button.getAttribute("data-size");
+  const downloadLink = button.getAttribute("data-link");
+  button.addEventListener("click", async (event) => {
+    event.preventDefault();
+    const magnetLink = await getMagnetLink(downloadLink);
+    document.body.insertAdjacentHTML(
+      "beforeend",
+      `<div class="modal-wrapper">
+                <div class="modal">
+                    <div class="modal-heading">
+                        <div class="modal-title">
+                            <div>
+                                ${downloadButtonText(downloadSize)}
+                            </div>
+                        </div>
+                        <div onclick="closeModal()" class="modal-close-button">
+                            <div>
+                                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 14 14" fill="none">
+                                    <path fill-rule="evenodd" clip-rule="evenodd" d="M13.7071 1.70711C14.0976 1.31658 14.0976
+                                    0.683417 13.7071 0.292893C13.3166 -0.0976311 12.6834 -0.0976311 12.2929 0.292893L7 5.58579L1.70711
+                                    0.292893C1.31658 -0.0976311 0.683417 -0.0976311 0.292893 0.292893C-0.0976311 0.683417
+                                    -0.0976311 1.31658 0.292893 1.70711L5.58579 7L0.292893 12.2929C-0.0976311 12.6834
+                                    -0.0976311 13.3166 0.292893 13.7071C0.683417 14.0976 1.31658 14.0976 1.70711 13.7071L7
+                                    8.41421L12.2929 13.7071C12.6834 14.0976 13.3166 14.0976 13.7071 13.7071C14.0976 13.3166
+                                    14.0976 12.6834 13.7071 12.2929L8.41421 7L13.7071 1.70711Z" fill="black" />
+                                </svg>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="modal-content">
+                        <div class="modal-regular-download">
+                            <a href="${downloadLink}" download>
+                                <img src="${root}/skin/download.png?KIWIXCACHEID" alt="${$t("direct-download-alt-text")}" />
+                                <div>${$t("direct-download-link-text")}</div>
+                            </a>
+                        </div>
+                        <div class="modal-regular-download">
+                            <a href="${downloadLink}.sha256" download>
+                                <img src="${root}/skin/hash.png?KIWIXCACHEID" alt="${$t("hash-download-alt-text")}" />
+                                <div>${$t("hash-download-link-text")}</div>
+                            </a>
+                        </div>
+                        ${
+                          magnetLink
+                            ? `<div class="modal-regular-download">
+                            <a href="${magnetLink}" target="_blank">
+                                <img src="${root}/skin/magnet.png?KIWIXCACHEID" alt="${$t("magnet-alt-text")}" />
+                                <div>${$t("magnet-link-text")}</div>
+                            </a>
+                        </div>`
+                            : ``
+                        }
+                        <div class="modal-regular-download">
+                            <a href="${downloadLink}.torrent" download>
+                                <img src="${root}/skin/bittorrent.png?KIWIXCACHEID" alt="${$t("torrent-download-alt-text")}" />
+                                <div>${$t("torrent-download-link-text")}</div>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>`,
+    );
+  });
+}
+
+async function getFixedMirrorbrainMagnet(magnetLink) {
+  const params = new URLSearchParams(
+    magnetLink.replaceAll("&amp;", "&").replace(/^magnet:/, ""),
+  );
+  const zimUrl = params.get("as");
+  let mirrorUrls = [];
+  const metalink = await fetch(`${zimUrl}.meta4`)
+    .then((response) => {
+      return response.ok ? response.text() : "";
+    })
+    .catch((_error) => "");
+  if (metalink) {
+    try {
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(metalink, "application/xml");
+      doc.querySelectorAll("url").forEach((node) => {
+        if (node.hasAttribute("priority")) {
+          mirrorUrls.push(node.innerHTML);
+        }
+      });
+    } catch (err) {
+      console.debug(`Failed to parse mirror links for ${zimUrl}`);
+    }
+  }
+  params.set("ws", zimUrl);
+  if (mirrorUrls) {
+    mirrorUrls.forEach((url) => {
+      params.append("ws", url);
+    });
+  }
+  params.set("xs", `${zimUrl}.torrent`);
+  return (
+    "magnet:?" + makeURLSearchString(params, ["ws", "as", "dn", "xs", "tr"])
+  );
+}

--- a/static/skin/viewer.js
+++ b/static/skin/viewer.js
@@ -65,6 +65,81 @@ function gotoRandomPage() {
   gotoUrl(`/random?content=${currentBook}`);
 }
 
+function downloadCurrentBook() {
+  const downloadButton = document.getElementById("kiwix_serve_download_zimfile");
+  if (!downloadButton || !currentBook) {
+    return;
+  }
+  
+  const downloadLink = downloadButton.getAttribute('data-link');
+  if (!downloadLink) {
+    return;
+  }
+  const showModal = async () => {
+    let magnetLinkHTML = '';
+    try {
+      const magnetLink = await getMagnetLink(downloadLink);
+      if (magnetLink) {
+        magnetLinkHTML = `<div class="modal-regular-download">
+          <a href="${magnetLink}" target="_blank">
+            <img src="./skin/magnet.png?KIWIXCACHEID" alt="Magnet link" />
+            <div>Magnet Link</div>
+          </a>
+        </div>`;
+      }
+    } catch (e) {
+      console.log("Could not fetch magnet link");
+    }
+    
+    const modalHTML = `<div class="modal-wrapper">
+      <div class="modal">
+        <div class="modal-heading">
+          <div class="modal-title">
+            <div>Download</div>
+          </div>
+          <div onclick="closeModal()" class="modal-close-button">
+            <div>
+              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 14 14" fill="none">
+                <path fill-rule="evenodd" clip-rule="evenodd" d="M13.7071 1.70711C14.0976 1.31658 14.0976
+                  0.683417 13.7071 0.292893C13.3166 -0.0976311 12.6834 -0.0976311 12.2929 0.292893L7 5.58579L1.70711
+                  0.292893C1.31658 -0.0976311 0.683417 -0.0976311 0.292893 0.292893C-0.0976311 0.683417
+                 -0.0976311 1.31658 0.292893 1.70711L5.58579 7L0.292893 12.2929C-0.0976311 12.6834
+                 -0.0976311 13.3166 0.292893 13.7071C0.683417 14.0976 1.31658 14.0976 1.70711 13.7071L7
+                  8.41421L12.2929 13.7071C12.6834 14.0976 13.3166 14.0976 13.7071 13.7071C14.0976 13.3166
+                  14.0976 12.6834 13.7071 12.2929L8.41421 7L13.7071 1.70711Z" fill="black" />
+            </div>
+          </div>
+        </div>
+        <div class="modal-content">
+          <div class="modal-regular-download">
+            <a href="${downloadLink}" download>
+              <img src="./skin/download.png?KIWIXCACHEID" alt="Direct download" />
+              <div>Direct Download</div>
+            </a>
+          </div>
+          <div class="modal-regular-download">
+            <a href="${downloadLink}.sha256" download>
+              <img src="./skin/hash.png?KIWIXCACHEID" alt="SHA256 hash" />
+              <div>Download SHA256</div>
+            </a>
+          </div>
+          ${magnetLinkHTML}
+          <div class="modal-regular-download">
+            <a href="${downloadLink}.torrent" download>
+              <img src="./skin/bittorrent.png?KIWIXCACHEID" alt="Torrent download" />
+              <div>Download Torrent</div>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>`;
+    
+    document.body.insertAdjacentHTML('beforeend', modalHTML);
+  };
+  
+  showModal();
+}
+
 // URI-encodes only the specified special symbols (note, however, that '%' is
 // always considered a special symbol).
 function quasiUriEncode(s, specialSymbols) {
@@ -124,12 +199,27 @@ function setCurrentBook(book, title) {
   homeButton.innerHTML = `<button>${title}</button>`;
   bookUIGroup.style.display = 'inline';
   updateSearchBoxForBookChange();
+  updateDownloadButton(book);
+}
+
+function updateDownloadButton(book) {
+  const downloadButton = document.getElementById('kiwix_serve_download_zimfile');
+  if (downloadButton && book) {
+    const downloadLink = `${root}/download/${book}.zim`;
+    downloadButton.setAttribute('data-link', downloadLink);
+    downloadButton.style.display = 'inline-block';
+    downloadButton.style.cursor = 'pointer';
+  }
 }
 
 function noCurrentBook() {
   currentBook = null;
   currentBookTitle = null;
   bookUIGroup.style.display = 'none';
+  const downloadButton = document.getElementById('kiwix_serve_download_zimfile');
+  if (downloadButton) {
+    downloadButton.style.display = 'none';
+  }
   updateSearchBoxForBookChange();
 }
 

--- a/static/skin/viewer.js
+++ b/static/skin/viewer.js
@@ -65,80 +65,6 @@ function gotoRandomPage() {
   gotoUrl(`/random?content=${currentBook}`);
 }
 
-function downloadCurrentBook() {
-  const downloadButton = document.getElementById("kiwix_serve_download_zimfile");
-  if (!downloadButton || !currentBook) {
-    return;
-  }
-  
-  const downloadLink = downloadButton.getAttribute('data-link');
-  if (!downloadLink) {
-    return;
-  }
-  const showModal = async () => {
-    let magnetLinkHTML = '';
-    try {
-      const magnetLink = await getMagnetLink(downloadLink);
-      if (magnetLink) {
-        magnetLinkHTML = `<div class="modal-regular-download">
-          <a href="${magnetLink}" target="_blank">
-            <img src="./skin/magnet.png?KIWIXCACHEID" alt="Magnet link" />
-            <div>Magnet Link</div>
-          </a>
-        </div>`;
-      }
-    } catch (e) {
-      console.log("Could not fetch magnet link");
-    }
-    
-    const modalHTML = `<div class="modal-wrapper">
-      <div class="modal">
-        <div class="modal-heading">
-          <div class="modal-title">
-            <div>Download</div>
-          </div>
-          <div onclick="closeModal()" class="modal-close-button">
-            <div>
-              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 14 14" fill="none">
-                <path fill-rule="evenodd" clip-rule="evenodd" d="M13.7071 1.70711C14.0976 1.31658 14.0976
-                  0.683417 13.7071 0.292893C13.3166 -0.0976311 12.6834 -0.0976311 12.2929 0.292893L7 5.58579L1.70711
-                  0.292893C1.31658 -0.0976311 0.683417 -0.0976311 0.292893 0.292893C-0.0976311 0.683417
-                 -0.0976311 1.31658 0.292893 1.70711L5.58579 7L0.292893 12.2929C-0.0976311 12.6834
-                 -0.0976311 13.3166 0.292893 13.7071C0.683417 14.0976 1.31658 14.0976 1.70711 13.7071L7
-                  8.41421L12.2929 13.7071C12.6834 14.0976 13.3166 14.0976 13.7071 13.7071C14.0976 13.3166
-                  14.0976 12.6834 13.7071 12.2929L8.41421 7L13.7071 1.70711Z" fill="black" />
-            </div>
-          </div>
-        </div>
-        <div class="modal-content">
-          <div class="modal-regular-download">
-            <a href="${downloadLink}" download>
-              <img src="./skin/download.png?KIWIXCACHEID" alt="Direct download" />
-              <div>Direct Download</div>
-            </a>
-          </div>
-          <div class="modal-regular-download">
-            <a href="${downloadLink}.sha256" download>
-              <img src="./skin/hash.png?KIWIXCACHEID" alt="SHA256 hash" />
-              <div>Download SHA256</div>
-            </a>
-          </div>
-          ${magnetLinkHTML}
-          <div class="modal-regular-download">
-            <a href="${downloadLink}.torrent" download>
-              <img src="./skin/bittorrent.png?KIWIXCACHEID" alt="Torrent download" />
-              <div>Download Torrent</div>
-            </a>
-          </div>
-        </div>
-      </div>
-    </div>`;
-    
-    document.body.insertAdjacentHTML('beforeend', modalHTML);
-  };
-  
-  showModal();
-}
 
 // URI-encodes only the specified special symbols (note, however, that '%' is
 // always considered a special symbol).
@@ -202,13 +128,32 @@ function setCurrentBook(book, title) {
   updateDownloadButton(book);
 }
 
-function updateDownloadButton(book) {
+async function updateDownloadButton(book) {
   const downloadButton = document.getElementById('kiwix_serve_download_zimfile');
-  if (downloadButton && book) {
-    const downloadLink = `${root}/download/${book}.zim`;
+  if (!downloadButton) return;
+  if (!book) {
+    downloadButton.style.display = 'none';
+    return;
+  }
+
+  try{
+    const response= await fetch(`${root}/search?books.name=${book}&format=opds`);
+    const xml = await response.text();
+    const doc = new DOMParser().parseFromString(xml,'text/xml');
+    const downloadBookLink = doc.querySelector('link[type="application/x-zim"]');
+    if(!downloadBookLink){
+      downloadButton.style.display='none';
+      return;
+    }
+    const downloadLink = downloadBookLink.getAttribute('href').split('.meta4')[0];
+    const zimSize = parseInt(downloadBookLink.getAttribute('length'));
     downloadButton.setAttribute('data-link', downloadLink);
-    downloadButton.style.display = 'inline-block';
-    downloadButton.style.cursor = 'pointer';
+    downloadButton.setAttribute('data-size', zimSize);
+    downloadButton.style.display='inline';
+    downloadButton.style.cursor='pointer';
+    insertModal(downloadButton);
+  }  catch(e){
+    downloadButton.style.display='none';
   }
 }
 

--- a/static/templates/index.html
+++ b/static/templates/index.html
@@ -37,6 +37,7 @@
     <script type="text/javascript" src="{{root}}/skin/languages.js?KIWIXCACHEID" defer></script>
     <script src="{{root}}/skin/isotope.pkgd.min.js?KIWIXCACHEID" defer></script>
     <script src="{{root}}/skin/iso6391To3.js?KIWIXCACHEID"></script>
+    <script type="text/javascript" src="{{root}}/skin/lib.js?KIWIXCACHEID" defer></script>
     <script type="text/javascript" src="{{root}}/skin/index.js?KIWIXCACHEID" defer></script>
   </head>
   <body>
@@ -106,15 +107,4 @@
     <div class="loader" style="position: absolute; top: 50%"><div class="loader-spinner"></div></div>
     <div id="kiwixfooter" class="kiwixfooter">Powered by&nbsp;<a href="https://kiwix.org">Kiwix</a></div>
   </body>
-  <script>
-    function closeModal() {
-      for(modal of document.getElementsByClassName('modal-wrapper')) {
-        if ( modal.id == "uiLanguageSelector" ) {
-          window.modalUILanguageSelector.close();
-        } else {
-          modal.remove();
-        }
-      }
-    }
-  </script>
 </html>

--- a/static/viewer.html
+++ b/static/viewer.html
@@ -16,6 +16,7 @@
     <script type="text/javascript" src="./viewer_settings.js"></script>
     <script type="module" src="./skin/i18n.js?KIWIXCACHEID" defer></script>
     <script type="text/javascript" src="./skin/languages.js?KIWIXCACHEID" defer></script>
+    <script type="text/javascript" src="./skin/index.js" defer></script>
     <script type="text/javascript" src="./skin/viewer.js?KIWIXCACHEID" defer></script>
     <script type="text/javascript" src="./skin/autoComplete/autoComplete.min.js?KIWIXCACHEID"></script>
     <script>
@@ -71,6 +72,14 @@
                 <button>&#x1F3B2;</button>
               </a>
             </span>
+            <a id="kiwix_serve_download_zimfile"
+                 onclick="downloadCurrentBook()"
+                 title="Download the current zim file"
+                 accesskey="d"
+                 aria-label="Download the current zim file">
+                 <img id="uiDownloadButton"
+                 src="./skin/download.png?KIWIXCACHEID">
+              </a>
           </div>
         </div>
         <a onclick="window.modalUILanguageSelector.show()"
@@ -91,6 +100,15 @@
     </iframe>
 
     <script>
+      function closeModal() {
+      for(modal of document.getElementsByClassName('modal-wrapper')) {
+        if ( modal.id == "uiLanguageSelector" ) {
+          window.modalUILanguageSelector.close();
+        } else {
+          modal.remove();
+        }
+      }
+    }
     </script>
   </body>
 </html>

--- a/static/viewer.html
+++ b/static/viewer.html
@@ -16,7 +16,7 @@
     <script type="text/javascript" src="./viewer_settings.js"></script>
     <script type="module" src="./skin/i18n.js?KIWIXCACHEID" defer></script>
     <script type="text/javascript" src="./skin/languages.js?KIWIXCACHEID" defer></script>
-    <script type="text/javascript" src="./skin/index.js" defer></script>
+    <script type="text/javascript" src="./skin/lib.js?KIWIXCACHEID" defer></script>
     <script type="text/javascript" src="./skin/viewer.js?KIWIXCACHEID" defer></script>
     <script type="text/javascript" src="./skin/autoComplete/autoComplete.min.js?KIWIXCACHEID"></script>
     <script>
@@ -73,13 +73,12 @@
               </a>
             </span>
             <a id="kiwix_serve_download_zimfile"
-                 onclick="downloadCurrentBook()"
                  title="Download the current zim file"
                  accesskey="d"
                  aria-label="Download the current zim file">
                  <img id="uiDownloadButton"
                  src="./skin/download.png?KIWIXCACHEID">
-              </a>
+            </a>
           </div>
         </div>
         <a onclick="window.modalUILanguageSelector.show()"
@@ -99,16 +98,5 @@
             style="border:0px">
     </iframe>
 
-    <script>
-      function closeModal() {
-      for(modal of document.getElementsByClassName('modal-wrapper')) {
-        if ( modal.id == "uiLanguageSelector" ) {
-          window.modalUILanguageSelector.close();
-        } else {
-          modal.remove();
-        }
-      }
-    }
-    </script>
   </body>
 </html>

--- a/test/library_server.cpp
+++ b/test/library_server.cpp
@@ -1280,7 +1280,7 @@ TEST_F(LibraryServerTest, no_name_mapper_catalog_v2_individual_entry_access)
   "    <title>Welcome to Kiwix Server</title>\n" \
   "    <link\n" \
   "      type=\"text/css\"\n" \
-  "      href=\"/ROOT%23%3F/skin/kiwix.css?cacheid=b4e29e64\"\n" \
+  "      href=\"/ROOT%23%3F/skin/kiwix.css?cacheid=a9bdf3b4\"\n" \
   "      rel=\"Stylesheet\"\n" \
   "    />\n" \
   "    <link\n" \

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -67,19 +67,21 @@ const ResourceCollection resources200Compressible{
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/index.css" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/index.css?cacheid=ae79e41a" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/index.js" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/index.js?cacheid=e3305ca0" },
+  { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/lib.js" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/index.js?cacheid=0e7b39fa" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/lib.js?cacheid=0ac345f5" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/iso6391To3.js" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/iso6391To3.js?cacheid=ecde2bb3" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/isotope.pkgd.min.js" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/isotope.pkgd.min.js?cacheid=2e48d392" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/kiwix.css" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/kiwix.css?cacheid=b4e29e64" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/kiwix.css?cacheid=a9bdf3b4" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/mustache.min.js" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/mustache.min.js?cacheid=bd23c4fb" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/taskbar.css" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/taskbar.css?cacheid=42e90cb9" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/viewer.js" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=6192cae1" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=79a93e72" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Poppins.ttf" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/fonts/Poppins.ttf?cacheid=af705837" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Roboto.ttf" },
@@ -292,7 +294,7 @@ TEST_F(ServerTest, CacheIdsOfStaticResources)
   const std::vector<UrlAndExpectedResult> testData{
     {
       /* url */ "/ROOT%23%3F/",
-R"EXPECTEDRESULT(      href="/ROOT%23%3F/skin/kiwix.css?cacheid=b4e29e64"
+R"EXPECTEDRESULT(      href="/ROOT%23%3F/skin/kiwix.css?cacheid=a9bdf3b4"
       href="/ROOT%23%3F/skin/index.css?cacheid=ae79e41a"
     <link rel="apple-touch-icon" sizes="180x180" href="/ROOT%23%3F/skin/favicon/apple-touch-icon.png?cacheid=f86f8df3">
     <link rel="icon" type="image/png" sizes="32x32" href="/ROOT%23%3F/skin/favicon/favicon-32x32.png?cacheid=79ded625">
@@ -306,7 +308,8 @@ R"EXPECTEDRESULT(      href="/ROOT%23%3F/skin/kiwix.css?cacheid=b4e29e64"
     <script type="text/javascript" src="/ROOT%23%3F/skin/languages.js?cacheid=d2d6933b" defer></script>
     <script src="/ROOT%23%3F/skin/isotope.pkgd.min.js?cacheid=2e48d392" defer></script>
     <script src="/ROOT%23%3F/skin/iso6391To3.js?cacheid=ecde2bb3"></script>
-    <script type="text/javascript" src="/ROOT%23%3F/skin/index.js?cacheid=e3305ca0" defer></script>
+    <script type="text/javascript" src="/ROOT%23%3F/skin/lib.js?cacheid=0ac345f5" defer></script>
+    <script type="text/javascript" src="/ROOT%23%3F/skin/index.js?cacheid=0e7b39fa" defer></script>
         <img src="/ROOT%23%3F/skin/feed.svg?cacheid=055b333f"
         <img src="/ROOT%23%3F/skin/langSelector.svg?cacheid=00b59961"
 )EXPECTEDRESULT"
@@ -325,25 +328,31 @@ R"EXPECTEDRESULT(    background-image: url('../skin/search-icon.svg?cacheid=b10a
     {
       /* url */ "/ROOT%23%3F/skin/index.js",
 R"EXPECTEDRESULT(                  <img src="${root}/skin/download-white.svg?cacheid=079ab989">
-                                <img src="${root}/skin/download.png?cacheid=a39aa502" alt="${$t("direct-download-alt-text")}" />
+)EXPECTEDRESULT"
+    },
+    {
+  /* url */ "/ROOT%23%3F/skin/lib.js",
+R"EXPECTEDRESULT(                                <img src="${root}/skin/download.png?cacheid=a39aa502" alt="${$t("direct-download-alt-text")}" />
                                 <img src="${root}/skin/hash.png?cacheid=f836e872" alt="${$t("hash-download-alt-text")}" />
                                 <img src="${root}/skin/magnet.png?cacheid=73b6bddf" alt="${$t("magnet-alt-text")}" />
                                 <img src="${root}/skin/bittorrent.png?cacheid=4f5c6882" alt="${$t("torrent-download-alt-text")}" />
 )EXPECTEDRESULT"
     },
-    {
+    { 
       /* url */ "/ROOT%23%3F/viewer",
-R"EXPECTEDRESULT(    <link type="text/css" href="./skin/kiwix.css?cacheid=b4e29e64" rel="Stylesheet" />
+R"EXPECTEDRESULT(    <link type="text/css" href="./skin/kiwix.css?cacheid=a9bdf3b4" rel="Stylesheet" />
     <link type="text/css" href="./skin/taskbar.css?cacheid=42e90cb9" rel="Stylesheet" />
     <link type="text/css" href="./skin/autoComplete/css/autoComplete.css?cacheid=f2d376c4" rel="Stylesheet" />
     <link type="text/css" href="./skin/print.css?cacheid=65b1c1d2" media="print" rel="Stylesheet" />
     <script type="text/javascript" src="./skin/polyfills.js?cacheid=a0e0343d"></script>
     <script type="module" src="./skin/i18n.js?cacheid=e9a10ac1" defer></script>
     <script type="text/javascript" src="./skin/languages.js?cacheid=d2d6933b" defer></script>
-    <script type="text/javascript" src="./skin/viewer.js?cacheid=6192cae1" defer></script>
+    <script type="text/javascript" src="./skin/lib.js?cacheid=0ac345f5" defer></script>
+    <script type="text/javascript" src="./skin/viewer.js?cacheid=79a93e72" defer></script>
     <script type="text/javascript" src="./skin/autoComplete/autoComplete.min.js?cacheid=1191aaaf"></script>
       const blankPageUrl = root + "/skin/blank.html?cacheid=6b1fa032";
           <label for="kiwix_button_show_toggle"><img src="./skin/caret.png?cacheid=22b942b4" alt=""></label>
+                 src="./skin/download.png?cacheid=a39aa502">
                src="./skin/langSelector.svg?cacheid=00b59961">
             src="./skin/blank.html?cacheid=6b1fa032" title="ZIM content" width="100%"
 )EXPECTEDRESULT"
@@ -591,6 +600,8 @@ TEST_F(ServerTest, MimeTypes)
     { "/skin/blank.html",                  "text/html" },
     { "/skin/index.css",                   "text/css" },
     { "/skin/index.js",                    "application/javascript" },
+    { "/skin/lib.js",                      "application/javascript" },
+    { "/skin/lib.js",                      "application/javascript" },
     { "/catalog/root.xml",                 "application/atom+xml;profile=opds-catalog;kind=acquisition;charset=utf-8" },
     { "/catalog/v2/searchdescription.xml", "application/opensearchdescription+xml" },
     { "/catalog/v2/root.xml",              "application/atom+xml;profile=opds-catalog;kind=navigation;charset=utf-8" },


### PR DESCRIPTION
fixes #1083

This PR adds a download button to the preview page on library.kiwix.org making it making it easier for users to directly download the ZIM file they are currently viewing without navigating away or searching for the download link.

**Changes Implemented**

- Added the download button to the UI.
<img width="1796" height="270" alt="Screenshot from 2026-02-17 22-31-29" src="https://github.com/user-attachments/assets/5649cd3c-4d21-4289-86cf-8c9f086fcc35" />

- also added the modal box which appears when the user clicks on the download button, with different ways to download.
<img width="1784" height="772" alt="image" src="https://github.com/user-attachments/assets/8fa0d563-fd38-44cd-84bc-3c0a81167d6c" />
