### PR TITLE
aria2: increase curl timeout

### DIFF
--- a/src/aria2.cpp
+++ b/src/aria2.cpp
@@ -120,7 +120,7 @@ Aria2::Aria2(std::string sessionFileDir):
   curl_easy_setopt(p_curl, CURLOPT_PORT, m_port);
   curl_easy_setopt(p_curl, CURLOPT_POST, 1L);
   curl_easy_setopt(p_curl, CURLOPT_ERRORBUFFER, curlErrorBuffer);
-  curl_easy_setopt(p_curl, CURLOPT_TIMEOUT_MS, 100);
+  curl_easy_setopt(p_curl, CURLOPT_TIMEOUT_MS, 1000);
 
   typedef std::chrono::duration<double> Seconds;
 


### PR DESCRIPTION
The starting of aria2c is rather fragile as it depends on quite short fixed timeouts, and because kiwix-desktop cannot recover when it fails.

When this happens, it leads to "Cannot connect to aria2c rpc" when launching kiwix-desktop.

The waiting time has already been increased in the past to try to make it more robust:
https://github.com/kiwix/libkiwix/pull/1169

However, curl also has its own internal timeout that is currently shorter than MAX_WAITING_TIME_SECONDS. As a result when aria2 is a bit slow to start (on older systems for example), curl currently times out after 100ms, but we wait for 1 second regardless until we report the issue. The resulting curl error in that case is: "Connection timed out after 100 milliseconds"

As a quick fix to avoid having to change too much of the implementation, just increase curl's timeout to match MAX_WAITING_TIME_SECONDS.