### PR TITLE
Add TOC feature to Kiwix Server

### DIFF
--- a/static/skin/i18n/en.json
+++ b/static/skin/i18n/en.json
@@ -95,4 +95,5 @@
 	, "book-category.wiktionary": "Wiktionary"
 	, "book-category.other": "Other"
 	, "text-loading-content": "Loading Content"
+	, "table-of-content-button-text": "View table of contents"
 }

--- a/static/skin/i18n/qqq.json
+++ b/static/skin/i18n/qqq.json
@@ -97,5 +97,6 @@
 	"book-category.wikivoyage": "Name for the category of Wikivoyage books",
 	"book-category.wiktionary": "Name for the category of Wiktionary books",
 	"book-category.other": "Books not belonging to any special category are listed under this one",
-	"text-loading-content": "Text displayed while content is being loaded"
+	"text-loading-content": "Text displayed while content is being loaded",
+	"table-of-content-button-text": "Tooltip of the button toggling table of content"
 }

--- a/static/skin/kiwix.css
+++ b/static/skin/kiwix.css
@@ -14,6 +14,8 @@ body {
     position: relative;
     box-sizing: border-box;
     background: #ffffff;
+    --kiwix-content-offset-top: 0px;
+    --kiwix-toc-width: 28rem;
 }
 
 .loader {
@@ -143,4 +145,143 @@ body {
 @font-face {
   font-family: "roboto";
   src: url("../skin/fonts/Roboto.ttf?KIWIXCACHEID") format("truetype");
+}
+
+.button-disabled {
+  background-color: #ddd;
+  color: #808080;
+  pointer-events: none;
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+#kiwix_serve_taskbar_toc_button.button-disabled {
+  pointer-events: none;
+}
+
+#kiwix_serve_taskbar_toc_button.button-disabled button {
+  background-color: #ddd !important;
+  color: #808080 !important;
+}
+
+#kiwix_toc_backdrop {
+  position: fixed;
+  z-index: 98;
+  inset: var(--kiwix-content-offset-top) 0 0 0;
+  background-color: rgba(17, 24, 39, 0.32);
+  opacity: 1;
+  transition: opacity 0.2s ease, visibility 0.2s ease;
+}
+
+#kiwix_toc_panel {
+  position: fixed;
+  z-index: 99;
+  left: 0;
+  top: var(--kiwix-content-offset-top);
+  width: min(var(--kiwix-toc-width), calc(100vw - 2rem));
+  height: calc(100vh - var(--kiwix-content-offset-top));
+  overflow-y: auto;
+  background-color: #f7f7f7;
+  border-right: 1px solid #d7d7d7;
+  box-shadow: 0 14px 32px rgba(15, 23, 42, 0.18);
+  padding: 1.2rem 0;
+  opacity: 1;
+  transform: translateX(0);
+  transition: transform 0.2s ease, opacity 0.2s ease, visibility 0.2s ease;
+}
+
+#kiwix_toc_backdrop.hidden,
+#kiwix_toc_panel.hidden {
+  visibility: hidden;
+  opacity: 0;
+  pointer-events: none;
+}
+
+#kiwix_toc_panel.hidden {
+  transform: translateX(calc(-100% - 1rem));
+}
+
+#kiwix_toc_list {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+}
+
+.kiwix_toc_item {
+  font-family: roboto, sans-serif;
+}
+
+.kiwix_toc_item a {
+  display: block;
+  text-decoration: none;
+  color: #222;
+  border-left: 3px solid transparent;
+  line-height: 1.4;
+  padding: 0.8rem 1.8rem;
+}
+
+.kiwix_toc_item a:hover,
+.kiwix_toc_item a:focus {
+  background-color: #ebf7fb;
+  border-left-color: #00b4e4;
+  outline: none;
+}
+
+.kiwix_toc_item .toc-level-h1 {
+  font-size: 2rem;
+  font-weight: 600;
+}
+
+.kiwix_toc_item .toc-level-h2 {
+  font-size: 1.4rem;
+  font-weight: 600;
+}
+
+.kiwix_toc_item .toc-level-h3 {
+  color: #4d4d4d;
+  font-size: 1.3rem;
+  padding-left: 3.4rem;
+}
+
+body.kiwix_toc_docked #kiwix_toc_backdrop {
+  display: none;
+}
+
+body.kiwix_toc_docked #kiwix_toc_panel {
+  width: var(--kiwix-toc-width);
+  box-shadow: none;
+}
+
+body.kiwix_toc_docked #kiwix_toc_panel.hidden {
+  transform: translateX(calc(-100% - 1rem));
+}
+
+body.kiwix_toc_docked #content_iframe {
+  margin-left: var(--kiwix-toc-width);
+  width: calc(100% - var(--kiwix-toc-width));
+}
+
+body.kiwix_toc_docked #content_iframe.kiwix_toc_panel_hidden {
+  margin-left: 0;
+  width: 100%;
+}
+
+@media (max-width: 767px) {
+  #kiwix_toc_panel {
+    width: 100vw;
+    border-right: 0;
+  }
+}
+
+@media print {
+  #kiwix_toc_backdrop,
+  #kiwix_toc_panel {
+    display: none !important;
+  }
+
+  body.kiwix_toc_docked #content_iframe,
+  body.kiwix_toc_docked #content_iframe.kiwix_toc_panel_hidden {
+    margin-left: 0 !important;
+    width: 100% !important;
+  }
 }

