### PR TITLE
Optimized removeAccents() for ASCII-only input

### DIFF
--- a/src/tools/stringTools.cpp
+++ b/src/tools/stringTools.cpp
@@ -35,6 +35,28 @@
 #include <iomanip>
 #include <regex>
 
+namespace
+{
+
+bool isAsciiOnly(const std::string& s)
+{
+  for ( const unsigned char c : s ) {
+    if ( c >= 128 )
+      return false;
+  }
+  return true;
+}
+
+std::string asciiToLower(std::string s)
+{
+    std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) {
+        return ('A' <= c && c <= 'Z') ? c - ('Z' - 'z') : c;
+        });
+    return s;
+}
+
+} // unnamed namespace
+
 /* tell ICU where to find its dat file (tables) */
 void kiwix::loadICUExternalTables()
 {
@@ -71,6 +93,9 @@ std::string kiwix::ICULanguageInfo::selfName() const
 
 std::string kiwix::removeAccents(const std::string& text)
 {
+  if ( isAsciiOnly(text) )
+    return asciiToLower(text);
+
   loadICUExternalTables();
   ucnv_setDefaultName("UTF-8");
   UErrorCode status = U_ZERO_ERROR;
@@ -448,7 +473,7 @@ std::string kiwix::getSlugifiedFileName(const std::string& filename)
 #else
   const std::regex reservedCharsReg("/");
 #endif
-  return std::regex_replace(filename, reservedCharsReg, "_"); 
+  return std::regex_replace(filename, reservedCharsReg, "_");
 }
 
 std::string kiwix::trim(const std::string& s)

--- a/test/stringTools.cpp
+++ b/test/stringTools.cpp
@@ -196,4 +196,35 @@ TEST(stringTools, Trim)
     EXPECT_EQ(kiwix::trim("\t abc123 \n"), "abc123");
 }
 
-};
+TEST(stringTools, removeAccents)
+{
+    EXPECT_EQ(kiwix::removeAccents(""), "");
+
+    EXPECT_EQ(kiwix::removeAccents("qwertyuiop[]\\"), "qwertyuiop[]\\");
+    EXPECT_EQ(kiwix::removeAccents("asdfghjkl;'"),    "asdfghjkl;'");
+    EXPECT_EQ(kiwix::removeAccents("zxcvbnm,./"),     "zxcvbnm,./");
+    EXPECT_EQ(kiwix::removeAccents("`1234567890-="),  "`1234567890-=");
+
+    // Surprise! removeAccents() changes case to lower
+    EXPECT_EQ(kiwix::removeAccents("QWERTYUIOP{}|"), "qwertyuiop{}|");
+    EXPECT_EQ(kiwix::removeAccents("ASDFGHJKL:\""),    "asdfghjkl:\"");
+    EXPECT_EQ(kiwix::removeAccents("ZXCVBNM<>?"),     "zxcvbnm<>?");
+    EXPECT_EQ(kiwix::removeAccents("~!@#$%^&*()_+"),  "~!@#$%^&*()_+");
+
+    // removeAccents() removes diacritics (while also changing case)
+    EXPECT_EQ(kiwix::removeAccents("åçêȟïñöş"), "acehinos");
+    EXPECT_EQ(kiwix::removeAccents("ÅÇÊȞÏÑÖŞ"), "acehinos");
+
+    // removeAccents() doesn't mess with certain letters of European scripts
+    EXPECT_EQ(kiwix::removeAccents("ßæœøł"), "ßæœøł");
+
+    // Case is changed for non-ASCII letters too
+    EXPECT_EQ(kiwix::removeAccents("ÆŒØŁΓΦΣԱԲԳДЖИ"),  "æœøłγφσաբգджи");
+
+    // removeAccents() doesn't mess with symbols derived from Latin letters
+    EXPECT_EQ(kiwix::removeAccents("$¢"), "$¢");
+
+    EXPECT_EQ(kiwix::removeAccents("Mïß Ůñîvèrsé"), "miß universe");
+}
+
+} // unnamed namespace


### PR DESCRIPTION
Quick fix for #1275

Since most of the strings passed to `removeAccents()` while loading the current Kiwix online library and populating the in-memory Xapian database of book metadata are ASCII-only, it makes sense to bypass expensive ICU transliteration on such input.

The optimization results in ~3X speedup (down from ~9.8 seconds to ~3.3 seconds) of starting `kiwix-serve` in catalog-only mode using https://download.kiwix.org/library/library_zim.xml (which as of this writing contains 3444 entries and weighs 19MiB). Such testing doesn't exactly reproduce the flow reported in the mentioned ticket where the input data for library initialization comes from an OPDS feed but the effect should be the same. 