### PR TITLE
Align download links order across JS modal and no-JS page

### DIFF
--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -885,6 +885,7 @@ std::string InternalServer::getNoJSDownloadPageHTML(const std::string& bookId, c
   return render_template(
              RESOURCE::templates::no_js_download_html,
              kainjow::mustache::object{
+              {"root", m_root},
                {"url", bookUrl},
                {"translations", translations}
              }

--- a/static/skin/index.css
+++ b/static/skin/index.css
@@ -320,6 +320,10 @@
     color: #444343;
 }
 
+.modal-content a>div.checksum-spacing {
+    margin-top: 8px;
+}
+
 .modal-content img {
     display: inline-block;
     margin: 0 10px;

--- a/static/skin/index.js
+++ b/static/skin/index.js
@@ -346,9 +346,9 @@
                             </a>
                         </div>
                         <div class="modal-regular-download">
-                            <a href="${downloadLink}.sha256" download>
-                                <img src="${root}/skin/hash.png?KIWIXCACHEID" alt="${$t("hash-download-alt-text")}" />
-                                <div>${$t("hash-download-link-text")}</div>
+                            <a href="${downloadLink}.torrent" download>
+                                <img src="${root}/skin/bittorrent.png?KIWIXCACHEID" alt="${$t("torrent-download-alt-text")}" />
+                                <div>${$t("torrent-download-link-text")}</div>
                             </a>
                         </div>
                         ${magnetLink ?
@@ -359,9 +359,9 @@
                             </a>
                         </div>` : ``}
                         <div class="modal-regular-download">
-                            <a href="${downloadLink}.torrent" download>
-                                <img src="${root}/skin/bittorrent.png?KIWIXCACHEID" alt="${$t("torrent-download-alt-text")}" />
-                                <div>${$t("torrent-download-link-text")}</div>
+                            <a href="${downloadLink}.sha256" download>
+                                <img src="${root}/skin/hash.png?KIWIXCACHEID" alt="${$t("hash-download-alt-text")}" />
+                                <div class="checksum-spacing">${$t("hash-download-link-text")}</div>
                             </a>
                         </div>
                     </div>

--- a/static/templates/no_js_download.html
+++ b/static/templates/no_js_download.html
@@ -7,6 +7,15 @@
     <title>{{translations.download-links-title}}</title>
 </head>
 <style>
+    .downloadRow {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+    }
+    .downloadRow img {
+        width: 20px;
+        height: 20px;
+    }
     .downloadLinksTitle {
         text-align: center;
         font-size: 32px;
@@ -21,16 +30,28 @@
         {{{translations.download-links-heading}}}
     </div>
     <a href="{{url}}" download>
-        <div>{{translations.direct-download-link-text}}</div>
-    </a>
-    <a href="{{url}}.magnet" target="_blank">
-        <div>{{translations.magnet-link-text}}</div>
+        <div class="downloadRow">
+            <img src="{{root}}/skin/download.png?KIWIXCACHEID" alt="">
+            <div>{{translations.direct-download-link-text}}</div>
+        </div>
     </a>
     <a href="{{url}}.torrent" download>
-        <div>{{translations.torrent-download-link-text}}</div>
+        <div class="downloadRow">
+            <img src="{{root}}/skin/bittorrent.png?KIWIXCACHEID" alt="">
+            <div>{{translations.torrent-download-link-text}}</div>
+        </div>
+    </a>
+    <a href="{{url}}.magnet" target="_blank">
+        <div class="downloadRow">
+            <img src="{{root}}/skin/magnet.png?KIWIXCACHEID" alt="">
+            <div>{{translations.magnet-link-text}}</div>
+        </div>
     </a>
     <a href="{{url}}.sha256" download>
-        <div>{{translations.hash-download-link-text}}</div>
+        <div class="downloadRow checksum-spacing">
+            <img src="{{root}}/skin/hash.png?KIWIXCACHEID" alt="">
+            <div>{{translations.hash-download-link-text}}</div>
+        </div>
     </a>
 </body>
 </html>

--- a/static/templates/no_js_download.html
+++ b/static/templates/no_js_download.html
@@ -12,6 +12,9 @@
         font-size: 32px;
         margin-bottom: 8px;
     }
+    .checksum-spacing {
+        margin-top: 8px; 
+    }
 </style>
 <body>
     <div class="downloadLinksTitle">
@@ -20,14 +23,14 @@
     <a href="{{url}}" download>
         <div>{{translations.direct-download-link-text}}</div>
     </a>
-    <a href="{{url}}.sha256" download>
-        <div>{{translations.hash-download-link-text}}</div>
-    </a>
     <a href="{{url}}.magnet" target="_blank">
         <div>{{translations.magnet-link-text}}</div>
     </a>
     <a href="{{url}}.torrent" download>
         <div>{{translations.torrent-download-link-text}}</div>
+    </a>
+    <a href="{{url}}.sha256" download>
+        <div>{{translations.hash-download-link-text}}</div>
     </a>
 </body>
 </html>


### PR DESCRIPTION
<img width="825" height="595" alt="image" src="https://github.com/user-attachments/assets/bbbd251d-f9bb-4633-8586-a675e34c745f" />
<img width="820" height="231" alt="image" src="https://github.com/user-attachments/assets/03c0f421-9d97-4c4f-9878-92322dcbd201" />

Fixes kiwix/kiwix-tools#775