### PR TITLE
Made kiwix-serve friendly to IPv4-only systems 

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ import os
 # -- Project information -----------------------------------------------------
 
 project = 'libkiwix'
-copyright = '2022, libkiwix-team'
+copyright = '2026, libkiwix-team'
 author = 'libkiwix-team'
 
 

--- a/include/common.h
+++ b/include/common.h
@@ -14,12 +14,43 @@
 #endif
 
 
-namespace kiwix {
+namespace kiwix
+{
 
-enum class IpMode { IPV4, IPV6, ALL, AUTO }; // AUTO: Server decides the protocol
+/**
+ * `IpMode` is used to [configure](@ref Server::setIpMode()) a `Server` object
+ * to listen for incoming connections not on a single IP address but on all
+ * addresses of the specified family.
+ */
+enum class IpMode
+{
+  /**
+   * Listen on all IPv4 addresses.
+   */
+  IPV4,
+
+  /**
+   * Listen on all IPv6 addresses.
+   */
+  IPV6,
+
+  /**
+   * Listen on all available addresses.
+   */
+  ALL,
+
+  /**
+   * `IpMode::AUTO` (which is the default) must be used when an explicit
+   * (non-empty) IP address for listening is provided via
+   * `Server::setAddress()`. If no such address is enforced, then
+   * `IpMode::AUTO` is equivalent to `IpMode::ALL`.
+   */
+  AUTO
+};
+
 typedef zim::size_type size_type;
 typedef zim::offset_type offset_type;
 
-}
+} // namespace kiwix
 
 #endif //_KIWIX_COMMON_H_

--- a/include/server.h
+++ b/include/server.h
@@ -42,7 +42,7 @@ namespace kiwix
        virtual ~Server();
 
        /**
-        * Serve the content.
+        * Start serving the content.
         */
        bool start();
 
@@ -51,9 +51,27 @@ namespace kiwix
         */
        void stop();
 
+       /**
+        * Set the path of the root URL served by this server instance.
+        */
        void setRoot(const std::string& root);
+
+       /**
+        * Set the IP address on which to listen for incoming connections.
+        *
+        * Specifying a non-empty IP address requires that the IpMode is
+        * [set](@ref setIpMode()) to `IpMode::AUTO` (which is the default).
+        * Otherwise, [starting](@ref start()) the server will fail.
+        */
        void setAddress(const std::string& addr);
+
+       /**
+        * Set the port on which to listen for incoming connections.
+        *
+        * Default port is 80, but using it requires special privileges.
+        */
        void setPort(int port) { m_port = port; }
+
        void setNbThreads(int threads) { m_nbThreads = threads; }
        void setMultiZimSearchLimit(unsigned int limit) { m_multizimSearchLimit = limit; }
        void setIpConnectionLimit(int limit) { m_ipConnectionLimit = limit; }
@@ -65,10 +83,50 @@ namespace kiwix
         { m_blockExternalLinks = blockExternalLinks; }
        void setCatalogOnlyMode(bool enable) { m_catalogOnlyMode = enable; }
        void setContentServerUrl(std::string url) { m_contentServerUrl = url; }
+
+       /**
+        * Listen for incoming connections on all IP addresses of the specified
+        * IP protocol family.
+        */
        void setIpMode(IpMode mode) { m_ipMode = mode; }
+
+       /**
+        * Get the port on which the server listens for incoming connections
+        */
        int getPort() const;
+
+       /**
+        * Get the IPv4 and/or IPv6 address(es) on which the server can be
+        * contacted.
+        *
+        * The server may actually be listening on other IP addresses as well
+        * (see `setIpMode()`).  The IP address(es) returned by this method
+        * represent the best-guess public IP address(es) accessible by the
+        * broadest set of clients.
+        */
        IpAddress getAddress() const;
+
+       /**
+        * Get the effective IpMode used by this server.
+        *
+        * The returned value may be different from the one configured via
+        * `setIpMode()`, since the server is expected to adjust to the
+        * constraints of the environment (e.g. `IpMode::ALL` can be converted
+        * to `IpMode::IPV4` on a system that does not support IPv6).
+        */
        IpMode getIpMode() const;
