### PR TITLE
Correct error message for requests with wrong root URL prefix

### DIFF
--- a/src/server/internalServer.cpp
+++ b/src/server/internalServer.cpp
@@ -181,16 +181,6 @@ int getMHDFlags(IpMode ipMode, bool verbose)
   return flags;
 }
 
-std::string
-fullURL2LocalURL(const std::string& fullUrl, const std::string& rootLocation)
-{
-  if ( kiwix::startsWith(fullUrl, rootLocation) ) {
-    return fullUrl.substr(rootLocation.size());
-  } else {
-    return "INVALID URL";
-  }
-}
-
 std::string getSearchComponent(const RequestContext& request)
 {
     const std::string query = request.get_query();
@@ -645,11 +635,15 @@ MHD_Result InternalServer::handlerCallback(struct MHD_Connection* connection,
     printf("full_url  : %s\n", fullUrl);
   }
 
-  const auto url = fullURL2LocalURL(fullUrl, m_rootPrefixOfDecodedURL);
   RequestContext::NameValuePairs headers, queryArgs;
   MHD_get_connection_values(connection, MHD_HEADER_KIND, add_name_value_pair, &headers);
   MHD_get_connection_values(connection, MHD_GET_ARGUMENT_KIND, add_name_value_pair, &queryArgs);
-  RequestContext request(m_root, url, method, version, headers, queryArgs);
+
+  const int rootPrefixLen = kiwix::startsWith(fullUrl, m_rootPrefixOfDecodedURL)
+                          ? int(m_rootPrefixOfDecodedURL.size())
+                          : -1;
+
+  RequestContext request(fullUrl, rootPrefixLen, method, version, headers, queryArgs);
 
   if (m_verbose.load() ) {
     request.print_debug_info();

--- a/src/server/request_context.cpp
+++ b/src/server/request_context.cpp
@@ -51,14 +51,14 @@ RequestMethod str2RequestMethod(const std::string& method) {
 
 } // unnamed namespace
 
-RequestContext::RequestContext(const std::string& _rootLocation, // URI-encoded
-                               const std::string& unrootedUrl,   // URI-decoded
+RequestContext::RequestContext(const std::string& _fullUrl,   // URI-decoded
+                               int _rootPrefixLength,
                                const std::string& _method,
                                const std::string& version,
                                const NameValuePairs& headers,
                                const NameValuePairs& queryArgs) :
-  rootLocation(_rootLocation),
-  url(unrootedUrl),
+  fullUrl(_fullUrl),
+  rootPrefixLength(_rootPrefixLength),
   method(str2RequestMethod(_method)),
   version(version),
   requestIndex(s_requestIndex++),
@@ -128,7 +128,8 @@ void RequestContext::print_debug_info() const {
     printf("\n");
   }
   printf("Parsed : \n");
-  printf("url   : %s\n", url.c_str());
+  printf("full url: %s\n", fullUrl.c_str());
+  printf("derooted url: %s\n", get_url().c_str());
   printf("acceptEncodingGzip : %d\n", acceptEncodingGzip);
   printf("has_range : %d\n", byteRange_.kind() != ByteRange::NONE);
   printf("is_valid_url : %d\n", is_valid_url());
@@ -141,11 +142,14 @@ RequestMethod RequestContext::get_method() const {
 }
 
 std::string RequestContext::get_url() const {
-  return url;
+  return rootPrefixLength < 0
+       ? ""
+       : fullUrl.substr(rootPrefixLength);
 }
 
 std::string RequestContext::get_url_part(int number) const {
   size_t start = 1;
+  const std::string url = get_url();
   while(true) {
     auto found = url.find('/', start);
     if (number == 0) {
@@ -165,10 +169,14 @@ std::string RequestContext::get_url_part(int number) const {
 }
 
 std::string RequestContext::get_full_url() const {
-  return rootLocation + urlEncode(url);
+  return urlEncode(fullUrl);
 }
 
 bool RequestContext::is_valid_url() const {
+  if ( rootPrefixLength < 0 )
+    return false;
+
+  const std::string url = get_url();
   return url.empty() || url[0] == '/';
 }
 

--- a/src/server/request_context.cpp
+++ b/src/server/request_context.cpp
@@ -168,10 +168,6 @@ std::string RequestContext::get_full_url() const {
   return rootLocation + urlEncode(url);
 }
 
-std::string RequestContext::get_root_path() const {
-  return rootLocation.empty() ? "/" : rootLocation;
-}
-
 bool RequestContext::is_valid_url() const {
   return url.empty() || url[0] == '/';
 }

--- a/src/server/request_context.h
+++ b/src/server/request_context.h
@@ -59,8 +59,8 @@ class RequestContext {
     typedef std::vector<std::pair<const char*, const char*>> NameValuePairs;
 
   public: // functions
-    RequestContext(const std::string& rootLocation, // URI-encoded
-                   const std::string& unrootedUrl,  // URI-decoded
+    RequestContext(const std::string& fullUrl,  // URI-decoded
+                   int rootPrefixLength,
                    const std::string& method,
                    const std::string& version,
                    const NameValuePairs& headers,
@@ -138,8 +138,8 @@ class RequestContext {
     };
 
   private: // data
-    std::string rootLocation;
-    std::string url;
+    const std::string fullUrl; // URI-decoded
+    const int rootPrefixLength;
     RequestMethod method;
     std::string version;
     unsigned long long requestIndex;

--- a/src/server/request_context.h
+++ b/src/server/request_context.h
@@ -96,7 +96,6 @@ class RequestContext {
     std::string get_url() const;
     std::string get_url_part(int part) const;
     std::string get_full_url() const;
-    std::string get_root_path() const;
 
     std::string get_query() const { return queryString; }
 

--- a/test/response.cpp
+++ b/test/response.cpp
@@ -12,7 +12,7 @@ RequestContext makeHttpGetRequest(const std::string& url,
                                   const RequestContext::NameValuePairs& headers,
                                   const RequestContext::NameValuePairs& queryArgs)
 {
-  return RequestContext("", url, "GET", "1.1", headers, queryArgs);
+  return RequestContext(url, 0, "GET", "1.1", headers, queryArgs);
 }
 
 std::string getResponseContent(const ContentResponseBlueprint& crb)

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -788,6 +788,47 @@ TEST_F(ServerTest, Http404HtmlError)
 {
   using namespace TestingOfHtmlResponses;
   const std::vector<TestContentIn404HtmlResponse> testData{
+
+    // wrong root URL (root URL missing completely)
+    { /* url */ "/",
+      expected_kiwix_response_data==R"({ "CSS_URL" : false, "PAGE_HEADING" : { "msgid" : "404-page-heading", "params" : { } }, "PAGE_TITLE" : { "msgid" : "404-page-title", "params" : { } }, "details" : [ { "p" : { "msgid" : "url-not-found", "params" : { "url" : "/" } } } ] })" &&
+      expected_body==R"(
+    <h1>Not Found</h1>
+    <p>
+      The requested URL "/" was not found on this server.
+    </p>
+)"  },
+
+    // (conspicuously) wrong root URL
+    { /* url */ "/WRONGROOT",
+      expected_kiwix_response_data==R"({ "CSS_URL" : false, "PAGE_HEADING" : { "msgid" : "404-page-heading", "params" : { } }, "PAGE_TITLE" : { "msgid" : "404-page-title", "params" : { } }, "details" : [ { "p" : { "msgid" : "url-not-found", "params" : { "url" : "/WRONGROOT" } } } ] })" &&
+      expected_body==R"(
+    <h1>Not Found</h1>
+    <p>
+      The requested URL "/WRONGROOT" was not found on this server.
+    </p>
+)"  },
+
+    // wrong root URL with the correct root URL appearing as a suffix
+    { /* url */ "/WRONGROOT/ROOT%23%3F",
+      expected_kiwix_response_data==R"({ "CSS_URL" : false, "PAGE_HEADING" : { "msgid" : "404-page-heading", "params" : { } }, "PAGE_TITLE" : { "msgid" : "404-page-title", "params" : { } }, "details" : [ { "p" : { "msgid" : "url-not-found", "params" : { "url" : "/WRONGROOT/ROOT%23%3F" } } } ] })" &&
+      expected_body==R"(
+    <h1>Not Found</h1>
+    <p>
+      The requested URL "/WRONGROOT/ROOT%23%3F" was not found on this server.
+    </p>
+)"  },
+
+    // wrong root URL (with the correct root URL appearing as a prefix)
+    { /* url */ "/ROOT%23%3FWRONGROOT",
+      expected_kiwix_response_data==R"({ "CSS_URL" : false, "PAGE_HEADING" : { "msgid" : "404-page-heading", "params" : { } }, "PAGE_TITLE" : { "msgid" : "404-page-title", "params" : { } }, "details" : [ { "p" : { "msgid" : "url-not-found", "params" : { "url" : "/ROOT%23%3FWRONGROOT" } } } ] })" &&
+      expected_body==R"(
+    <h1>Not Found</h1>
+    <p>
+      The requested URL "/ROOT%23%3FWRONGROOT" was not found on this server.
+    </p>
+)"  },
+
     { /* url */ "/ROOT%23%3F/random?content=non-existent-book",
       expected_kiwix_response_data==R"({ "CSS_URL" : false, "PAGE_HEADING" : { "msgid" : "404-page-heading", "params" : { } }, "PAGE_TITLE" : { "msgid" : "404-page-title", "params" : { } }, "details" : [ { "p" : { "msgid" : "no-such-book", "params" : { "BOOK_NAME" : "non-existent-book" } } } ] })" &&
       expected_body==R"(

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -9,6 +9,9 @@
 #include "../src/tools/stringTools.h"
 
 #include "testing_tools.h"
+
+#include "../src/server/microhttpd_wrapper.h" // for MHD_VERSION
+
 using namespace kiwix::testing;
 
 const std::string ROOT_PREFIX("/ROOT%23%3F");


### PR DESCRIPTION
Fixes #1292 

Also fixes the [tiny problem](https://github.com/kiwix/libkiwix/pull/1293#issuecomment-4352877745) with #1293. 