### PR TITLE
Exact version of libmicrohttpd affecting the server unit-test

### DIFF
--- a/test/server.cpp
+++ b/test/server.cpp
@@ -442,7 +442,7 @@ TEST_F(ServerTest, CacheIdsOfStaticResourcesMatchTheSha1HashOfResourceContent)
 }
 
 const char* urls400[] = {
-#if MHD_VERSION >= 0x01000000
+#if MHD_VERSION >= 0x01000300
   "/ROOT%23%",
   "/ROOT%23%3",
 #endif // MHD_VERSION
@@ -468,7 +468,7 @@ const char* urls404[] = {
   "/",
   "/zimfile",
   "/ROOT",
-#if MHD_VERSION < 0x01000000
+#if MHD_VERSION < 0x01000300
   "/ROOT%23%",
   "/ROOT%23%3",
 #endif // MHD_VERSION


### PR DESCRIPTION
#1293 (with a [follow-up fix](https://github.com/kiwix/libkiwix/pull/1294/commits/fcebc2d4f625244270b2c85428e3c8ea153ed928) included in #1294) was implemented under the assumption that the problematic change in how `libmicrohttpd` parses URI-encoded URLs was brought by the major version change (from v0.x to `v1.x`). However it turns out that the version available on Ubuntu `noble` (v1.0.0) works the old way unlike v1.0.5 (the one behind #1291). The exact commit causing that behaviour change is https://git.gnunet.org/gnunet/libmicrohttpd/commit/ec6e6d288876606af964747f97379aa9371c4206.html and it first appears in `libmicrohttpd` v1.0.3.

Should unblock the merging of #1297