+
+       /**
+        * Get the list of HTTP URLs through which the server can be contacted.
+        *
+        * Each URL is composed of an IP address and optional port and includes
+        * the [root](@ref setRoot()) path component.
+        *
+        * In the current implementation at most 2 URLs may be returned - one
+        * for IPv4 and another for IPv6 protocol (whichever is available), as
+        * returned by `getAddress()`. Note, however, that the server may be
+        * also accessible via other IP-addresses/URLs (see `setIpMode()`).
+        */
        std::vector<std::string> getServerAccessUrls() const;
 
      protected:

--- a/include/tools.h
+++ b/include/tools.h
@@ -29,10 +29,13 @@
 namespace kiwix
 {
 
+/**
+ * An IPv4 and/or IPv6 address.
+ */
 struct IpAddress
 {
-    std::string addr;  // IPv4 address
-    std::string addr6; // IPv6 address
+    std::string addr;  /**< IPv4 address */
+    std::string addr6; /**< IPv6 address */
 };
 
 typedef std::pair<std::string, std::string> LangNameCodePair;
@@ -263,7 +266,7 @@ std::string getLanguageSelfName(const std::string& lang);
  * Slugifies the filename by converting any characters reserved by the operating
  * system to '_'. Note filename is only the file name and not a path.
  *
- * @param filename Valid UTF-8 encoded file name string. 
+ * @param filename Valid UTF-8 encoded file name string.
  * @return slugified string.
  */
 std::string getSlugifiedFileName(const std::string& filename);

--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -118,10 +118,19 @@ public: // functions
     v6.sin6_port   = htons(port);
   }
 
-  void setAnyAddress()
+  IpAddress setAnyAddress(IpMode ipMode)
   {
     v6.sin6_addr = in6addr_any;
     v4.sin_addr.s_addr = htonl(INADDR_ANY);
+
+    IpAddress a = kiwix::getBestPublicIps();
+    if (ipMode == IpMode::IPV6) {
+      a.addr = "";
+    } else if (ipMode == IpMode::IPV4) {
+      a.addr6 = "";
+    }
+
+    return a;
   }
 
   IpMode setAddress(const IpAddress& a)
