### PR TITLE
Fix white line at bottom of iframe kiwix/kiwix-tools#809

### DIFF
--- a/static/skin/viewer.js
+++ b/static/skin/viewer.js
@@ -228,12 +228,6 @@ function updateToolbarVisibilityState() {
   previousScrollTop = st;
 }
 
-function handle_visual_viewport_change() {
- // const wh = window.visualViewport
-   //        ? window.visualViewport.height
-     //      : window.innerHeight;
-  //  contentIframe.height = wh - contentIframe.offsetTop - 4;
-}
 
 function setIframeUrl(path) {
   try {
@@ -583,9 +577,7 @@ function setupViewer() {
   // Defer the call of handle_visual_viewport_change() until after the
   // presence or absence of the taskbar as determined by this function
   // has been settled.
-  setTimeout(handle_visual_viewport_change, 0);
 
-  window.onresize = handle_visual_viewport_change;
 
   const kiwixToolBarWrapper = document.getElementById('kiwixtoolbarwrapper');
   if ( ! viewerSettings.toolbarEnabled ) {

--- a/static/skin/viewer.js
+++ b/static/skin/viewer.js
@@ -229,10 +229,10 @@ function updateToolbarVisibilityState() {
 }
 
 function handle_visual_viewport_change() {
-  const wh = window.visualViewport
-           ? window.visualViewport.height
-           : window.innerHeight;
-  contentIframe.height = wh - contentIframe.offsetTop - 4;
+ // const wh = window.visualViewport
+   //        ? window.visualViewport.height
+     //      : window.innerHeight;
+  //  contentIframe.height = wh - contentIframe.offsetTop - 4;
 }
 
 function setIframeUrl(path) {

--- a/static/viewer.html
+++ b/static/viewer.html
@@ -7,6 +7,16 @@
                    frame-src 'self';
                    object-src 'none';">
     <title>ZIM Viewer</title>
+    <style>
+      html {
+        height: 100%;
+      }
+      html, body, #content_iframe {
+        display: flex;
+        flex-direction: column;
+        flex: 1;
+      }
+    </style>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link type="text/css" href="./skin/kiwix.css?KIWIXCACHEID" rel="Stylesheet" />
     <link type="text/css" href="./skin/taskbar.css?KIWIXCACHEID" rel="Stylesheet" />

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -79,7 +79,7 @@ const ResourceCollection resources200Compressible{
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/taskbar.css" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/taskbar.css?cacheid=42e90cb9" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/viewer.js" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=6192cae1" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=570868db" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Poppins.ttf" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/fonts/Poppins.ttf?cacheid=af705837" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Roboto.ttf" },
@@ -340,7 +340,7 @@ R"EXPECTEDRESULT(    <link type="text/css" href="./skin/kiwix.css?cacheid=b4e29e
     <script type="text/javascript" src="./skin/polyfills.js?cacheid=a0e0343d"></script>
     <script type="module" src="./skin/i18n.js?cacheid=e9a10ac1" defer></script>
     <script type="text/javascript" src="./skin/languages.js?cacheid=d2d6933b" defer></script>
-    <script type="text/javascript" src="./skin/viewer.js?cacheid=6192cae1" defer></script>
+    <script type="text/javascript" src="./skin/viewer.js?cacheid=570868db" defer></script>
     <script type="text/javascript" src="./skin/autoComplete/autoComplete.min.js?cacheid=1191aaaf"></script>
       const blankPageUrl = root + "/skin/blank.html?cacheid=6b1fa032";
           <label for="kiwix_button_show_toggle"><img src="./skin/caret.png?cacheid=22b942b4" alt=""></label>

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -79,7 +79,7 @@ const ResourceCollection resources200Compressible{
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/taskbar.css" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/taskbar.css?cacheid=42e90cb9" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/viewer.js" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=570868db" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=f78c03d9" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Poppins.ttf" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/fonts/Poppins.ttf?cacheid=af705837" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Roboto.ttf" },
@@ -340,7 +340,7 @@ R"EXPECTEDRESULT(    <link type="text/css" href="./skin/kiwix.css?cacheid=b4e29e
     <script type="text/javascript" src="./skin/polyfills.js?cacheid=a0e0343d"></script>
     <script type="module" src="./skin/i18n.js?cacheid=e9a10ac1" defer></script>
     <script type="text/javascript" src="./skin/languages.js?cacheid=d2d6933b" defer></script>
-    <script type="text/javascript" src="./skin/viewer.js?cacheid=570868db" defer></script>
+    <script type="text/javascript" src="./skin/viewer.js?cacheid=f78c03d9" defer></script>
     <script type="text/javascript" src="./skin/autoComplete/autoComplete.min.js?cacheid=1191aaaf"></script>
       const blankPageUrl = root + "/skin/blank.html?cacheid=6b1fa032";
           <label for="kiwix_button_show_toggle"><img src="./skin/caret.png?cacheid=22b942b4" alt=""></label>


### PR DESCRIPTION
Fixes kiwix/kiwix-tools#809

I removed the hardcoded Javascript math that was calculating the iframe height with an arbitrary - 4 pixel offset. I replaced it with the CSS Flexbox approach (display: flex, flex: 1) on the html, body, and iframe elements to allow it to scale naturally without leaving a gap at the bottom.