--- a/static/skin/viewer.js
+++ b/static/skin/viewer.js
@@ -124,6 +124,7 @@ function setCurrentBook(book, title) {
   homeButton.innerHTML = `<button>${title}</button>`;
   bookUIGroup.style.display = 'inline';
   updateSearchBoxForBookChange();
+  syncTocUI();
 }
 
 function noCurrentBook() {
@@ -131,6 +132,7 @@ function noCurrentBook() {
   currentBookTitle = null;
   bookUIGroup.style.display = 'none';
   updateSearchBoxForBookChange();
+  syncTocUI();
 }
 
 function updateCurrentBookIfNeeded(userUrl) {
@@ -233,6 +235,13 @@ function handle_visual_viewport_change() {
            ? window.visualViewport.height
            : window.innerHeight;
   contentIframe.height = wh - contentIframe.offsetTop - 4;
+  document.body.style.setProperty("--kiwix-content-offset-top",
+                                  `${contentIframe.offsetTop}px`);
+}
+
+function handle_viewer_size_change() {
+  handle_visual_viewport_change();
+  syncTocUI()
 }
 
 function setIframeUrl(path) {
@@ -442,6 +451,7 @@ function on_content_load() {
   contentIframe.contentWindow.onhashchange = handle_content_url_change;
   setInterval(handle_content_url_change, 100);
   setup_chaperon_mode();
+  rebuildToc();
 }
 
 function htmlDecode(input) {
@@ -583,9 +593,9 @@ function setupViewer() {
   // Defer the call of handle_visual_viewport_change() until after the
   // presence or absence of the taskbar as determined by this function
   // has been settled.
-  setTimeout(handle_visual_viewport_change, 0);
+  setTimeout(handle_viewer_size_change, 0);
 
-  window.onresize = handle_visual_viewport_change;
+  window.onresize = handle_viewer_size_change;
 
   const kiwixToolBarWrapper = document.getElementById('kiwixtoolbarwrapper');
   if ( ! viewerSettings.toolbarEnabled ) {
@@ -607,6 +617,7 @@ function setupViewer() {
 
   initUILanguageSelector(viewerState.uiLanguage, changeUILanguage);
   setupSuggestions();
+  setupToc();
 
   // cybook hack
   if (navigator.userAgent.indexOf("bookeen/cybook") != -1) {
@@ -628,6 +639,9 @@ function updateUIText() {
   setTitle(document.getElementById("kiwix_serve_taskbar_random_button"),
            $t("random-page-button-text"));
 
+  setTitle(document.getElementById("kiwix_serve_taskbar_toc_button"),
+           $t("table-of-content-button-text"));
+
   // Add translation for loading text as soon as translations are available
   const loadingTextElement = document.getElementById("kiwix__loading_text");
   if (loadingTextElement) {
@@ -647,4 +661,119 @@ function finishViewerSetup()
 
   window.onhashchange = handle_location_hash_change;
   window.onpopstate = handle_history_state_change;
+}
+
+let tocState = {
+  headings : [],
+  expanded : false,
+  dockable : false
+};
+
+const TocPanelElement = document.getElementById("kiwix_toc_panel");
+const TocBackdropElement = document.getElementById("kiwix_toc_backdrop");
+const TocButtonElement = document.getElementById('kiwix_serve_taskbar_toc_button');
+const TOC_DOCKED_MIN_WIDTH = 1180;
+
+function syncTocUI() {
+  // Synchronize tocState and DOM 
+  const hasContent = tocState.headings.length > 0; // is TOC exists?
+  const shouldShow = tocState.expanded && hasContent; // should TOC show?
+  // A. Sync "TOC" button status on Navbar.
+  TocButtonElement.classList.toggle("button-disabled", !hasContent);
+  TocButtonElement.setAttribute("aria-disabled", String(!hasContent));
+  TocButtonElement.setAttribute("aria-expanded", String(shouldShow));
+  // B. Check page width to decide docking. Then sync with DOM.
+  tocState.dockable = hasContent && (window.innerWidth >= TOC_DOCKED_MIN_WIDTH);
+  document.body.classList.toggle("kiwix_toc_docked", tocState.dockable);
+  // C. Sync tocStatus to Panel DOM
+  TocPanelElement.classList.toggle("hidden", !shouldShow);
+  TocPanelElement.setAttribute("aria-hidden", String(!shouldShow));
+  // D. Sync tocStatus to Backdrop DOM. The alternative of Docking.
+  const showBackdrop = shouldShow && !tocState.dockable;
+  TocBackdropElement.classList.toggle("hidden", !showBackdrop);
+  // E. Push Main content to right if docking.
+  const isIframePushed = tocState.dockable && !shouldShow;
+  contentIframe.classList.toggle("kiwix_toc_panel_hidden", isIframePushed);
+}
+
+function switchToc() {
+  if (tocState.headings.length > 0) {
+    tocState.expanded = !tocState.expanded;
+    syncTocUI();
+  }
+}
+
+function closeToc() {
+  tocState.expanded = false;
+  syncTocUI();
+}
+
+function buildToc() {
+  const doc = contentIframe.contentDocument;
+  tocState.headings = [];
+
+  if (!doc) return;
+
+  const headings = Array.from(doc.querySelectorAll('h1, h2, h3'))
+    .filter(h => h.textContent.trim().length > 0);
+
+  if (headings.length <= 1 && headings[0]?.tagName === 'H1') return;
+
+  tocState.headings = headings.map((h, i) => {
+    if (!h.id) h.id = `kiwix_toc_h_${i}`;
+    return {
+      type: h.tagName,
+      title: h.textContent.trim(),
+      targetId: h.id
+    };
+  });
+}
+
+function renderToc() {
+  const list = document.getElementById('kiwix_toc_list');
+  list.innerHTML = "";
+  
+  tocState.headings.forEach(item => {
+    const li = document.createElement('li');
+    li.className = "kiwix_toc_item";
+    
+    const a = document.createElement('a');
+    a.textContent = item.title;
+    a.href = "#";
+    a.className = `toc-level-${item.type.toLowerCase()}`;
+    
+    a.onclick = (e) => {
+      e.preventDefault();
+      const target = contentIframe.contentDocument.getElementById(item.targetId);
+      if (target) target.scrollIntoView({ behavior: 'smooth' });
+      
+      if (!tocState.dockable) closeToc();
+    };
+
+    li.appendChild(a);
+    list.appendChild(li);
+  });
+}
+
+function rebuildToc() {
+  buildToc();
+  renderToc();
+  tocState.expanded = false; 
+  syncTocUI();
+}
+
+function setupToc() {
+  TocBackdropElement.onclick = closeToc;
+  window.onresize = syncTocUI; 
+  
+  document.addEventListener("click", (e) => {
+    if (tocState.expanded && !tocState.dockable && 
+        !TocPanelElement.contains(e.target) && !TocButtonElement.contains(e.target)) {
+      closeToc();
+    }
+  });
+
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") closeToc();
+  });
 }

--- a/static/viewer.html
+++ b/static/viewer.html
@@ -70,6 +70,15 @@
                  onclick="gotoRandomPage()">
                 <button>&#x1F3B2;</button>
               </a>
+              <a id="kiwix_serve_taskbar_toc_button"
+                 title="View table of contents"
+                 accesskey="t"
+                 aria-label="View table of contents"
+                 aria-controls="kiwix_toc_panel"
+                 aria-expanded="false"
+                 onclick="switchToc()">
+                <button>TOC</button>
+              </a>
             </span>
           </div>
         </div>
@@ -89,6 +98,11 @@
             src="./skin/blank.html?KIWIXCACHEID" title="ZIM content" width="100%"
             style="border:0px">
     </iframe>
+
+    <div id="kiwix_toc_backdrop" class="hidden"></div>
+    <aside id="kiwix_toc_panel" class="hidden" aria-hidden="true">
+      <ul id="kiwix_toc_list"></ul>
+    </aside>
 
     <script>
     </script>

--- a/test/library_server.cpp
+++ b/test/library_server.cpp
@@ -1280,7 +1280,7 @@ TEST_F(LibraryServerTest, no_name_mapper_catalog_v2_individual_entry_access)
   "    <title>Welcome to Kiwix Server</title>\n" \
   "    <link\n" \
   "      type=\"text/css\"\n" \
-  "      href=\"/ROOT%23%3F/skin/kiwix.css?cacheid=b4e29e64\"\n" \
+  "      href=\"/ROOT%23%3F/skin/kiwix.css?cacheid=d2489de4\"\n" \
   "      rel=\"Stylesheet\"\n" \
   "    />\n" \
   "    <link\n" \

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -73,13 +73,13 @@ const ResourceCollection resources200Compressible{
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/isotope.pkgd.min.js" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/isotope.pkgd.min.js?cacheid=2e48d392" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/kiwix.css" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/kiwix.css?cacheid=b4e29e64" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/kiwix.css?cacheid=d2489de4" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/mustache.min.js" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/mustache.min.js?cacheid=bd23c4fb" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/taskbar.css" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/taskbar.css?cacheid=42e90cb9" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/viewer.js" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=6192cae1" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=1b7dce0e" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Poppins.ttf" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/fonts/Poppins.ttf?cacheid=af705837" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Roboto.ttf" },
@@ -292,7 +292,7 @@ TEST_F(ServerTest, CacheIdsOfStaticResources)
   const std::vector<UrlAndExpectedResult> testData{
     {
       /* url */ "/ROOT%23%3F/",
-R"EXPECTEDRESULT(      href="/ROOT%23%3F/skin/kiwix.css?cacheid=b4e29e64"
+R"EXPECTEDRESULT(      href="/ROOT%23%3F/skin/kiwix.css?cacheid=d2489de4"
       href="/ROOT%23%3F/skin/index.css?cacheid=ae79e41a"
     <link rel="apple-touch-icon" sizes="180x180" href="/ROOT%23%3F/skin/favicon/apple-touch-icon.png?cacheid=f86f8df3">
     <link rel="icon" type="image/png" sizes="32x32" href="/ROOT%23%3F/skin/favicon/favicon-32x32.png?cacheid=79ded625">
@@ -333,14 +333,14 @@ R"EXPECTEDRESULT(                  <img src="${root}/skin/download-white.svg?cac
     },
     {
       /* url */ "/ROOT%23%3F/viewer",
-R"EXPECTEDRESULT(    <link type="text/css" href="./skin/kiwix.css?cacheid=b4e29e64" rel="Stylesheet" />
+R"EXPECTEDRESULT(    <link type="text/css" href="./skin/kiwix.css?cacheid=d2489de4" rel="Stylesheet" />
     <link type="text/css" href="./skin/taskbar.css?cacheid=42e90cb9" rel="Stylesheet" />
     <link type="text/css" href="./skin/autoComplete/css/autoComplete.css?cacheid=f2d376c4" rel="Stylesheet" />
     <link type="text/css" href="./skin/print.css?cacheid=65b1c1d2" media="print" rel="Stylesheet" />
     <script type="text/javascript" src="./skin/polyfills.js?cacheid=a0e0343d"></script>
     <script type="module" src="./skin/i18n.js?cacheid=e9a10ac1" defer></script>
     <script type="text/javascript" src="./skin/languages.js?cacheid=d2d6933b" defer></script>
-    <script type="text/javascript" src="./skin/viewer.js?cacheid=6192cae1" defer></script>
+    <script type="text/javascript" src="./skin/viewer.js?cacheid=1b7dce0e" defer></script>
     <script type="text/javascript" src="./skin/autoComplete/autoComplete.min.js?cacheid=1191aaaf"></script>
       const blankPageUrl = root + "/skin/blank.html?cacheid=6b1fa032";
           <label for="kiwix_button_show_toggle"><img src="./skin/caret.png?cacheid=22b942b4" alt=""></label>


### PR DESCRIPTION
Fixes [kiwix/kiwix-tools#754](https://github.com/kiwix/kiwix-tools/issues/754)

<img width="1582" height="1103" alt="image" src="https://github.com/user-attachments/assets/4346776b-d56e-4129-bc33-4db719d1d106" />

This PR implements Table of Contents for Reader.

For widely enough desktops or iPads, it will use dock just like wikipedia does. For smaller ones, it will use floating TOC. For phones, it will be a full-screen TOC.

For mini ZIMs, like `wikipedia_zh_physics_mini_2026-03.zim`, it will disable TOC because the content only have a h1.

Tested on Firefox & Chromium.

More i18n keys need to be added. 