@@ -527,10 +536,7 @@ void InternalServer::startMHD() {
   InSockAddr inSockAddr(m_port);
   if (m_addr.addr.empty() && m_addr.addr6.empty()) { // No ip address provided
     if (m_ipMode == IpMode::AUTO) m_ipMode = IpMode::ALL;
-    inSockAddr.setAnyAddress();
-    IpAddress bestIps = kiwix::getBestPublicIps();
-    if (m_ipMode == IpMode::IPV4 || m_ipMode == IpMode::ALL) m_addr.addr = bestIps.addr;
-    if (m_ipMode == IpMode::IPV6 || m_ipMode == IpMode::ALL) m_addr.addr6 = bestIps.addr6;
+    m_addr = inSockAddr.setAnyAddress(m_ipMode);
   } else {
     if (m_ipMode != kiwix::IpMode::AUTO) {
       error("When an IP address is provided the IP mode must not be set");

--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -519,7 +519,7 @@ bool InternalServer::start() {
                             MHD_OPTION_PER_IP_CONNECTION_LIMIT, m_ipConnectionLimit,
                             MHD_OPTION_END);
   if (mp_daemon == nullptr) {
-    std::cerr << "Unable to instantiate the HTTP daemon. The port " << m_port
+    std::cerr << "ERROR: Unable to instantiate the HTTP daemon. The port " << m_port
               << " is maybe already occupied or need more permissions to be open. "
                  "Please try as root or with a port number higher or equal to 1024."
               << std::endl;

--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -450,7 +450,7 @@ InternalServer::InternalServer(LibraryPtr library,
 
 InternalServer::~InternalServer() = default;
 
-bool InternalServer::start() {
+bool InternalServer::startMHD() {
 #ifdef _WIN32
   int flags = MHD_USE_SELECT_INTERNALLY;
 #else
@@ -525,6 +525,14 @@ bool InternalServer::start() {
               << std::endl;
     return false;
   }
+  return true;
+}
+
+bool InternalServer::start() {
+  if ( !startMHD() ) {
+    return false;
+  }
+
   auto server_start_time = std::chrono::system_clock::now().time_since_epoch();
   m_server_id = kiwix::to_string(server_start_time.count());
   return true;

--- a/src/server/internalServer.h
+++ b/src/server/internalServer.h
@@ -126,7 +126,7 @@ class InternalServer {
     IpMode getIpMode() const { return m_ipMode; }
 
   private: // functions
-    bool startMHD();
+    void startMHD();
     std::unique_ptr<Response> handle_request(const RequestContext& request);
     std::unique_ptr<Response> build_redirect(const std::string& bookName, const zim::Item& item) const;
     std::unique_ptr<Response> build_homepage(const RequestContext& request);

--- a/src/server/internalServer.h
+++ b/src/server/internalServer.h
@@ -126,6 +126,7 @@ class InternalServer {
     IpMode getIpMode() const { return m_ipMode; }
 
   private: // functions
+    bool startMHD();
     std::unique_ptr<Response> handle_request(const RequestContext& request);
     std::unique_ptr<Response> build_redirect(const std::string& bookName, const zim::Item& item) const;
     std::unique_ptr<Response> build_homepage(const RequestContext& request);

--- a/src/server/internalServer.h
+++ b/src/server/internalServer.h
@@ -127,6 +127,7 @@ class InternalServer {
 
   private: // functions
     void startMHD();
+    struct MHD_Daemon* startMHD(int flags, struct sockaddr* sockaddr);
     std::unique_ptr<Response> handle_request(const RequestContext& request);
     std::unique_ptr<Response> build_redirect(const std::string& bookName, const zim::Item& item) const;
     std::unique_ptr<Response> build_homepage(const RequestContext& request);

--- a/test/name_mapper.cpp
+++ b/test/name_mapper.cpp
@@ -2,6 +2,9 @@
 
 #include "../include/library.h"
 #include "../include/manager.h"
+#include "testing_tools.h"
+using namespace kiwix::testing;
+
 #include "gtest/gtest.h"
 
 namespace
@@ -56,27 +59,6 @@ class NameMapperTest : public ::testing::Test {
   }
 
   std::shared_ptr<kiwix::Library> lib;
-};
-
-class CapturedStderr
-{
-  std::ostringstream buffer;
-  std::streambuf* const sbuf;
-public:
-  CapturedStderr()
-    : sbuf(std::cerr.rdbuf())
-  {
-    std::cerr.rdbuf(buffer.rdbuf());
-  }
-
-  CapturedStderr(const CapturedStderr&) = delete;
-
-  ~CapturedStderr()
-  {
-    std::cerr.rdbuf(sbuf);
-  }
-
-  operator std::string() const { return buffer.str(); }
 };
 
 #if _WIN32

--- a/test/testing_tools.h
+++ b/test/testing_tools.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 Veloman Yunkan
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU  General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+#ifndef LIBKIWIX_TESTING_TOOLS_H
+#define LIBKIWIX_TESTING_TOOLS_H
+
+#include <sstream>
+#include <iostream>
+
+namespace kiwix
+{
+
+namespace testing
+{
+
+class CapturedStderr
+{
+  std::ostringstream buffer;
+  std::streambuf* const sbuf;
+public:
+  CapturedStderr()
+    : sbuf(std::cerr.rdbuf())
+  {
+    std::cerr.rdbuf(buffer.rdbuf());
+  }
+
+  CapturedStderr(const CapturedStderr&) = delete;
+
+  ~CapturedStderr()
+  {
+    std::cerr.rdbuf(sbuf);
+  }
+
+  operator std::string() const { return buffer.str(); }
+};
+
+} // namespace testing
+
+} // namespace kiwix
+
+#endif // LIBKIWIX_TESTING_TOOLS_H


### PR DESCRIPTION
Fixes kiwix/kiwix-tools#806

The PR mostly consists of adding test-cases for errors reported by the `kiwix::InternalServer::start()` method and refactoring/clean-up of the latter. The fix itself is in the last commit and is quite small. Note however that the situation described in kiwix/kiwix-tools#806 is not unit-tested. The fix was manually validated in a virtual machine. 

As a result of this fix, the semantics of the [`-i all`](https://kiwix-tools.readthedocs.io/en/latest/kiwix-serve.html#cmdoption-i) mode of `kiwix-serve` has undergone a subtle change, which is, however, within the slight slack of interpretation that was already there. Previously, that mode was implied to mean "listen on both IPv4 **and** IPv6". Now it means "listen on all IP protocols that are available".