### PR TITLE
"Fixed" the server unit-test for libmicrohttpd 1.x

### DIFF
--- a/test/server.cpp
+++ b/test/server.cpp
@@ -439,6 +439,10 @@ TEST_F(ServerTest, CacheIdsOfStaticResourcesMatchTheSha1HashOfResourceContent)
 }
 
 const char* urls400[] = {
+#if MHD_VERSION >= 0x01000000
+  "/ROOT%23%",
+  "/ROOT%23%3",
+#endif // MHD_VERSION
   "/ROOT%23%3F/search",
   "/ROOT%23%3F/search?content=non-existing-book&pattern=asdfqwerty",
   "/ROOT%23%3F/search?content=non-existing-book&pattern=asd<qwerty",
@@ -461,8 +465,10 @@ const char* urls404[] = {
   "/",
   "/zimfile",
   "/ROOT",
+#if MHD_VERSION < 0x01000000
   "/ROOT%23%",
   "/ROOT%23%3",
+#endif // MHD_VERSION
   "/ROOT%23%3Fxyz",
   "/ROOT%23%3F/skin/non-existent-skin-resource",
   "/ROOT%23%3F/skin/autoComplete/autoComplete.min.js?cacheid=wrongcacheid",


### PR DESCRIPTION
Part of the fix for #1291

libmicrohttpd 1.0.5 (the version used at this point under the debian testing distribution) seems to return an HTTP 400 (Bad Request) error if the URL contains an invalid URI-encoding sequence, thus breaking our unit-tests involving such URLs. Upgrading our libmicrohttpd dependency is not easy, so this change is an optimistic attempt to fix the build of the libkiwix package under debian testing.

For this change to fix #1291 the debian package of `libkiwix` must be upgraded to the most recent version or this patch must be applied to the 14.0 release.

--- 
**Update (2026-05-09):** This PR was followed-up by

- The first commit of #1294
- #1298