### PR TITLE
Refactoring, moving potential reusable methods to library_dumper

### DIFF
--- a/src/library_dumper.cpp
+++ b/src/library_dumper.cpp
@@ -1,10 +1,63 @@
 #include "library_dumper.h"
+#include "book.h"
+
+#include "libkiwix-resources.h"
+#include <mustache.hpp>
+
 #include "tools/stringTools.h"
 #include "tools/otherTools.h"
 #include "tools.h"
 
 namespace kiwix
 {
+
+kainjow::mustache::list getBookIllustrationInfo(const Book& book)
+{
+    kainjow::mustache::list illustrations;
+    for ( const auto& illustration : book.getIllustrations() ) {
+      // For now, we are handling only sizexsize@1 illustration.
+      // So we can simply pass one size to mustache.
+      illustrations.push_back(kainjow::mustache::object{
+        {"icon_size", to_string(illustration->width)},
+        {"icon_mimetype", illustration->mimeType}
+      });
+    }
+    return illustrations;
+}
+
+std::string fullEntryXML(const Book& book,
+                         const std::string& rootLocation,
+                         const std::string& contentAccessUrl,
+                         const std::string& contentId,
+                         const std::string& selfPath)
+{
+    const auto bookDate = book.getDate() + "T00:00:00Z";
+    const kainjow::mustache::object data{
+      {"root",  rootLocation},
+      {"contentAccessUrl",  onlyAsNonEmptyMustacheValue(contentAccessUrl)},
+      {"id", book.getId()},
+      {"name", book.getName()},
+      {"title", book.getTitle()},
+      {"description", book.getDescription()},
+      {"language", book.getCommaSeparatedLanguages()},
+      {"content_id",  urlEncode(contentId)},
+      {"updated", bookDate}, // XXX: this should be the entry update datetime
+      {"book_date", bookDate},
+      {"category", book.getCategory()},
+      {"flavour", book.getFlavour()},
+      {"tags", book.getTags()},
+      {"article_count", to_string(book.getArticleCount())},
+      {"media_count", to_string(book.getMediaCount())},
+      {"author_name", book.getCreator()},
+      {"publisher_name", book.getPublisher()},
+      {"url", onlyAsNonEmptyMustacheValue(book.getUrl())},
+      {"size", to_string(book.getSize())},
+      {"icons", getBookIllustrationInfo(book)},
+      {"self_path", onlyAsNonEmptyMustacheValue(selfPath)},
+    };
+    return render_template(RESOURCE::templates::catalog_v2_entry_xml, data);
+}
+
 /* Constructor */
 LibraryDumper::LibraryDumper(const Library* library, const NameMapper* nameMapper)
   : library(library),

--- a/src/library_dumper.h
+++ b/src/library_dumper.h
@@ -31,6 +31,28 @@
 namespace kiwix
 {
 
+class Book;
+
+/**
+ * Get the illustration data (size/mimetype) of a book, for use in OPDS entry rendering.
+ */
+kainjow::mustache::list getBookIllustrationInfo(const Book& book);
+
+/**
+ * Render the full OPDS entry XML for a book.
+ *
+ * @param selfPath If non-empty, rendered as the entry's rel="self" link (its
+ *                 local file path). Only meant for local/offline dumps
+ *                 (LibOPDSDumper) - leave empty for the live HTTP catalog
+ *                 (OPDSDumper), which must not leak server-side filesystem
+ *                 paths to remote clients.
+ */
+std::string fullEntryXML(const Book& book,
+                          const std::string& rootLocation,
+                          const std::string& contentAccessUrl,
+                          const std::string& contentId,
+                          const std::string& selfPath = "");
+
 /**
  * A base class to dump Library in various formats.
  *

--- a/src/opds_dumper.cpp
+++ b/src/opds_dumper.cpp
@@ -46,52 +46,6 @@ const std::string XML_HEADER(R"(<?xml version="1.0" encoding="UTF-8"?>)");
 
 typedef kainjow::mustache::data MustacheData;
 typedef kainjow::mustache::list BooksData;
-typedef kainjow::mustache::list IllustrationInfo;
-
-IllustrationInfo getBookIllustrationInfo(const Book& book)
-{
-    kainjow::mustache::list illustrations;
-    for ( const auto& illustration : book.getIllustrations() ) {
-      // For now, we are handling only sizexsize@1 illustration.
-      // So we can simply pass one size to mustache.
-      illustrations.push_back(kainjow::mustache::object{
-        {"icon_size", to_string(illustration->width)},
-        {"icon_mimetype", illustration->mimeType}
-      });
-    }
-    return illustrations;
-}
-
-std::string fullEntryXML(const Book& book,
-                         const std::string& rootLocation,
-                         const std::string& contentAccessUrl,
-                         const std::string& contentId)
-{
-    const auto bookDate = book.getDate() + "T00:00:00Z";
-    const kainjow::mustache::object data{
-      {"root",  rootLocation},
-      {"contentAccessUrl",  onlyAsNonEmptyMustacheValue(contentAccessUrl)},
-      {"id", book.getId()},
-      {"name", book.getName()},
-      {"title", book.getTitle()},
-      {"description", book.getDescription()},
-      {"language", book.getCommaSeparatedLanguages()},
-      {"content_id",  urlEncode(contentId)},
-      {"updated", bookDate}, // XXX: this should be the entry update datetime
-      {"book_date", bookDate},
-      {"category", book.getCategory()},
-      {"flavour", book.getFlavour()},
-      {"tags", book.getTags()},
-      {"article_count", to_string(book.getArticleCount())},
-      {"media_count", to_string(book.getMediaCount())},
-      {"author_name", book.getCreator()},
-      {"publisher_name", book.getPublisher()},
-      {"url", onlyAsNonEmptyMustacheValue(book.getUrl())},
-      {"size", to_string(book.getSize())},
-      {"icons", getBookIllustrationInfo(book)},
-    };
-    return render_template(RESOURCE::templates::catalog_v2_entry_xml, data);
-}
 
 std::string partialEntryXML(const Book& book, const std::string& rootLocation)
 {


### PR DESCRIPTION
Adds the ability for `Manager` to load a library directly from an OPDS feed,
in addition to the existing `library.xml` format — as a step toward the
issue's longer-term goal of simplifying library I/O around a single format.
This PR doesn't remove `library.xml` support — it adds OPDS as a parallel                                                                                            
  input format, which is the enabling step before any future removal.   

**Format auto-detection**: `Manager::readFile()`/`reload()` now detect                                                                                             
    whether a given path is `library.xml` or an OPDS feed                                                                                                              
    (`Manager::detectFormat`) and dispatch to the right parser transparently;                                                                                          
    callers don't need to know or specify the format.
**Local path support in OPDS**: `Book::updateFromOpds()` now recognizes a                                                                                          
    `rel="self"` link as the book's local file path, so an OPDS document can                                                                                           
    describe on-disk books, not just remote/importable ones.
**`LibOPDSDumper`**: a new class to dump a `Library` to OPDS for                                                                                                   
    local/offline use (as opposed to the existing `OPDSDumper`, used for the                                                                                           
    live HTTP catalog, which never leaks local filesystem paths to remote                                                                                              
    clients). `library_dumper.{h,cpp}` was refactored into a shared base so                                                                                            
    `OPDSDumper` and `LibOPDSDumper` reuse the same entry-rendering logic                                                                                              
    (`fullEntryOpds`, renamed from `fullEntryXML` for clarity).
**Test coverage**: new dedicated suites (`libopds_dumper`, `libxml_dumper`,                                                                                        
    `opds_dumper`, `library_dumper`), new unit tests for `updateFromOpds`                                                                                              
    mirroring the existing `updateFromXml` ones, and two new OPDS test fixtures                                                                                        
    (`test/data/library.opds`, `test/data/lib_for_server_search_test.opds`)                                                                                            
    mirroring existing XML ones. Several existing suites (`manager`, `library`,                                                                                        
    `library_server`, `server_search`) were parameterized to run their existing                                                                                        
    test bodies against both the XML and OPDS forms of the same library data,                                                                                          
    rather than duplicating test logic.
Unrelated small fix: `ServerNegativeTest.UnusablePort` was flaky on macOS                                                                                          
    (address binding); now binds explicitly to `127.0.0.1`. 