### PR TITLE
Reading OPDS library file

### DIFF
--- a/include/book.h
+++ b/include/book.h
@@ -78,7 +78,7 @@ class Book
    * @param baseDir base directory used to resolve a relative `rel="self"`
    *                link into an absolute book path.
    */
-  void updateFromOpds(const pugi::xml_node& node, const std::string& urlHost, const std::string& baseDir = "");
+  void updateFromOpds(const pugi::xml_node& node, const std::string& urlHost, const std::string& baseDir);
   std::string getHumanReadableIdFromPath() const;
 
   bool readOnly() const { return m_readOnly; }

--- a/include/book.h
+++ b/include/book.h
@@ -70,7 +70,15 @@ class Book
   bool update(const Book& other);
   void update(const zim::Archive& archive);
   void updateFromXml(const pugi::xml_node& node, const std::string& baseDir);
-  void updateFromOpds(const pugi::xml_node& node, const std::string& urlHost);
+  /**
+   * Update the book's metadata from an OPDS entry XML node.
+   *
+   * @param node the `<entry>` node of an OPDS feed describing the book.
+   * @param urlHost host to prepend to relative illustration/thumbnail URLs.
+   * @param baseDir base directory used to resolve a relative `rel="self"`
+   *                link into an absolute book path.
+   */
+  void updateFromOpds(const pugi::xml_node& node, const std::string& urlHost, const std::string& baseDir = "");
   std::string getHumanReadableIdFromPath() const;
 
   bool readOnly() const { return m_readOnly; }

--- a/include/book.h
+++ b/include/book.h
@@ -71,14 +71,14 @@ class Book
   void update(const zim::Archive& archive);
   void updateFromXml(const pugi::xml_node& node, const std::string& baseDir);
   /**
- * Update the book's metadata from an OPDS entry XML node.
- *
- * @param node the `<entry>` node of an OPDS feed describing the book.
- * @param urlHost host to prepend to relative illustration/thumbnail URLs.
- * @param baseDir base directory used to resolve a relative `rel="self"`
- *                link into an absolute book path.
- */
-  void updateFromOpds(const pugi::xml_node& node, const std::string& urlHost, const std::string& baseDir);
+   * Update the book's metadata from an OPDS entry XML node.
+   *
+   * @param node the `<entry>` node of an OPDS feed describing the book.
+   * @param urlHost host to prepend to relative illustration/thumbnail URLs.
+   * @param baseDir base directory used to resolve a relative `rel="self"`
+   *                link into an absolute book path.
+   */
+  void updateFromOpds(const pugi::xml_node& node, const std::string& urlHost, const std::string& baseDir = "");
   std::string getHumanReadableIdFromPath() const;
 
   bool readOnly() const { return m_readOnly; }

--- a/include/book.h
+++ b/include/book.h
@@ -70,7 +70,7 @@ class Book
   bool update(const Book& other);
   void update(const zim::Archive& archive);
   void updateFromXml(const pugi::xml_node& node, const std::string& baseDir);
-  void updateFromOpds(const pugi::xml_node& node, const std::string& urlHost);
+  void updateFromOpds(const pugi::xml_node& node, const std::string& urlHost, const std::string& baseDir);
   std::string getHumanReadableIdFromPath() const;
 
   bool readOnly() const { return m_readOnly; }

--- a/include/book.h
+++ b/include/book.h
@@ -71,14 +71,14 @@ class Book
   void update(const zim::Archive& archive);
   void updateFromXml(const pugi::xml_node& node, const std::string& baseDir);
   /**
-   * Update the book's metadata from an OPDS entry XML node.
-   *
-   * @param node the `<entry>` node of an OPDS feed describing the book.
-   * @param urlHost host to prepend to relative illustration/thumbnail URLs.
-   * @param baseDir base directory used to resolve a relative `rel="self"`
-   *                link into an absolute book path.
-   */
-  void updateFromOpds(const pugi::xml_node& node, const std::string& urlHost, const std::string& baseDir = "");
+ * Update the book's metadata from an OPDS entry XML node.
+ *
+ * @param node the `<entry>` node of an OPDS feed describing the book.
+ * @param urlHost host to prepend to relative illustration/thumbnail URLs.
+ * @param baseDir base directory used to resolve a relative `rel="self"`
+ *                link into an absolute book path.
+ */
+  void updateFromOpds(const pugi::xml_node& node, const std::string& urlHost, const std::string& baseDir);
   std::string getHumanReadableIdFromPath() const;
 
   bool readOnly() const { return m_readOnly; }

--- a/include/library.h
+++ b/include/library.h
@@ -312,7 +312,7 @@ class Library: public std::enable_shared_from_this<Library>
    * @return The number of bookmarks updated.
    */
   int migrateBookmarks(const std::string& sourceBookId, const std::string& targetBookId);
- 
+
   /**
    * Get the best available bookId for a bookmark.
    *
@@ -469,6 +469,8 @@ class Library: public std::enable_shared_from_this<Library>
    * @return Count of books that were removed by this operation.
    */
   uint32_t removeBooksNotUpdatedSince(Revision rev);
+
+  std::string dumpOpds(const std::string& outputPath) const;
 
   friend class OPDSDumper;
   friend class libXMLDumper;

--- a/include/library.h
+++ b/include/library.h
@@ -361,12 +361,32 @@ class Library: public std::enable_shared_from_this<Library>
   bool removeBookById(const std::string& id);
 
   /**
-   * Write the library to a file.
+   * Writes the library to a file as library.xml.
+   *
+   * @deprecated Calls writeToXMLFile directly and is kept for compatibility
+   * with external usages. This method is subject to removal in the future;
+   * please use writeToXMLFile instead.
    *
    * @param path the path of the file to write to.
    * @return True if the library has been correctly saved.
    */
   bool writeToFile(const std::string& path) const;
+
+  /**
+   * Write the library to a file as library.xml.
+   *
+   * @param path the path of the file to write to.
+   * @return True if the library has been correctly saved.
+   */
+  bool writeToXMLFile(const std::string& path) const;
+
+  /**
+   * Write the library to a file as an OPDS document.
+   *
+   * @param path the path of the file to write to.
+   * @return True if the library has been correctly saved.
+   */
+  bool writeToOPDSFile(const std::string& path) const;
 
   /**
    * Write the library bookmarks to a file.
@@ -473,7 +493,6 @@ class Library: public std::enable_shared_from_this<Library>
   std::string dumpOpds(const std::string& outputPath) const;
 
   friend class OPDSDumper;
-  friend class libXMLDumper;
 
 private: // types
   typedef const std::string& (Book::*BookStrPropMemFn)() const;

--- a/include/manager.h
+++ b/include/manager.h
@@ -188,7 +188,7 @@ class Manager
                    bool trustLibrary);
   bool parseOpdsDom(const pugi::xml_document& doc,
                     const std::string& urlHost,
-                    const std::string& libraryPath,
+                    const std::string& baseDir,
                     bool readOnly);
 };
 }  // namespace kiwix

--- a/include/manager.h
+++ b/include/manager.h
@@ -182,6 +182,7 @@ class Manager
                    bool trustLibrary);
   bool parseOpdsDom(const pugi::xml_document& doc,
                     const std::string& urlHost,
+                    const std::string& libraryPath,
                     bool readOnly,
                     bool trustLibrary);
 };

--- a/include/manager.h
+++ b/include/manager.h
@@ -108,18 +108,18 @@ class Manager
    * Load a library content stored in a OPDS stream or a local library file.
    *
    * @param content The content of the OPDS stream.
-   * @param urlHost The host used to resolve relative acquisition/thumbnail
-   *                links.
+   * @param contentOriginUri Where content was read from: either the URL it
+   *        was fetched from (used to resolve relative acquisition/thumbnail
+   *        links) or the local filesystem path it was read from (used to
+   *        resolve a relative rel="self" link). See
+   *        kiwix::resolveContentOrigin() for the exact splitting rules.
    * @param readOnly Set if the library path could be overwritten later with
    *                 updated content.
-   * @param libraryPath The library path (used to resolve a relative
-   *                     rel="self" link)
    * @return True if the content has been properly parsed.
    */
   bool readOpds(const std::string& content,
-                const std::string& urlHost,
-                bool readOnly = false,
-                const std::string& libraryPath = "");
+                const std::string& contentOriginUri,
+                bool readOnly = false);
 
 
   /**

--- a/include/manager.h
+++ b/include/manager.h
@@ -107,9 +107,8 @@ class Manager
    * Load a library content stored in a OPDS stream.
    *
    * @param content The content of the OPDS stream.
-   * @param readOnly Set if the library path could be overwritten later with
-   *                 updated content.
-   * @param libraryPath The library path (used to resolve relative path)
+   * @param urlHost The host used to resolve relative acquisition/thumbnail
+   *                links.
    * @return True if the content has been properly parsed.
    */
   bool readOpds(const std::string& content, const std::string& urlHost);

--- a/include/manager.h
+++ b/include/manager.h
@@ -68,12 +68,13 @@ class Manager
   explicit Manager(LibraryPtr library);
 
   /**
-   * Read a `library.xml` and add book in the file to the library.
+   * Read a library XML or an OPDS file and add the books in the file to the
+   * library.
    *
-   * @param path The (utf8) path to the `library.xml`.
+   * @param path The (utf8) path to the library file.
    * @param readOnly Set if the libray path could be overwritten latter with
    *                 updated content.
-   * @param trustLibrary use book metadata coming from XML.
+   * @param trustLibrary use book metadata coming from the file.
    * @return True if file has been properly parsed.
    */
   bool readFile(const std::string& path, bool readOnly = true, bool trustLibrary = true);
@@ -104,7 +105,7 @@ class Manager
                bool trustLibrary = true);
 
   /**
-   * Load a library content stored in a OPDS stream.
+   * Load a library content stored in a OPDS stream/file.
    *
    * @param content The content of the OPDS stream.
    * @param readOnly Set if the library path could be overwritten later with
@@ -157,7 +158,7 @@ class Manager
 
   /**
    * Add all books from the directory tree into the library.
-   * 
+   *
    * @param path          The path of the directory to scan.
    * @param verboseFlag   Verbose logs flag.
    */
@@ -180,9 +181,10 @@ class Manager
                    const std::string& libraryPath,
                    bool trustLibrary);
   bool parseOpdsDom(const pugi::xml_document& doc,
-                    const std::string& urlHost);
-
+                    const std::string& urlHost,
+                    bool readOnly,
+                    bool trustLibrary);
 };
-}
+}  // namespace kiwix
 
 #endif

--- a/include/manager.h
+++ b/include/manager.h
@@ -68,9 +68,10 @@ class Manager
   explicit Manager(LibraryPtr library);
 
   /**
-   * Read a `library.xml` and add book in the file to the library.
+   * Read a library XML or an OPDS file and add the books in the file to the
+   * library.
    *
-   * @param path The (utf8) path to the `library.xml`.
+   * @param path The (utf8) path to the library file.
    * @param readOnly Set if the libray path could be overwritten latter with
    *                 updated content.
    * @param trustLibrary use book metadata coming from XML.
@@ -104,14 +105,18 @@ class Manager
                bool trustLibrary = true);
 
   /**
-   * Load a library content stored in a OPDS stream.
+   * Load a library content stored in a OPDS stream or a local library file.
    *
    * @param content The content of the OPDS stream.
    * @param urlHost The host used to resolve relative acquisition/thumbnail
    *                links.
+   * @param readOnly Set if the library path could be overwritten later with
+   *                 updated content.
    * @return True if the content has been properly parsed.
    */
-  bool readOpds(const std::string& content, const std::string& urlHost);
+  bool readOpds(const std::string& content,
+                const std::string& urlHost,
+                bool readOnly = false);
 
 
   /**
@@ -156,7 +161,7 @@ class Manager
 
   /**
    * Add all books from the directory tree into the library.
-   * 
+   *
    * @param path          The path of the directory to scan.
    * @param verboseFlag   Verbose logs flag.
    */
@@ -179,9 +184,9 @@ class Manager
                    const std::string& libraryPath,
                    bool trustLibrary);
   bool parseOpdsDom(const pugi::xml_document& doc,
-                    const std::string& urlHost);
-
+                    const std::string& urlHost,
+                    bool readOnly);
 };
-}
+}  // namespace kiwix
 
 #endif

--- a/include/manager.h
+++ b/include/manager.h
@@ -112,11 +112,14 @@ class Manager
    *                links.
    * @param readOnly Set if the library path could be overwritten later with
    *                 updated content.
+   * @param libraryPath The library path (used to resolve a relative
+   *                     rel="self" link)
    * @return True if the content has been properly parsed.
    */
   bool readOpds(const std::string& content,
                 const std::string& urlHost,
-                bool readOnly = false);
+                bool readOnly = false,
+                const std::string& libraryPath = "");
 
 
   /**
@@ -185,6 +188,7 @@ class Manager
                    bool trustLibrary);
   bool parseOpdsDom(const pugi::xml_document& doc,
                     const std::string& urlHost,
+                    const std::string& libraryPath,
                     bool readOnly);
 };
 }  // namespace kiwix

--- a/include/tools.h
+++ b/include/tools.h
@@ -38,6 +38,16 @@ struct IpAddress
     std::string addr6; /**< IPv6 address */
 };
 
+/**
+ * The pieces needed to resolve references found in OPDS content, split out
+ * of the location that content was read from. See resolveContentOrigin().
+ */
+struct ContentOrigin
+{
+    std::string urlHost; /**< scheme+host[:port], no trailing slash; "" if the origin is a local path */
+    std::string baseDir; /**< parent directory of a local path; "" if the origin is a URL */
+};
+
 typedef std::pair<std::string, std::string> LangNameCodePair;
 typedef std::vector<LangNameCodePair> FeedLanguages;
 typedef std::vector<std::string> FeedCategories;
@@ -125,6 +135,23 @@ std::string computeAbsolutePath(const std::string& path, const std::string& rela
  * @return a relative path (pointing to absolutePath, relative to path).
  */
 std::string computeRelativePath(const std::string& path, const std::string& absolutePath);
+
+/** Split a "content origin" locator into a urlHost/baseDir pair.
+ *
+ * contentOriginUri is either a URL that some content was fetched from (e.g.
+ * "https://library.kiwix.org/catalog/v2/entries") or a local filesystem path
+ * that content was read from (e.g. "/data/library.opds"). Classification is
+ * purely syntactic: a "://" substring marks the input as a URL; everything
+ * else (including a Windows drive-letter path) is treated as a local path.
+ * Exactly one of the two returned fields is non-empty.
+ *
+ * Known limitation: a "file://" URI is classified as a URL, not a local
+ * path (no current caller produces one).
+ *
+ * @param contentOriginUri the URL or local path some content was read from.
+ * @return the corresponding urlHost/baseDir pair.
+ */
+ContentOrigin resolveContentOrigin(const std::string& contentOriginUri);
 
 /** Sleep the current thread.
  *

--- a/src/book.cpp
+++ b/src/book.cpp
@@ -145,13 +145,12 @@ static std::string fromOpdsDate(const std::string& date)
 
 
 #define VALUE(name) node.child(name).child_value()
-void Book::updateFromOpds(const pugi::xml_node& node, const std::string& urlHost)
+void Book::updateFromOpds(const pugi::xml_node& node, const std::string& urlHost, const std::string& baseDir)
 {
   m_id = VALUE("id");
   if (!m_id.compare(0, 9, "urn:uuid:")) {
     m_id.erase(0, 9);
   }
-  // No path on opds.
   m_title = VALUE("title");
   m_description = VALUE("summary");
   m_language = VALUE("language");
@@ -171,6 +170,12 @@ void Book::updateFromOpds(const pugi::xml_node& node, const std::string& urlHost
   for(auto linkNode = node.child("link"); linkNode;
            linkNode = linkNode.next_sibling("link")) {
     std::string rel = linkNode.attribute("rel").value();
+
+    if (rel == "self") {
+      const std::string path = linkNode.attribute("href").value();
+      m_path = isRelativePath(path)? computeAbsolutePath(baseDir, path): path;
+      m_pathValid = fileReadable(m_path);
+    }
 
     if (rel == "http://opds-spec.org/acquisition/open-access") {
       m_url = linkNode.attribute("href").value();

--- a/src/book.cpp
+++ b/src/book.cpp
@@ -251,7 +251,9 @@ void Book::updateFromOpds(const pugi::xml_node& node, const std::string& urlHost
       // XXX non-absolute URL is expected to be an absolute-path.
       favicon->url = isAbsoluteUrl(thumbnailUrl)? thumbnailUrl: joinUrl(urlHost, thumbnailUrl);
       favicon->mimeType = linkNode.attribute("type").value();
-      m_illustrations.push_back(favicon);
+      if ( !favicon->mimeType.empty() ) {
+        m_illustrations.push_back(favicon);
+      }
     }
   }
 

--- a/src/book.cpp
+++ b/src/book.cpp
@@ -25,12 +25,47 @@
 #include "tools/networkTools.h"
 #include "tools/otherTools.h"
 #include "tools/stringTools.h"
-#include "tools/pathTools.h"
 #include "tools/archiveTools.h"
 
 #include <zim/archive.h>
 #include <zim/item.h>
 #include <pugixml.hpp>
+
+#include <sstream>
+
+namespace
+{
+/**
+ * Tells whether a URL string is already absolute (contains a scheme,
+ * e.g. "https://example.com/x.png") as opposed to being a relative path
+ * (e.g. "/x.png"). Only a relative URL should be prefixed with a base host
+ * or URL—doing so unconditionally would garble an already-absolute one.
+ */
+bool isAbsoluteUrl(const std::string& url)
+{
+  // Find the scheme separator
+  size_t pos = url.find("://");
+  if (pos == 0 || pos == std::string::npos) {
+    return false; // No scheme or empty scheme
+  }
+
+  // RFC 3986: Scheme must begin with a letter, followed by letters, digits, '+', '.', or '-'
+  if (!std::isalpha(static_cast<unsigned char>(url[0]))) {
+    return false;
+  }
+
+  // Validate that all remaining characters in the scheme comply with RFC 3986
+  for (size_t i = 1; i < pos; ++i) {
+    char c = url[i];
+    if (!std::isalnum(static_cast<unsigned char>(c)) && c != '+' && c != '-' && c != '.') {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+} // anonymous namespace
 
 namespace kiwix
 {
@@ -184,7 +219,9 @@ void Book::updateFromOpds(const pugi::xml_node& node, const std::string& urlHost
     if (rel == "http://opds-spec.org/image/thumbnail") {
       const auto favicon = std::make_shared<Illustration>();
       favicon->data.clear();
-      favicon->url = urlHost + linkNode.attribute("href").value();
+      const std::string thumbnailUrl = linkNode.attribute("href").value();
+      // XXX non-absolute URL is expected to be an absolute-path.
+      favicon->url = isAbsoluteUrl(thumbnailUrl)? thumbnailUrl: urlHost + thumbnailUrl;
       favicon->mimeType = linkNode.attribute("type").value();
       m_illustrations.push_back(favicon);
     }

--- a/src/book.cpp
+++ b/src/book.cpp
@@ -65,6 +65,34 @@ bool isAbsoluteUrl(const std::string& url)
   return true;
 }
 
+/**
+ * Joins a host and a reference into a single URL without producing a double slash,
+ * respecting the host's format.
+ */
+std::string joinUrl(const std::string& host, const std::string& ref)
+{
+  if (host.empty()) {
+    return ref;
+  }
+  if (ref.empty()) {
+    return host;
+  }
+
+  const bool hostEndsWithSlash = (host.back() == '/');
+  const bool refStartsWithSlash = (ref.front() == '/');
+
+  if (hostEndsWithSlash && refStartsWithSlash) {
+    // Both have a slash; omit one to avoid a double slash
+    return host + ref.substr(1);
+  } else if (!hostEndsWithSlash && !refStartsWithSlash) {
+    // Neither has a slash; insert one
+    return host + "/" + ref;
+  } else {
+    // Exactly one has a slash; simple concatenation is correct
+    return host + ref;
+  }
+}
+
 } // anonymous namespace
 
 namespace kiwix
@@ -221,7 +249,7 @@ void Book::updateFromOpds(const pugi::xml_node& node, const std::string& urlHost
       favicon->data.clear();
       const std::string thumbnailUrl = linkNode.attribute("href").value();
       // XXX non-absolute URL is expected to be an absolute-path.
-      favicon->url = isAbsoluteUrl(thumbnailUrl)? thumbnailUrl: urlHost + thumbnailUrl;
+      favicon->url = isAbsoluteUrl(thumbnailUrl)? thumbnailUrl: joinUrl(urlHost, thumbnailUrl);
       favicon->mimeType = linkNode.attribute("type").value();
       m_illustrations.push_back(favicon);
     }

--- a/src/book.cpp
+++ b/src/book.cpp
@@ -145,13 +145,12 @@ static std::string fromOpdsDate(const std::string& date)
 
 
 #define VALUE(name) node.child(name).child_value()
-void Book::updateFromOpds(const pugi::xml_node& node, const std::string& urlHost)
+void Book::updateFromOpds(const pugi::xml_node& node, const std::string& urlHost, const std::string& baseDir)
 {
   m_id = VALUE("id");
   if (!m_id.compare(0, 9, "urn:uuid:")) {
     m_id.erase(0, 9);
   }
-  // No path on opds.
   m_title = VALUE("title");
   m_description = VALUE("summary");
   m_language = VALUE("language");
@@ -167,9 +166,18 @@ void Book::updateFromOpds(const pugi::xml_node& node, const std::string& urlHost
   m_category = catnode.empty() ? getCategoryFromTags() : catnode.child_value();
   m_articleCount = strtoull(VALUE("articleCount"), 0, 0);
   m_mediaCount = strtoull(VALUE("mediaCount"), 0, 0);
-  for(auto linkNode = node.child("link"); linkNode;
+  for (auto linkNode = node.child("link"); linkNode;
            linkNode = linkNode.next_sibling("link")) {
     std::string rel = linkNode.attribute("rel").value();
+
+    if (rel == "self") {
+      std::string path = linkNode.attribute("href").value();
+      if (isRelativePath(path)) {
+        path = computeAbsolutePath(baseDir, path);
+      }
+      m_path = path;
+      m_pathValid = fileReadable(path);
+    }
 
     if (rel == "http://opds-spec.org/acquisition/open-access") {
       m_url = linkNode.attribute("href").value();

--- a/src/book.cpp
+++ b/src/book.cpp
@@ -225,7 +225,23 @@ void Book::updateFromOpds(const pugi::xml_node& node, const std::string& urlHost
       favicon->mimeType = linkNode.attribute("type").value();
       m_illustrations.push_back(favicon);
     }
- }
+  }
+
+  for (auto thumbnailNode = node.child("thumbnails").child("thumbnail"); thumbnailNode;
+           thumbnailNode = thumbnailNode.next_sibling("thumbnail")) {
+    const auto thumbnail = std::make_shared<Illustration>();
+    thumbnail->data = base64_decode(thumbnailNode.child_value());
+    thumbnail->mimeType = thumbnailNode.attribute("mimetype").value();
+    const std::string widthAttr = thumbnailNode.attribute("width").value();
+    if (!widthAttr.empty()) {
+      thumbnail->width = static_cast<uint16_t>(strtoul(widthAttr.c_str(), 0, 0));
+    }
+    const std::string heightAttr = thumbnailNode.attribute("height").value();
+    if (!heightAttr.empty()) {
+      thumbnail->height = static_cast<uint16_t>(strtoul(heightAttr.c_str(), 0, 0));
+    }
+    m_illustrations.push_back(thumbnail);
+  }
 }
 #undef VALUE
 

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -20,6 +20,7 @@
 #include "library.h"
 #include "book.h"
 #include "libxml_dumper.h"
+#include "library_dumper.h"
 
 #include "tools.h"
 #include "tools/base64.h"
@@ -729,7 +730,7 @@ Xapian::Query buildXapianQuery(const Filter& filter)
     q = Xapian::Query(Xapian::Query::OP_AND, q, nameQuery(filter.getName()));
   }
   if ( filter.hasFlavour() )  {
-    q = Xapian::Query(Xapian::Query::OP_AND, q, flavourQuery(filter.getFlavour()));     
+    q = Xapian::Query(Xapian::Query::OP_AND, q, flavourQuery(filter.getFlavour()));
   }
   if ( filter.hasCategory() ) {
     q = Xapian::Query(Xapian::Query::OP_AND, q, categoryQuery(filter.getCategory()));
@@ -998,7 +999,7 @@ Filter& Filter::name(std::string name)
   activeFilters |= NAME;
   return *this;
 }
-  
+
 Filter& Filter::flavour(std::string flavour)
 {
   _flavour = flavour;
@@ -1073,6 +1074,38 @@ bool Filter::accept(const Book& book) const
   FILTER(MAXSIZE, book.getSize() <= _maxSize)
 
   return true;
+}
+
+std::string Library::dumpOpds(const std::string& outputPath) const
+{
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+
+  const auto baseDir = kiwix::removeLastPathElement(outputPath);
+
+  std::ostringstream ss;
+  ss << R"(<feed xmlns="http://www.w3.org/2005/Atom"
+      xmlns:dc="http://purl.org/dc/terms/"
+      xmlns:opds="http://opds-spec.org/2010/catalog">
+)";
+
+  for (auto& pair: m_books) {
+    const Book& book = pair.second;
+    // Local/offline dump: the book's own id is used as the content id, there
+    // is no content-access URL to link to (no server involved), and the
+    // book's local path is safe to expose as the rel="self" link, resolved
+    // relative to baseDir the same way LibXMLDumper does.
+    const std::string selfPath = book.getPath().empty()
+        ? ""
+        : computeRelativePath(baseDir, book.getPath());
+    ss << fullEntryOpds(book,
+                        /*rootLocation=*/"",
+                        /*contentAccessUrl=*/"",
+                        /*contentId=*/book.getId(),
+                        selfPath);
+  }
+
+  ss << "</feed>\n";
+  return ss.str();
 }
 
 }

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -23,8 +23,6 @@
 #include "library_dumper.h"
 
 #include "tools.h"
-#include "tools/base64.h"
-#include "tools/regexTools.h"
 #include "tools/pathTools.h"
 #include "tools/stringTools.h"
 #include "tools/otherTools.h"
@@ -435,6 +433,11 @@ unsigned int Library::getBookCount(const bool localBooks,
 
 bool Library::writeToFile(const std::string& path) const
 {
+  return writeToXMLFile(path);
+}
+
+bool Library::writeToXMLFile(const std::string& path) const
+{
   const auto allBookIds = getBooksIds();
 
   auto baseDir = removeLastPathElement(path);
@@ -446,6 +449,11 @@ bool Library::writeToFile(const std::string& path) const
     xml = dumper.dumpLibXMLContent(allBookIds);
   };
   return writeTextFile(path, xml);
+}
+
+bool Library::writeToOPDSFile(const std::string& path) const
+{
+  return writeTextFile(path, dumpOpds(path));
 }
 
 bool Library::writeBookmarksToFile(const std::string& path) const

--- a/src/library_dumper.cpp
+++ b/src/library_dumper.cpp
@@ -50,7 +50,8 @@ kainjow::mustache::list getBookIllustrationInfo(const Book& book)
 std::string fullEntryOpds(const Book& book,
                          const std::string& rootLocation,
                          const std::string& contentAccessUrl,
-                         const std::string& contentId)
+                         const std::string& contentId,
+                         const std::string& selfPath)
 {
     const auto bookDate = book.getDate() + "T00:00:00Z";
     const kainjow::mustache::object data{
@@ -74,6 +75,7 @@ std::string fullEntryOpds(const Book& book,
       {"url", onlyAsNonEmptyMustacheValue(book.getUrl())},
       {"size", to_string(book.getSize())},
       {"icons", getBookIllustrationInfo(book)},
+      {"self_path", onlyAsNonEmptyMustacheValue(selfPath)},
     };
     return render_template(RESOURCE::templates::catalog_v2_entry_xml, data);
 }

--- a/src/library_dumper.cpp
+++ b/src/library_dumper.cpp
@@ -11,6 +11,28 @@
 namespace kiwix
 {
 
+namespace
+{
+
+std::string getIllustrationMimeTypeStr(const Book::Illustration& illustration)
+{
+  std::ostringstream result;
+
+  result << illustration.mimeType;
+  if ( !contains(illustration.mimeType, ";width=") ) {
+      result << ";width=" << illustration.width;
+  }
+  if ( !contains(illustration.mimeType, ";height=") ) {
+      result << ";height=" << illustration.height;
+  }
+  if ( !contains(illustration.mimeType, ";scale=") ) {
+      result << ";scale=1";
+  }
+  return result.str();
+}
+
+} // namespace
+
 kainjow::mustache::list getBookIllustrationInfo(const Book& book)
 {
     kainjow::mustache::list illustrations;
@@ -19,7 +41,7 @@ kainjow::mustache::list getBookIllustrationInfo(const Book& book)
       // So we can simply pass one size to mustache.
       illustrations.push_back(kainjow::mustache::object{
         {"icon_size", to_string(illustration->width)},
-        {"icon_mimetype", illustration->mimeType}
+        {"icon_mimetype", getIllustrationMimeTypeStr(*illustration)}
       });
     }
     return illustrations;

--- a/src/library_dumper.h
+++ b/src/library_dumper.h
@@ -49,10 +49,9 @@ kainjow::mustache::list getBookIllustrationInfo(const Book& book);
  * @param contentId The identifier of the book's content, used when building
  *                 content access links.
  * @param selfPath If non-empty, rendered as the entry's rel="self" link (its
- *                 local file path). Only meant for local/offline dumps
- *                 (LibOPDSDumper) - leave empty for the live HTTP catalog
- *                 (OPDSDumper), which must not leak server-side filesystem
- *                 paths to remote clients.
+ *                 local file path). Only meant for local/offline dumps, leave
+ *                 empty for the live HTTP catalog (OPDSDumper), which must not
+ *                 leak server-side filesystem paths to remote clients.
  */
 std::string fullEntryOpds(const Book& book,
                           const std::string& rootLocation,

--- a/src/library_dumper.h
+++ b/src/library_dumper.h
@@ -40,11 +40,25 @@ kainjow::mustache::list getBookIllustrationInfo(const Book& book);
 
 /**
  * Render the full OPDS entry XML for a book.
+ *
+ * @param book The book to render the OPDS entry for.
+ * @param rootLocation The root URL/path the catalog is served from, used to
+ *                 build absolute links within the entry.
+ * @param contentAccessUrl The URL (or URL prefix) used to access the book's
+ *                 content itself (as opposed to the catalog entry).
+ * @param contentId The identifier of the book's content, used when building
+ *                 content access links.
+ * @param selfPath If non-empty, rendered as the entry's rel="self" link (its
+ *                 local file path). Only meant for local/offline dumps
+ *                 (LibOPDSDumper) - leave empty for the live HTTP catalog
+ *                 (OPDSDumper), which must not leak server-side filesystem
+ *                 paths to remote clients.
  */
 std::string fullEntryOpds(const Book& book,
                           const std::string& rootLocation,
                           const std::string& contentAccessUrl,
-                          const std::string& contentId);
+                          const std::string& contentId,
+                          const std::string& selfPath = "");
 
 /**
  * A base class to dump Library in various formats.
@@ -73,7 +87,7 @@ class LibraryDumper
   void setContentAccessUrl(const std::string& url) { this->contentAccessUrl = url; }
 
   /**
-   * Set some informations about the search results.
+   * Set some information about the search results.
    *
    * @param totalResult the total number of results of the search.
    * @param startIndex the start index of the result.

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -170,7 +170,7 @@ bool Manager::readXml(const std::string& xml,
 
 bool Manager::parseOpdsDom(const pugi::xml_document& doc,
                            const std::string& urlHost,
-                           const std::string& libraryPath,
+                           const std::string& baseDir,
                            bool readOnly)
 {
   pugi::xml_node libraryNode = doc.child("feed");
@@ -194,8 +194,6 @@ bool Manager::parseOpdsDom(const pugi::xml_document& doc,
     m_itemsPerPage = 0;
   }
 
-
-  const auto baseDir = removeLastPathElement(libraryPath);
   for (pugi::xml_node entryNode = libraryNode.child("entry"); entryNode;
        entryNode = entryNode.next_sibling("entry")) {
     kiwix::Book book;
@@ -222,7 +220,8 @@ bool Manager::readOpds(const std::string& content,
       = doc.load_buffer((void*)content.data(), content.size());
 
   if (result) {
-    return this->parseOpdsDom(doc, urlHost, libraryPath, readOnly);
+    const auto origin = resolveContentOrigin(libraryPath);
+    return this->parseOpdsDom(doc, urlHost, origin.baseDir, readOnly);
   }
 
   return false;

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -171,6 +171,7 @@ bool Manager::readXml(const std::string& xml,
 
 bool Manager::parseOpdsDom(const pugi::xml_document& doc,
                            const std::string& urlHost,
+                           const std::string& libraryPath,
                            bool readOnly,
                            bool trustLibrary)
 {
@@ -190,7 +191,7 @@ bool Manager::parseOpdsDom(const pugi::xml_document& doc,
     kiwix::Book book;
 
     book.setReadOnly(readOnly);
-    book.updateFromOpds(entryNode, urlHost);
+    book.updateFromOpds(entryNode, urlHost, removeLastPathElement(libraryPath));
 
     if (!trustLibrary && !book.getPath().empty()) {
       this->readBookFromPath(book.getPath(), &book);
@@ -212,7 +213,7 @@ bool Manager::readOpds(const std::string& content, const std::string& urlHost)
       = doc.load_buffer((void*)content.data(), content.size());
 
   if (result) {
-    this->parseOpdsDom(doc, urlHost, /*readOnly=*/false, /*trustLibrary=*/true);
+    this->parseOpdsDom(doc, urlHost, /*libraryPath=*/"", /*readOnly=*/false, /*trustLibrary=*/true);
     return true;
   }
 
@@ -236,7 +237,7 @@ bool Manager::readFile(
   if (result) {
     FileFormat format = detectFormat(path);
     if (format == FileFormat::OPDS) {
-      this->parseOpdsDom(doc, "", readOnly, trustLibrary);
+      this->parseOpdsDom(doc, "", path, readOnly, trustLibrary);
     } else {
       this->parseXmlDom(doc, readOnly, path, trustLibrary);
     }

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -32,6 +32,32 @@
 
 namespace fs = std::filesystem;
 
+namespace
+{
+
+/**
+ * The format of the file passed to readFile().
+ */
+enum class FileFormat { XML, OPDS };
+
+/**
+ * Detect the format of a library file based on its content.
+ *
+ * @param libraryPath The path of the file to inspect.
+ * @return FileFormat::OPDS if the file content looks like an OPDS feed,
+ *         FileFormat::XML otherwise.
+ */
+FileFormat detectFormat(const std::string& libraryPath)
+{
+  auto format
+      = (kiwix::getFileContent(libraryPath).find("<feed") != std::string::npos)
+            ? FileFormat::OPDS
+            : FileFormat::XML;
+  return format;
+}
+
+} // anonymous namespace
+
 namespace kiwix
 {
 
@@ -208,7 +234,12 @@ bool Manager::readFile(
 #endif
 
   if (result) {
-    this->parseXmlDom(doc, readOnly, path, trustLibrary);
+    FileFormat format = detectFormat(path);
+    if (format == FileFormat::OPDS) {
+      this->parseOpdsDom(doc, "", readOnly, trustLibrary);
+    } else {
+      this->parseXmlDom(doc, readOnly, path, trustLibrary);
+    }
   } else {
     retVal = false;
   }

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -142,7 +142,9 @@ bool Manager::readXml(const std::string& xml,
 
 
 
-bool Manager::parseOpdsDom(const pugi::xml_document& doc, const std::string& urlHost)
+bool Manager::parseOpdsDom(const pugi::xml_document& doc,
+                           const std::string& urlHost,
+                           bool readOnly)
 {
   pugi::xml_node libraryNode = doc.child("feed");
   if (!libraryNode) {
@@ -169,7 +171,7 @@ bool Manager::parseOpdsDom(const pugi::xml_document& doc, const std::string& url
        entryNode = entryNode.next_sibling("entry")) {
     kiwix::Book book;
 
-    book.setReadOnly(false);
+    book.setReadOnly(readOnly);
     book.updateFromOpds(entryNode, urlHost);
 
     /* Update the book properties with the new importer */
@@ -181,15 +183,16 @@ bool Manager::parseOpdsDom(const pugi::xml_document& doc, const std::string& url
 
 
 
-bool Manager::readOpds(const std::string& content, const std::string& urlHost)
+bool Manager::readOpds(const std::string& content,
+                       const std::string& urlHost,
+                       bool readOnly)
 {
   pugi::xml_document doc;
   pugi::xml_parse_result result
       = doc.load_buffer((void*)content.data(), content.size());
 
   if (result) {
-    this->parseOpdsDom(doc, urlHost);
-    return true;
+    return this->parseOpdsDom(doc, urlHost, readOnly);
   }
 
   return false;

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -170,6 +170,7 @@ bool Manager::readXml(const std::string& xml,
 
 bool Manager::parseOpdsDom(const pugi::xml_document& doc,
                            const std::string& urlHost,
+                           const std::string& libraryPath,
                            bool readOnly)
 {
   pugi::xml_node libraryNode = doc.child("feed");
@@ -193,12 +194,14 @@ bool Manager::parseOpdsDom(const pugi::xml_document& doc,
     m_itemsPerPage = 0;
   }
 
+
+  const auto baseDir = removeLastPathElement(libraryPath);
   for (pugi::xml_node entryNode = libraryNode.child("entry"); entryNode;
        entryNode = entryNode.next_sibling("entry")) {
     kiwix::Book book;
 
     book.setReadOnly(readOnly);
-    book.updateFromOpds(entryNode, urlHost);
+    book.updateFromOpds(entryNode, urlHost, baseDir);
 
     /* Update the book properties with the new importer */
     manipulator.addBookToLibrary(book);
@@ -211,14 +214,15 @@ bool Manager::parseOpdsDom(const pugi::xml_document& doc,
 
 bool Manager::readOpds(const std::string& content,
                        const std::string& urlHost,
-                       bool readOnly)
+                       bool readOnly,
+                       const std::string& libraryPath)
 {
   pugi::xml_document doc;
   pugi::xml_parse_result result
       = doc.load_buffer((void*)content.data(), content.size());
 
   if (result) {
-    return this->parseOpdsDom(doc, urlHost, readOnly);
+    return this->parseOpdsDom(doc, urlHost, libraryPath, readOnly);
   }
 
   return false;
@@ -243,7 +247,7 @@ bool Manager::readFile(
   const std::string content = getFileContent(path);
 
   return detectFormat(content) == FileFormat::OPDS
-    ? this->readOpds(content, "", readOnly)
+    ? this->readOpds(content, "", readOnly, path)
     : this->readXml(content, readOnly, path, trustLibrary);
 }
 

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -143,7 +143,10 @@ bool Manager::readXml(const std::string& xml,
 
 
 
-bool Manager::parseOpdsDom(const pugi::xml_document& doc, const std::string& urlHost)
+bool Manager::parseOpdsDom(const pugi::xml_document& doc,
+                           const std::string& urlHost,
+                           bool readOnly,
+                           bool trustLibrary)
 {
   pugi::xml_node libraryNode = doc.child("feed");
 
@@ -160,8 +163,12 @@ bool Manager::parseOpdsDom(const pugi::xml_document& doc, const std::string& url
        entryNode = entryNode.next_sibling("entry")) {
     kiwix::Book book;
 
-    book.setReadOnly(false);
+    book.setReadOnly(readOnly);
     book.updateFromOpds(entryNode, urlHost);
+
+    if (!trustLibrary && !book.getPath().empty()) {
+      this->readBookFromPath(book.getPath(), &book);
+    }
 
     /* Update the book properties with the new importer */
     manipulator.addBookToLibrary(book);
@@ -179,7 +186,7 @@ bool Manager::readOpds(const std::string& content, const std::string& urlHost)
       = doc.load_buffer((void*)content.data(), content.size());
 
   if (result) {
-    this->parseOpdsDom(doc, urlHost);
+    this->parseOpdsDom(doc, urlHost, /*readOnly=*/false, /*trustLibrary=*/true);
     return true;
   }
 

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -31,6 +31,32 @@
 
 namespace fs = std::filesystem;
 
+namespace
+{
+
+/**
+ * The format of the file passed to readFile().
+ */
+enum class FileFormat { XML, OPDS };
+
+/**
+ * Detect the format of a library file based on its content.
+ *
+ * @param content The content of the file to inspect.
+ * @return FileFormat::OPDS if the file content looks like an OPDS feed,
+ *         FileFormat::XML otherwise.
+ */
+FileFormat detectFormat(const std::string& content)
+{
+  auto format
+      = (content.find("<feed") != std::string::npos)
+            ? FileFormat::OPDS
+            : FileFormat::XML;
+  return format;
+}
+
+} // anonymous namespace
+
 namespace kiwix
 {
 
@@ -214,8 +240,11 @@ bool Manager::readFile(
     return false;
   }
 
-  const std::string xml = getFileContent(path);
-  return this->readXml(xml, readOnly, path, trustLibrary);
+  const std::string content = getFileContent(path);
+
+  return detectFormat(content) == FileFormat::OPDS
+    ? this->readOpds(content, "", readOnly)
+    : this->readXml(content, readOnly, path, trustLibrary);
 }
 
 

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -211,17 +211,16 @@ bool Manager::parseOpdsDom(const pugi::xml_document& doc,
 
 
 bool Manager::readOpds(const std::string& content,
-                       const std::string& urlHost,
-                       bool readOnly,
-                       const std::string& libraryPath)
+                       const std::string& contentOriginUri,
+                       bool readOnly)
 {
   pugi::xml_document doc;
   pugi::xml_parse_result result
       = doc.load_buffer((void*)content.data(), content.size());
 
   if (result) {
-    const auto origin = resolveContentOrigin(libraryPath);
-    return this->parseOpdsDom(doc, urlHost, origin.baseDir, readOnly);
+    const auto origin = resolveContentOrigin(contentOriginUri);
+    return this->parseOpdsDom(doc, origin.urlHost, origin.baseDir, readOnly);
   }
 
   return false;
@@ -246,7 +245,7 @@ bool Manager::readFile(
   const std::string content = getFileContent(path);
 
   return detectFormat(content) == FileFormat::OPDS
-    ? this->readOpds(content, "", readOnly, path)
+    ? this->readOpds(content, path, readOnly)
     : this->readXml(content, readOnly, path, trustLibrary);
 }
 

--- a/src/tools/pathTools.cpp
+++ b/src/tools/pathTools.cpp
@@ -228,6 +228,19 @@ std::string kiwix::removeLastPathElement(const std::string& path)
   return ret;
 }
 
+kiwix::ContentOrigin kiwix::resolveContentOrigin(const std::string& contentOriginUri)
+{
+  const auto schemeEnd = contentOriginUri.find("://");
+  if (schemeEnd == std::string::npos) {
+    return { /*urlHost=*/"", removeLastPathElement(contentOriginUri) };
+  }
+  const auto pathStart = contentOriginUri.find('/', schemeEnd + 3);
+  const auto urlHost = pathStart == std::string::npos
+                      ? contentOriginUri
+                      : contentOriginUri.substr(0, pathStart);
+  return { urlHost, /*baseDir=*/"" };
+}
+
 std::string kiwix::appendToDirectory(const std::string& directoryPath, const std::string& filename)
 {
   std::string newPath = directoryPath;

--- a/src/tools/stringTools.h
+++ b/src/tools/stringTools.h
@@ -69,8 +69,8 @@ std::string lcAll(const std::string& word);
 std::string ucFirst(const std::string& word);
 std::string lcFirst(const std::string& word);
 
-/* This function is broken, related Github issue 
- * https://github.com/kiwix/libkiwix/issues/1188 */ 
+/* This function is broken, related Github issue
+ * https://github.com/kiwix/libkiwix/issues/1188 */
 std::string toTitle(const std::string& word);
 
 std::string normalize(const std::string& word);
@@ -97,6 +97,12 @@ template<>
 std::string extractFromString(const std::string& str);
 
 bool startsWith(const std::string& base, const std::string& start);
+
+inline bool contains(const std::string& str, const std::string& substr)
+{
+  return str.find(substr) != std::string::npos;
+}
+
 
 std::string stripSuffix(const std::string& str, const std::string& suffix);
 

--- a/static/templates/catalog_v2_entry.xml
+++ b/static/templates/catalog_v2_entry.xml
@@ -24,5 +24,5 @@
     <dc:issued>{{book_date}}</dc:issued>
     {{#url}}
     <link rel="http://opds-spec.org/acquisition/open-access" type="application/x-zim" href="{{{url}}}" length="{{{size}}}" />
-    {{/url}}
+    {{/url}}{{#self_path}}<link rel="self" href="{{self_path}}" type="application/x-zim"/>{{/self_path}}
   </entry>

--- a/static/templates/catalog_v2_entry.xml
+++ b/static/templates/catalog_v2_entry.xml
@@ -12,7 +12,7 @@
     <mediaCount>{{media_count}}</mediaCount>
     {{#icons}}<link rel="http://opds-spec.org/image/thumbnail"
           href="{{root}}/catalog/v2/illustration/{{{id}}}/?size={{icon_size}}"
-          type="{{icon_mimetype}};width={{icon_size}};height={{icon_size}};scale=1"/>
+          type="{{icon_mimetype}}"/>
     {{/icons}}{{#contentAccessUrl}}<link type="text/html" href="{{contentAccessUrl}}/{{{content_id}}}" />
     {{/contentAccessUrl}}
     <author>

--- a/static/templates/catalog_v2_entry.xml
+++ b/static/templates/catalog_v2_entry.xml
@@ -14,8 +14,7 @@
           href="{{root}}/catalog/v2/illustration/{{{id}}}/?size={{icon_size}}"
           type="{{icon_mimetype}}"/>
     {{/icons}}{{#contentAccessUrl}}<link type="text/html" href="{{contentAccessUrl}}/{{{content_id}}}" />
-    {{/contentAccessUrl}}
-    <author>
+    {{/contentAccessUrl}}<author>
       <name>{{author_name}}</name>
     </author>
     <publisher>

--- a/test/book.cpp
+++ b/test/book.cpp
@@ -90,11 +90,11 @@ TEST(BookTest, updateFromOPDSTest)
     )");
 
     kiwix::Book book;
-    book.updateFromOpds(opds.child("entry"), "http://who.org");
+    book.updateFromOpds(opds.child("entry"), "http://who.org", "");
 
-    // Unlike updateFromXml(), updateFromOpds() has no notion of a local
-    // path - OPDS entries only ever carry acquisition/thumbnail links, so
-    // these are expected to stay at their default (unset) values.
+    // This entry has no rel="self" link, so - unlike updateFromXml(), which
+    // always resolves a "path" attribute - updateFromOpds() leaves path at
+    // its default (unset) value.
     EXPECT_EQ(book.getPath(), "");
     EXPECT_FALSE(book.isPathValid());
 
@@ -126,6 +126,25 @@ TEST(BookTest, updateFromOPDSTest)
     EXPECT_EQ(defaultIllustration->url, "http://who.org/zara.fav");
 }
 
+TEST(BookTest, updateFromOPDSSelfLinkTest)
+{
+    const XMLDoc opds(R"(
+      <entry>
+        <id>urn:uuid:zara</id>
+        <link rel="self" href="zara.zim" />
+      </entry>
+    )");
+
+    kiwix::Book book;
+    book.updateFromOpds(opds.child("entry"), "http://who.org", DATA_ABS_PATH);
+
+    // Unlike the acquisition/thumbnail links, a rel="self" link's href IS
+    // resolved against baseDir when relative - mirroring
+    // updateFromXml()'s "path" attribute handling (see
+    // BookTest.updateFromXMLTest above).
+    EXPECT_EQ(book.getPath(), ZARA_ABS_PATH);
+}
+
 namespace
 {
 
@@ -137,11 +156,11 @@ kiwix::Book makeBook(const std::string& attr, const std::string& baseDir="")
     return book;
 }
 
-kiwix::Book makeBookFromOpds(const std::string& entryContent, const std::string& urlHost="")
+kiwix::Book makeBookFromOpds(const std::string& entryContent, const std::string& urlHost="", const std::string& baseDir="")
 {
     const XMLDoc opds("<entry>" + entryContent + "</entry>");
     kiwix::Book book;
-    book.updateFromOpds(opds.child("entry"), urlHost);
+    book.updateFromOpds(opds.child("entry"), urlHost, baseDir);
     return book;
 }
 

--- a/test/book.cpp
+++ b/test/book.cpp
@@ -242,6 +242,23 @@ TEST(BookTest, updateFromOPDSCategoryHandlingTest)
   }
 }
 
+TEST(BookTest, updateFromOPDSThumbnailWithAbsoluteHrefIgnoresUrlHostTest)
+{
+    // An already-absolute href (as real OPDS catalogs commonly send, see
+    // test/data/library.opds) must be left untouched, not prefixed with
+    // urlHost - concatenating the two would produce a garbled URL. This is
+    // the counterpart to updateFromOPDSTest above, which covers the
+    // relative-href case (where prefixing with urlHost IS expected).
+    const kiwix::Book book = makeBookFromOpds(R"(
+        <link rel="http://opds-spec.org/image/thumbnail"
+              type="image/png"
+              href="https://example.com/favicon/zara.png" />
+    )", "http://who.org");
+
+    const auto illustration = book.getIllustrations().at(0);
+    EXPECT_EQ(illustration->url, "https://example.com/favicon/zara.png");
+}
+
 TEST(BookTest, setTagsDoesntAffectCategory)
 {
     kiwix::Book book;

--- a/test/book.cpp
+++ b/test/book.cpp
@@ -259,6 +259,55 @@ TEST(BookTest, updateFromOPDSThumbnailWithAbsoluteHrefIgnoresUrlHostTest)
     EXPECT_EQ(illustration->url, "https://example.com/favicon/zara.png");
 }
 
+TEST(BookTest, updateFromOPDSMultipleBase64ThumbnailsTest)
+{
+    const kiwix::Book book = makeBookFromOpds(R"(
+        <thumbnails>
+          <thumbnail width="96" height="256" mimetype="image/jpeg">Zmlyc3QtdGh1bWJuYWls</thumbnail>
+          <thumbnail>c2Vjb25kLXRodW1ibmFpbA==</thumbnail>
+        </thumbnails>
+    )");
+
+    const auto& illustrations = book.getIllustrations();
+    ASSERT_EQ(illustrations.size(), 2U);
+    EXPECT_EQ(illustrations[0]->getData(), "first-thumbnail");
+    EXPECT_EQ(illustrations[0]->width, 96);
+    EXPECT_EQ(illustrations[0]->height, 256);
+    EXPECT_EQ(illustrations[0]->mimeType, "image/jpeg");
+
+    EXPECT_EQ(illustrations[1]->getData(), "second-thumbnail");
+    EXPECT_EQ(illustrations[1]->width, 48);
+    EXPECT_EQ(illustrations[1]->height, 48);
+    EXPECT_EQ(illustrations[1]->mimeType, "");
+}
+
+TEST(BookTest, updateFromOPDSBase64ThumbnailPartialAttributesTest)
+{
+    // Only "width" is given; "height" and "mimetype" are missing and must
+    // fall back to the Illustration's own defaults independently.
+    const kiwix::Book book = makeBookFromOpds(R"(
+        <thumbnails>
+          <thumbnail width="96">Zmlyc3QtdGh1bWJuYWls</thumbnail>
+        </thumbnails>
+    )");
+
+    const auto& illustrations = book.getIllustrations();
+    ASSERT_EQ(illustrations.size(), 1U);
+    EXPECT_EQ(illustrations[0]->getData(), "first-thumbnail");
+    EXPECT_EQ(illustrations[0]->width, 96);
+    EXPECT_EQ(illustrations[0]->height, 48);
+    EXPECT_EQ(illustrations[0]->mimeType, "");
+}
+
+TEST(BookTest, updateFromOPDSNoThumbnailsTest)
+{
+    const kiwix::Book book = makeBookFromOpds(R"(
+        <id>abcd</id>
+    )");
+
+    EXPECT_TRUE(book.getIllustrations().empty());
+}
+
 TEST(BookTest, setTagsDoesntAffectCategory)
 {
     kiwix::Book book;

--- a/test/data/lib_for_server_search_test.opds
+++ b/test/data/lib_for_server_search_test.opds
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom"
+      xmlns:dc="http://purl.org/dc/terms/"
+      xmlns:opds="http://opds-spec.org/2010/catalog">
+  <id>32f4d6e1-1a5b-4c9a-9d4a-0b8f2f7f9c3a</id>
+  <title>lib_for_server_search_test</title>
+  <entry>
+    <id>urn:uuid:5dc0b3af-5df2-0925-f0ca-d2bf75e78af6</id>
+    <title>Wikibooks</title>
+    <updated>2021-04-17T00:00:00Z</updated>
+    <summary>testZim</summary>
+    <language>eng</language>
+    <name>bookname_of_example_zim</name>
+    <tags>_ftindex:yes;_ftindex:yes;_pictures:yes;_videos:yes;_details:yes</tags>
+    <mediaCount>22</mediaCount>
+    <author>
+      <name>test</name>
+    </author>
+    <publisher>
+      <name>test</name>
+    </publisher>
+    <dc:issued>2021-04-17T00:00:00Z</dc:issued>
+    <link rel="self" href="./example.zim" type="application/x-zim"/>
+  </entry>
+  <entry>
+    <id>urn:uuid:6f1d19d0-633f-087b-fb55-7ac324ff9baf</id>
+    <title>Ray Charles</title>
+    <updated>2020-03-31T00:00:00Z</updated>
+    <summary>Wikipedia articles about Ray Charles</summary>
+    <language>eng</language>
+    <name>wikipedia_en_ray_charles</name>
+    <flavour>_mini</flavour>
+    <tags>wikipedia;_category:wikipedia;_pictures:no;_videos:no;_details:no;_ftindex:yes</tags>
+    <articleCount>129</articleCount>
+    <mediaCount>45</mediaCount>
+    <author>
+      <name>Wikipedia</name>
+    </author>
+    <publisher>
+      <name>Kiwix</name>
+    </publisher>
+    <dc:issued>2020-03-31T00:00:00Z</dc:issued>
+    <link rel="self" href="./zimfile.zim" type="application/x-zim"/>
+  </entry>
+</feed>

--- a/test/data/library.opds
+++ b/test/data/library.opds
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  OPDS analogue of library.xml - same four books, with each XML attribute
+  mapped to its corresponding OPDS element/link (see Book::updateFromOpds()
+  in src/book.cpp):
+    id                       -> <id>urn:uuid:ID</id> ("urn:uuid:" is
+                                 stripped by updateFromOpds())
+    path                     -> no OPDS equivalent (OPDS entries have no
+                                 local path - see Book::updateFromOpds())
+    url                      -> acquisition <link>'s href
+    size (KiB, XML)          -> acquisition <link>'s length (bytes, i.e.
+                                 size * 1024)
+    title/description/       -> <title>/<summary>/<language>/<name>/<tags>
+      language/name/tags
+    creator/publisher        -> <author><name>/<publisher><name>
+    date                     -> <updated> (only the first 10 chars are kept
+                                 by Book::fromOpdsDate())
+    articleCount/mediaCount  -> <articleCount>/<mediaCount>
+    favicon/faviconMimeType  -> thumbnail <link>'s href/type (OPDS only
+                                 carries a URL to the image, never embedded
+                                 data, so favicon's placeholder text becomes
+                                 a placeholder href instead)
+-->
+<feed xmlns="http://www.w3.org/2005/Atom"
+      xmlns:opds="https://specs.opds.io/opds-1.2">
+  <id>7f8a2b1e-0000-4000-8000-000000000000</id>
+  <title>Test OPDS library</title>
+  <entry>
+    <id>urn:uuid:raycharles</id>
+    <title>Ray Charles</title>
+    <summary>Wikipedia articles about Ray Charles (not all of them but near to what an average newborn may find more than enough)</summary>
+    <language>eng</language>
+    <author><name>Wikipedia</name></author>
+    <publisher><name>Kiwix</name></publisher>
+    <updated>2020-03-31T00:00:00Z</updated>
+    <name>wikipedia_en_ray_charles</name>
+    <tags>public_tag_without_a_value;_private_tag_without_a_value;wikipedia;_category:wikipedia;_pictures:no;_videos:no;_details:no;_ftindex:yes</tags>
+    <articleCount>284</articleCount>
+    <mediaCount>2</mediaCount>
+    <link rel="http://opds-spec.org/acquisition/open-access"
+          type="application/x-zim"
+          href="https://github.com/kiwix/libkiwix/raw/master/test/data/zimfile_raycharles.zim"
+          length="569344" />
+    <link rel="http://opds-spec.org/image/thumbnail"
+          type="image/png;width=48;height=48;scale=1"
+          href="https://example.com/favicon/raycharles.png" />
+  </entry>
+  <entry>
+    <id>urn:uuid:raycharles_uncategorized</id>
+    <title>Ray (uncategorized) Charles</title>
+    <summary>No category is assigned to this library entry (neither adj nor xor was considered a good option)</summary>
+    <language>rus,eng</language>
+    <author><name>Wikipedia</name></author>
+    <publisher><name>Kiwix</name></publisher>
+    <updated>2020-03-31T00:00:00Z</updated>
+    <name>wikipedia_ru_ray_charles</name>
+    <tags>public_tag_with_a_value:value_of_a_public_tag;_private_tag_with_a_value:value_of_a_private_tag;wikipedia;_pictures:no;_videos:no;_details:no</tags>
+    <articleCount>284</articleCount>
+    <mediaCount>2</mediaCount>
+    <link rel="http://opds-spec.org/acquisition/open-access"
+          type="application/x-zim"
+          href="https://github.com/kiwix/libkiwix/raw/master/test/data/zimfile_raycharles_uncategorized.zim"
+          length="125952" />
+  </entry>
+  <entry>
+    <id>urn:uuid:charlesray</id>
+    <title>Charles, Ray</title>
+    <summary>Wikipedia articles about Ray Charles or why and when one should go to library</summary>
+    <language>fra</language>
+    <author><name>Wikipedia</name></author>
+    <publisher><name>Kiwix</name></publisher>
+    <updated>2020-03-31T00:00:00Z</updated>
+    <name>wikipedia_fr_ray_charles</name>
+    <tags>unittest;wikipedia;_category:jazz;_pictures:no;_videos:no;_details:no;_ftindex:yes</tags>
+    <articleCount>284</articleCount>
+    <mediaCount>2</mediaCount>
+    <link rel="http://opds-spec.org/acquisition/open-access"
+          type="application/x-zim"
+          href="https://github.com/kiwix/libkiwix/raw/master/test/data/zimfile%26other.zim"
+          length="569344" />
+    <link rel="http://opds-spec.org/image/thumbnail"
+          href="https://example.com/favicon/charlesray" />
+  </entry>
+  <entry>
+    <id>urn:uuid:inaccessiblezim</id>
+    <title>Catalog of all catalogs</title>
+    <summary>Testing that running kiwix-serve without access to ZIM files doesn't lead to a catastrophe</summary>
+    <language>cat</language>
+    <author><name>Catherine of Catalonia</name></author>
+    <publisher><name>Caterpillar</name></publisher>
+    <updated>2025-09-04T00:00:00Z</updated>
+    <name>catalog_of_all_catalogs</name>
+    <tags>unittest;_category:cats</tags>
+    <articleCount>12107</articleCount>
+    <mediaCount>8</mediaCount>
+    <link rel="http://opds-spec.org/acquisition/open-access"
+          type="application/x-zim"
+          href="https://github.com/kiwix/libkiwix/raw/master/test/data/nosuchzimfile.zim"
+          length="20736925696" />
+    <link rel="http://opds-spec.org/image/thumbnail"
+          href="https://example.com/favicon/inaccessiblezim" />
+  </entry>
+</feed>

--- a/test/data/library.opds
+++ b/test/data/library.opds
@@ -5,8 +5,10 @@
   in src/book.cpp):
     id                       -> <id>urn:uuid:ID</id> ("urn:uuid:" is
                                  stripped by updateFromOpds())
-    path                     -> no OPDS equivalent (OPDS entries have no
-                                 local path - see Book::updateFromOpds())
+    path                     -> rel="self" <link>'s href, resolved against
+                                 the library file's own directory just like
+                                 XML's "path" attribute (see
+                                 Book::updateFromOpds())
     url                      -> acquisition <link>'s href
     size (KiB, XML)          -> acquisition <link>'s length (bytes, i.e.
                                  size * 1024)
@@ -37,6 +39,7 @@
     <tags>public_tag_without_a_value;_private_tag_without_a_value;wikipedia;_category:wikipedia;_pictures:no;_videos:no;_details:no;_ftindex:yes</tags>
     <articleCount>284</articleCount>
     <mediaCount>2</mediaCount>
+    <link rel="self" href="./zimfile_raycharles.zim" />
     <link rel="http://opds-spec.org/acquisition/open-access"
           type="application/x-zim"
           href="https://github.com/kiwix/libkiwix/raw/master/test/data/zimfile_raycharles.zim"
@@ -57,6 +60,7 @@
     <tags>public_tag_with_a_value:value_of_a_public_tag;_private_tag_with_a_value:value_of_a_private_tag;wikipedia;_pictures:no;_videos:no;_details:no</tags>
     <articleCount>284</articleCount>
     <mediaCount>2</mediaCount>
+    <link rel="self" href="./zimfile_raycharles_uncategorized.zim" />
     <link rel="http://opds-spec.org/acquisition/open-access"
           type="application/x-zim"
           href="https://github.com/kiwix/libkiwix/raw/master/test/data/zimfile_raycharles_uncategorized.zim"
@@ -74,6 +78,7 @@
     <tags>unittest;wikipedia;_category:jazz;_pictures:no;_videos:no;_details:no;_ftindex:yes</tags>
     <articleCount>284</articleCount>
     <mediaCount>2</mediaCount>
+    <link rel="self" href="./zimfile&amp;other.zim" />
     <link rel="http://opds-spec.org/acquisition/open-access"
           type="application/x-zim"
           href="https://github.com/kiwix/libkiwix/raw/master/test/data/zimfile%26other.zim"
@@ -93,6 +98,7 @@
     <tags>unittest;_category:cats</tags>
     <articleCount>12107</articleCount>
     <mediaCount>8</mediaCount>
+    <link rel="self" href="./nosuchzimfile.zim" />
     <link rel="http://opds-spec.org/acquisition/open-access"
           type="application/x-zim"
           href="https://github.com/kiwix/libkiwix/raw/master/test/data/nosuchzimfile.zim"

--- a/test/data/library.opds
+++ b/test/data/library.opds
@@ -5,8 +5,10 @@
   in src/book.cpp):
     id                       -> <id>urn:uuid:ID</id> ("urn:uuid:" is
                                  stripped by updateFromOpds())
-    path                     -> no OPDS equivalent (OPDS entries have no
-                                 local path - see Book::updateFromOpds())
+    path                     -> rel="self" <link>'s href, resolved against
+                                 the library file's own directory just like
+                                 XML's "path" attribute (see
+                                 Book::updateFromOpds())
     url                      -> acquisition <link>'s href
     size (KiB, XML)          -> acquisition <link>'s length (bytes, i.e.
                                  size * 1024)
@@ -40,6 +42,7 @@
     <tags>public_tag_without_a_value;_private_tag_without_a_value;wikipedia;_category:wikipedia;_pictures:no;_videos:no;_details:no;_ftindex:yes</tags>
     <articleCount>284</articleCount>
     <mediaCount>2</mediaCount>
+    <link rel="self" href="./zimfile_raycharles.zim" />
     <link rel="http://opds-spec.org/acquisition/open-access"
           type="application/x-zim"
           href="https://github.com/kiwix/libkiwix/raw/master/test/data/zimfile_raycharles.zim"
@@ -60,6 +63,7 @@
     <tags>public_tag_with_a_value:value_of_a_public_tag;_private_tag_with_a_value:value_of_a_private_tag;wikipedia;_pictures:no;_videos:no;_details:no</tags>
     <articleCount>284</articleCount>
     <mediaCount>2</mediaCount>
+    <link rel="self" href="./zimfile_raycharles_uncategorized.zim" />
     <link rel="http://opds-spec.org/acquisition/open-access"
           type="application/x-zim"
           href="https://github.com/kiwix/libkiwix/raw/master/test/data/zimfile_raycharles_uncategorized.zim"
@@ -77,6 +81,7 @@
     <tags>unittest;wikipedia;_category:jazz;_pictures:no;_videos:no;_details:no;_ftindex:yes</tags>
     <articleCount>284</articleCount>
     <mediaCount>2</mediaCount>
+    <link rel="self" href="./zimfile&amp;other.zim" />
     <link rel="http://opds-spec.org/acquisition/open-access"
           type="application/x-zim"
           href="https://github.com/kiwix/libkiwix/raw/master/test/data/zimfile%26other.zim"
@@ -96,6 +101,7 @@
     <tags>unittest;_category:cats</tags>
     <articleCount>12107</articleCount>
     <mediaCount>8</mediaCount>
+    <link rel="self" href="./nosuchzimfile.zim" />
     <link rel="http://opds-spec.org/acquisition/open-access"
           type="application/x-zim"
           href="https://github.com/kiwix/libkiwix/raw/master/test/data/nosuchzimfile.zim"

--- a/test/data/library.opds
+++ b/test/data/library.opds
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  OPDS analogue of library.xml - same four books, with each XML attribute
+  mapped to its corresponding OPDS element/link (see Book::updateFromOpds()
+  in src/book.cpp):
+    id                       -> <id>urn:uuid:ID</id> ("urn:uuid:" is
+                                 stripped by updateFromOpds())
+    path                     -> no OPDS equivalent (OPDS entries have no
+                                 local path - see Book::updateFromOpds())
+    url                      -> acquisition <link>'s href
+    size (KiB, XML)          -> acquisition <link>'s length (bytes, i.e.
+                                 size * 1024)
+    title/description/       -> <title>/<summary>/<language>/<name>/<tags>
+      language/name/tags
+    creator/publisher        -> <author><name>/<publisher><name>
+    date                     -> <updated> (only the first 10 chars are kept
+                                 by Book::fromOpdsDate())
+    articleCount/mediaCount  -> <articleCount>/<mediaCount>
+    favicon/faviconMimeType  -> thumbnail <link>'s href/type (OPDS only
+                                 carries a URL to the image, never embedded
+                                 data, so favicon's placeholder text becomes
+                                 a placeholder href instead)
+-->
+<feed xmlns="http://www.w3.org/2005/Atom"
+      xmlns:opds="https://specs.opds.io/opds-1.2">
+  <id>7f8a2b1e-0000-4000-8000-000000000000</id>
+  <title>Test OPDS library</title>
+  <totalResults>4</totalResults>
+  <startIndex>0</startIndex>
+  <itemsPerPage>4</itemsPerPage>
+  <entry>
+    <id>urn:uuid:raycharles</id>
+    <title>Ray Charles</title>
+    <summary>Wikipedia articles about Ray Charles (not all of them but near to what an average newborn may find more than enough)</summary>
+    <language>eng</language>
+    <author><name>Wikipedia</name></author>
+    <publisher><name>Kiwix</name></publisher>
+    <updated>2020-03-31T00:00:00Z</updated>
+    <name>wikipedia_en_ray_charles</name>
+    <tags>public_tag_without_a_value;_private_tag_without_a_value;wikipedia;_category:wikipedia;_pictures:no;_videos:no;_details:no;_ftindex:yes</tags>
+    <articleCount>284</articleCount>
+    <mediaCount>2</mediaCount>
+    <link rel="http://opds-spec.org/acquisition/open-access"
+          type="application/x-zim"
+          href="https://github.com/kiwix/libkiwix/raw/master/test/data/zimfile_raycharles.zim"
+          length="569344" />
+    <link rel="http://opds-spec.org/image/thumbnail"
+          type="image/png"
+          href="https://example.com/favicon/raycharles.png" />
+  </entry>
+  <entry>
+    <id>urn:uuid:raycharles_uncategorized</id>
+    <title>Ray (uncategorized) Charles</title>
+    <summary>No category is assigned to this library entry (neither adj nor xor was considered a good option)</summary>
+    <language>rus,eng</language>
+    <author><name>Wikipedia</name></author>
+    <publisher><name>Kiwix</name></publisher>
+    <updated>2020-03-31T00:00:00Z</updated>
+    <name>wikipedia_ru_ray_charles</name>
+    <tags>public_tag_with_a_value:value_of_a_public_tag;_private_tag_with_a_value:value_of_a_private_tag;wikipedia;_pictures:no;_videos:no;_details:no</tags>
+    <articleCount>284</articleCount>
+    <mediaCount>2</mediaCount>
+    <link rel="http://opds-spec.org/acquisition/open-access"
+          type="application/x-zim"
+          href="https://github.com/kiwix/libkiwix/raw/master/test/data/zimfile_raycharles_uncategorized.zim"
+          length="125952" />
+  </entry>
+  <entry>
+    <id>urn:uuid:charlesray</id>
+    <title>Charles, Ray</title>
+    <summary>Wikipedia articles about Ray Charles or why and when one should go to library</summary>
+    <language>fra</language>
+    <author><name>Wikipedia</name></author>
+    <publisher><name>Kiwix</name></publisher>
+    <updated>2020-03-31T00:00:00Z</updated>
+    <name>wikipedia_fr_ray_charles</name>
+    <tags>unittest;wikipedia;_category:jazz;_pictures:no;_videos:no;_details:no;_ftindex:yes</tags>
+    <articleCount>284</articleCount>
+    <mediaCount>2</mediaCount>
+    <link rel="http://opds-spec.org/acquisition/open-access"
+          type="application/x-zim"
+          href="https://github.com/kiwix/libkiwix/raw/master/test/data/zimfile%26other.zim"
+          length="569344" />
+    <link rel="http://opds-spec.org/image/thumbnail"
+          href="https://example.com/favicon/charlesray" />
+  </entry>
+  <entry>
+    <id>urn:uuid:inaccessiblezim</id>
+    <title>Catalog of all catalogs</title>
+    <summary>Testing that running kiwix-serve without access to ZIM files doesn't lead to a catastrophe</summary>
+    <language>cat</language>
+    <author><name>Catherine of Catalonia</name></author>
+    <publisher><name>Caterpillar</name></publisher>
+    <updated>2025-09-04T00:00:00Z</updated>
+    <name>catalog_of_all_catalogs</name>
+    <tags>unittest;_category:cats</tags>
+    <articleCount>12107</articleCount>
+    <mediaCount>8</mediaCount>
+    <link rel="http://opds-spec.org/acquisition/open-access"
+          type="application/x-zim"
+          href="https://github.com/kiwix/libkiwix/raw/master/test/data/nosuchzimfile.zim"
+          length="20736925696" />
+    <link rel="http://opds-spec.org/image/thumbnail"
+          href="https://example.com/favicon/inaccessiblezim" />
+  </entry>
+</feed>

--- a/test/library.cpp
+++ b/test/library.cpp
@@ -268,15 +268,15 @@ const char * sampleOpdsStream = R"(
 )";
 
 #ifdef _WIN32
-# define ZIMFILE_PATH ".\\zimfile.zim"
-# define EXAMPLE_PATH ".\\example.zim"
-# define XML_LIBRARY_PATH ".\\test\\library.xml"
-# define OPDS_LIBRARY_PATH ".\\test\\library.opds"
+# define ZIMFILE_PATH "zimfile.zim"
+# define EXAMPLE_PATH "example.zim"
+# define XML_LIBRARY_PATH "test\\library.xml"
+# define OPDS_LIBRARY_PATH "test\\library.opds"
 #else
-# define ZIMFILE_PATH "./zimfile.zim"
-# define EXAMPLE_PATH "./example.zim"
-# define XML_LIBRARY_PATH "./test/library.xml"
-# define OPDS_LIBRARY_PATH "./test/library.opds"
+# define ZIMFILE_PATH "zimfile.zim"
+# define EXAMPLE_PATH "example.zim"
+# define XML_LIBRARY_PATH "test/library.xml"
+# define OPDS_LIBRARY_PATH "test/library.opds"
 #endif
 
 const char sampleLibraryXML[] = R"(
@@ -315,11 +315,35 @@ const char sampleLibraryXML[] = R"(
 </library>
 )";
 
-const char sampleLibraryOpds[] = R"(
-<feed xmlns="http://www.w3.org/2005/Atom"
+// The formatting of this OPDS XML (element order, indentation, and
+// whitespace) is intentionally chosen to exactly match Library::dumpOpds()'s
+// output, so that it stays invariant when read via Manager::readOpds() and
+// dumped back via Library::dumpOpds() (see LibraryOpdsExportTest.allInOne
+// below). Reformatting this string may break that round-trip test.
+const char sampleLibraryOpds[] = R"(<feed xmlns="http://www.w3.org/2005/Atom"
       xmlns:dc="http://purl.org/dc/terms/"
       xmlns:opds="http://opds-spec.org/2010/catalog">
-  <id>c0602b41-aef2-4c5a-9f31-3f6ee912c159</id>
+  <entry>
+    <id>urn:uuid:example</id>
+    <title>An example ZIM archive</title>
+    <updated>2021-04-11T00:00:00Z</updated>
+    <summary>An eXaMpLe book added to the catalog via XML</summary>
+    <language>deu</language>
+    <name>wikibooks.de</name>
+    <flavour>maxi</flavour>
+    <category>wikibooks</category>
+    <tags>unittest;wikibooks;_category:wikibooks</tags>
+    <articleCount>12</articleCount>
+    <mediaCount>0</mediaCount>
+    <author>
+      <name>Wikibooks</name>
+    </author>
+    <publisher>
+      <name>Kiwix &amp; Some Enthusiasts</name>
+    </publisher>
+    <dc:issued>2021-04-11T00:00:00Z</dc:issued>
+    <link rel="self" href=")" EXAMPLE_PATH R"(" type="application/x-zim"/>
+  </entry>
   <entry>
     <id>urn:uuid:raycharles</id>
     <title>Ray Charles</title>
@@ -327,6 +351,8 @@ const char sampleLibraryOpds[] = R"(
     <summary>Wikipedia articles about Ray Charles</summary>
     <language>eng,spa</language>
     <name>wikipedia_en_ray_charles</name>
+    <flavour>mini</flavour>
+    <category>wikipedia</category>
     <tags>wikipedia;_category:wikipedia;_pictures:no</tags>
     <articleCount>284</articleCount>
     <mediaCount>2</mediaCount>
@@ -339,25 +365,6 @@ const char sampleLibraryOpds[] = R"(
     <dc:issued>2020-03-31T00:00:00Z</dc:issued>
     <link rel="http://opds-spec.org/acquisition/open-access" type="application/x-zim" href="https://github.com/kiwix/libkiwix/raw/master/test/data/zimfile.zim" length="569344" />
     <link rel="self" href=")" ZIMFILE_PATH R"(" type="application/x-zim"/>
-  </entry>
-  <entry>
-    <id>urn:uuid:example</id>
-    <title>An example ZIM archive</title>
-    <updated>2021-04-11T00:00:00Z</updated>
-    <summary>An eXaMpLe book added to the catalog via XML</summary>
-    <language>deu</language>
-    <name>wikibooks.de</name>
-    <tags>unittest;wikibooks;_category:wikibooks</tags>
-    <articleCount>12</articleCount>
-    <mediaCount>0</mediaCount>
-    <author>
-      <name>Wikibooks</name>
-    </author>
-    <publisher>
-      <name>Kiwix &amp; Some Enthusiasts</name>
-    </publisher>
-    <dc:issued>2021-04-11T00:00:00Z</dc:issued>
-    <link rel="self" href=")" EXAMPLE_PATH R"(" type="application/x-zim"/>
   </entry>
 </feed>
 )";
@@ -1344,5 +1351,17 @@ TEST_P(LibraryTest, removeBooksNotUpdatedSince)
     "Mythology & Folklore Stack Exchange",
   );
 };
+
+TEST(LibraryOpdsExportTest, allInOne)
+{
+  auto lib = kiwix::Library::create();
+  kiwix::Manager manager(lib);
+  manager.readOpds(sampleLibraryOpds, OPDS_LIBRARY_PATH);
+
+  // sampleLibraryOpds is formatted to be round-trip invariant (see comment
+  // above its definition), so dumping what was just read back out should
+  // reproduce it exactly.
+  EXPECT_EQ(lib->dumpOpds(OPDS_LIBRARY_PATH), sampleLibraryOpds);
+}
 
 };

--- a/test/library.cpp
+++ b/test/library.cpp
@@ -327,7 +327,7 @@ TEST(LibraryOpdsImportTest, allInOne)
 {
   auto lib = kiwix::Library::create();
   kiwix::Manager manager(lib);
-  manager.readOpds(sampleOpdsStream, "library-opds-import.unittests.dev");
+  manager.readOpds(sampleOpdsStream, "http://library-opds-import.unittests.dev");
 
   EXPECT_EQ(14U, lib->getBookCount(true, true));
 
@@ -354,7 +354,7 @@ TEST(LibraryOpdsImportTest, allInOne)
   EXPECT_EQ(illustration->width, 48U);
   EXPECT_EQ(illustration->height, 48U);
   EXPECT_EQ(illustration->mimeType, "image/png");
-  EXPECT_EQ(illustration->url, "library-opds-import.unittests.dev/meta?name=favicon&content=wikipedia_fr_tunisie_novid_2018-10");
+  EXPECT_EQ(illustration->url, "http://library-opds-import.unittests.dev/meta?name=favicon&content=wikipedia_fr_tunisie_novid_2018-10");
   }
 
   {
@@ -379,7 +379,7 @@ TEST(LibraryOpdsImportTest, allInOne)
   EXPECT_EQ(illustration->width, 48U);
   EXPECT_EQ(illustration->height, 48U);
   EXPECT_EQ(illustration->mimeType, "image/png");
-  EXPECT_EQ(illustration->url, "library-opds-import.unittests.dev/meta?name=favicon&content=ted_en_business_2018-07");
+  EXPECT_EQ(illustration->url, "http://library-opds-import.unittests.dev/meta?name=favicon&content=ted_en_business_2018-07");
   }
 }
 
@@ -392,7 +392,7 @@ class LibraryTest : public ::testing::Test {
 
   void SetUp() override {
      kiwix::Manager manager(lib);
-     manager.readOpds(sampleOpdsStream, "foo.urlHost");
+     manager.readOpds(sampleOpdsStream, "http://foo.urlHost");
      manager.readXml(sampleLibraryXML, false, LIBRARY_PATH, true);
   }
 
@@ -480,7 +480,7 @@ TEST_F(LibraryTest, bookmarksSerializationTest)
     auto new_lib = kiwix::Library::create();
     {
       kiwix::Manager manager(new_lib);
-      manager.readOpds(sampleOpdsStream, "foo.urlHost");
+      manager.readOpds(sampleOpdsStream, "http://foo.urlHost");
       manager.readXml(sampleLibraryXML, false, "./test/library.xml", true);
       manager.readBookmarkFile("__test__bookmarks.xml");
     }

--- a/test/library.cpp
+++ b/test/library.cpp
@@ -270,11 +270,13 @@ const char * sampleOpdsStream = R"(
 #ifdef _WIN32
 # define ZIMFILE_PATH ".\\zimfile.zim"
 # define EXAMPLE_PATH ".\\example.zim"
-# define LIBRARY_PATH ".\\test\\library.xml"
+# define XML_LIBRARY_PATH ".\\test\\library.xml"
+# define OPDS_LIBRARY_PATH ".\\test\\library.opds"
 #else
 # define ZIMFILE_PATH "./zimfile.zim"
 # define EXAMPLE_PATH "./example.zim"
-# define LIBRARY_PATH "./test/library.xml"
+# define XML_LIBRARY_PATH "./test/library.xml"
+# define OPDS_LIBRARY_PATH "./test/library.opds"
 #endif
 
 const char sampleLibraryXML[] = R"(
@@ -313,10 +315,58 @@ const char sampleLibraryXML[] = R"(
 </library>
 )";
 
+const char sampleLibraryOpds[] = R"(
+<feed xmlns="http://www.w3.org/2005/Atom"
+      xmlns:dc="http://purl.org/dc/terms/"
+      xmlns:opds="http://opds-spec.org/2010/catalog">
+  <id>c0602b41-aef2-4c5a-9f31-3f6ee912c159</id>
+  <entry>
+    <id>urn:uuid:raycharles</id>
+    <title>Ray Charles</title>
+    <updated>2020-03-31T00:00:00Z</updated>
+    <summary>Wikipedia articles about Ray Charles</summary>
+    <language>eng,spa</language>
+    <name>wikipedia_en_ray_charles</name>
+    <tags>wikipedia;_category:wikipedia;_pictures:no</tags>
+    <articleCount>284</articleCount>
+    <mediaCount>2</mediaCount>
+    <author>
+      <name>Wikipedia</name>
+    </author>
+    <publisher>
+      <name>Kiwix</name>
+    </publisher>
+    <dc:issued>2020-03-31T00:00:00Z</dc:issued>
+    <link rel="http://opds-spec.org/acquisition/open-access" type="application/x-zim" href="https://github.com/kiwix/libkiwix/raw/master/test/data/zimfile.zim" length="569344" />
+    <link rel="self" href=")" ZIMFILE_PATH R"(" type="application/x-zim"/>
+  </entry>
+  <entry>
+    <id>urn:uuid:example</id>
+    <title>An example ZIM archive</title>
+    <updated>2021-04-11T00:00:00Z</updated>
+    <summary>An eXaMpLe book added to the catalog via XML</summary>
+    <language>deu</language>
+    <name>wikibooks.de</name>
+    <tags>unittest;wikibooks;_category:wikibooks</tags>
+    <articleCount>12</articleCount>
+    <mediaCount>0</mediaCount>
+    <author>
+      <name>Wikibooks</name>
+    </author>
+    <publisher>
+      <name>Kiwix &amp; Some Enthusiasts</name>
+    </publisher>
+    <dc:issued>2021-04-11T00:00:00Z</dc:issued>
+    <link rel="self" href=")" EXAMPLE_PATH R"(" type="application/x-zim"/>
+  </entry>
+</feed>
+)";
+
 #include "../include/library.h"
 #include "../include/manager.h"
 #include "../include/book.h"
 #include "../include/bookmark.h"
+#include "../include/tools.h"
 
 namespace
 {
@@ -383,17 +433,25 @@ TEST(LibraryOpdsImportTest, allInOne)
   }
 }
 
-class LibraryTest : public ::testing::Test {
+class LibraryTest : public ::testing::TestWithParam<std::string> {
  protected:
   typedef kiwix::Library::BookIdCollection BookIdCollection;
   typedef std::vector<std::string> TitleCollection;
 
   LibraryTest(): lib(kiwix::Library::create()) {}
 
+  void loadSampleLibrary(kiwix::Manager& manager) {
+    if (GetParam() == "xml") {
+      manager.readXml(sampleLibraryXML, false, XML_LIBRARY_PATH, true);
+    } else {
+      manager.readOpds(sampleLibraryOpds, OPDS_LIBRARY_PATH, false);
+    }
+  }
+
   void SetUp() override {
      kiwix::Manager manager(lib);
      manager.readOpds(sampleOpdsStream, "http://foo.urlHost");
-     manager.readXml(sampleLibraryXML, false, LIBRARY_PATH, true);
+     loadSampleLibrary(manager);
   }
 
   kiwix::Bookmark createBookmark(const std::string &id, const std::string& url="", const std::string& title="") {
@@ -421,7 +479,10 @@ class LibraryTest : public ::testing::Test {
   std::shared_ptr<kiwix::Library> lib;
 };
 
-TEST_F(LibraryTest, createBookMark)
+INSTANTIATE_TEST_CASE_P(XmlAndOpds, LibraryTest,
+    ::testing::Values("xml", "opds"));
+
+TEST_P(LibraryTest, createBookMark)
 {
   auto bookId = "0c45160e-f917-760a-9159-dfe3c53cdcdd";
   auto book = lib->getBookById(bookId);
@@ -439,7 +500,7 @@ TEST_F(LibraryTest, createBookMark)
   EXPECT_EQ(bookmark.getLanguage(), book.getCommaSeparatedLanguages());
 }
 
-TEST_F(LibraryTest, getBookMarksTest)
+TEST_P(LibraryTest, getBookMarksTest)
 {
     auto bookId1 = "0c45160e-f917-760a-9159-dfe3c53cdcdd";
     auto bookId2 = "0189d9be-2fd0-b4b6-7300-20fab0b5cdc8";
@@ -461,7 +522,7 @@ TEST_F(LibraryTest, getBookMarksTest)
     EXPECT_EQ(allBookmarks[2].getBookId(), bookId2);
 }
 
-TEST_F(LibraryTest, bookmarksSerializationTest)
+TEST_P(LibraryTest, bookmarksSerializationTest)
 {
     auto bookId1 = lib->getBooksIds()[0];
     auto bookId2 = lib->getBooksIds()[1];
@@ -481,7 +542,7 @@ TEST_F(LibraryTest, bookmarksSerializationTest)
     {
       kiwix::Manager manager(new_lib);
       manager.readOpds(sampleOpdsStream, "http://foo.urlHost");
-      manager.readXml(sampleLibraryXML, false, "./test/library.xml", true);
+      loadSampleLibrary(manager);
       manager.readBookmarkFile("__test__bookmarks.xml");
     }
     std::remove("__test__bookmarks.xml");
@@ -525,7 +586,7 @@ TEST_F(LibraryTest, bookmarksSerializationTest)
     EXPECT_EQ(bookmark3.getDate(), book2.getDate());
 }
 
-TEST_F(LibraryTest, MigrateBookmark)
+TEST_P(LibraryTest, MigrateBookmark)
 {
     std::string bookId1 = "0c45160e-f917-760a-9159-dfe3c53cdcdd";
     std::string bookId2 = "0189d9be-2fd0-b4b6-7300-20fab0b5cdc8";
@@ -644,7 +705,7 @@ TEST_F(LibraryTest, MigrateBookmark)
     EXPECT_EQ(allBookmarks[5].getBookId(), bookId1+"_updated1yearlater_flavour");
 }
 
-TEST_F(LibraryTest, GetBestTargetBookIdOlder)
+TEST_P(LibraryTest, GetBestTargetBookIdOlder)
 {
     auto bookId = std::string("0c45160e-f917-760a-9159-dfe3c53cdcdd");
 
@@ -657,7 +718,7 @@ TEST_F(LibraryTest, GetBestTargetBookIdOlder)
     ASSERT_EQ(lib->getBestTargetBookId(validBookmark, kiwix::ALLOW_DOWNGRADE), bookId+"_updated1yearlater");
 }
 
-TEST_F(LibraryTest, GetBestTargetBookIdNewer)
+TEST_P(LibraryTest, GetBestTargetBookIdNewer)
 {
     auto bookId = std::string("0c45160e-f917-760a-9159-dfe3c53cdcdd_updated1yearlater");
 
@@ -678,7 +739,7 @@ TEST_F(LibraryTest, GetBestTargetBookIdNewer)
     ASSERT_EQ(lib->getBestTargetBookId(validBookmark, kiwix::ALLOW_DOWNGRADE), bookId);
 }
 
-TEST_F(LibraryTest, GetBestTargetBookIdInvalidOlder)
+TEST_P(LibraryTest, GetBestTargetBookIdInvalidOlder)
 {
     auto bookId = std::string("0c45160e-f917-760a-9159-dfe3c53cdcdd");
 
@@ -692,7 +753,7 @@ TEST_F(LibraryTest, GetBestTargetBookIdInvalidOlder)
     ASSERT_EQ(lib->getBestTargetBookId(invalidBookmark, kiwix::ALLOW_DOWNGRADE), bookId+"_updated1yearlater");
 }
 
-TEST_F(LibraryTest, GetBestTargetBookIdInvalidNewer)
+TEST_P(LibraryTest, GetBestTargetBookIdInvalidNewer)
 {
     auto bookId = std::string("0c45160e-f917-760a-9159-dfe3c53cdcdd");
 
@@ -708,7 +769,7 @@ TEST_F(LibraryTest, GetBestTargetBookIdInvalidNewer)
     ASSERT_EQ(lib->getBestTargetBookId(invalidBookmark, kiwix::ALLOW_DOWNGRADE), bookId+"_updated1yearlater");
 }
 
-TEST_F(LibraryTest, GetBestTargetBookIdFlavour)
+TEST_P(LibraryTest, GetBestTargetBookIdFlavour)
 {
     auto bookId = std::string("0c45160e-f917-760a-9159-dfe3c53cdcdd_flavour");
 
@@ -724,7 +785,7 @@ TEST_F(LibraryTest, GetBestTargetBookIdFlavour)
     ASSERT_EQ(lib->getBestTargetBookId(invalidBookmark, kiwix::ALLOW_DOWNGRADE), "0c45160e-f917-760a-9159-dfe3c53cdcdd_updated1yearlater_flavour");
 }
 
-TEST_F(LibraryTest, GetBestTargetBookIdName)
+TEST_P(LibraryTest, GetBestTargetBookIdName)
 {
     ASSERT_EQ(lib->getBestTargetBookId("wikipedia_fr_tunisie"), "0c45160e-f917-760a-9159-dfe3c53cdcdd_updated1yearlater");
     ASSERT_EQ(lib->getBestTargetBookId("wikipedia_fr_tunisie", "novid"), "0c45160e-f917-760a-9159-dfe3c53cdcdd_updated1yearlater");
@@ -732,7 +793,7 @@ TEST_F(LibraryTest, GetBestTargetBookIdName)
     ASSERT_EQ(lib->getBestTargetBookId("wikipedia_fr_tunisie", "other_flavour", "2020-12-12"), "");
 }
 
-TEST_F(LibraryTest, sanityCheck)
+TEST_P(LibraryTest, sanityCheck)
 {
   EXPECT_EQ(lib->getBookCount(true, true), 16U);
   EXPECT_EQ(lib->getBooksLanguages(),
@@ -757,7 +818,7 @@ TEST_F(LibraryTest, sanityCheck)
   }));
 }
 
-TEST_F(LibraryTest, categoryHandling)
+TEST_P(LibraryTest, categoryHandling)
 {
   EXPECT_EQ("", lib->getBookById("0c45160e-f917-760a-9159-dfe3c53cdcdd").getCategory());
   EXPECT_EQ("category_defined_via_tags_only", lib->getBookById("0d0bcd57-d3f6-cb22-44cc-a723ccb4e1b2").getCategory());
@@ -766,7 +827,7 @@ TEST_F(LibraryTest, categoryHandling)
   EXPECT_EQ("category_element_overrides_tags", lib->getBookById("14829621-c490-c376-0792-9de558b57efa").getCategory());
 }
 
-TEST_F(LibraryTest, emptyFilter)
+TEST_P(LibraryTest, emptyFilter)
 {
   const auto bookIds = lib->filter(kiwix::Filter());
   EXPECT_EQ(bookIds, lib->getBooksIds());
@@ -778,7 +839,7 @@ TEST_F(LibraryTest, emptyFilter)
           TitleCollection({ __VA_ARGS__ })   \
         )
 
-TEST_F(LibraryTest, filterLocal)
+TEST_P(LibraryTest, filterLocal)
 {
   EXPECT_FILTER_RESULTS(kiwix::Filter().local(true),
     "An example ZIM archive",
@@ -803,7 +864,7 @@ TEST_F(LibraryTest, filterLocal)
   );
 }
 
-TEST_F(LibraryTest, filterRemote)
+TEST_P(LibraryTest, filterRemote)
 {
   EXPECT_FILTER_RESULTS(kiwix::Filter().remote(true),
     "Business talks about TED",
@@ -828,7 +889,7 @@ TEST_F(LibraryTest, filterRemote)
   );
 }
 
-TEST_F(LibraryTest, filterByLanguage)
+TEST_P(LibraryTest, filterByLanguage)
 {
   EXPECT_FILTER_RESULTS(kiwix::Filter().lang("eng"),
     "Business talks about TED",
@@ -855,7 +916,7 @@ TEST_F(LibraryTest, filterByLanguage)
   );
 }
 
-TEST_F(LibraryTest, filterByFlavour)
+TEST_P(LibraryTest, filterByFlavour)
 {
   EXPECT_FILTER_RESULTS(kiwix::Filter().flavour("full"),
     "Géographie par Wikipédia",
@@ -874,7 +935,7 @@ TEST_F(LibraryTest, filterByFlavour)
   );
 }
 
-TEST_F(LibraryTest, filterByTags)
+TEST_P(LibraryTest, filterByTags)
 {
   EXPECT_FILTER_RESULTS(kiwix::Filter().acceptTags({"stackexchange"}),
     "Islam Stack Exchange",
@@ -922,7 +983,7 @@ TEST_F(LibraryTest, filterByTags)
 }
 
 
-TEST_F(LibraryTest, filterByQuery)
+TEST_P(LibraryTest, filterByQuery)
 {
   // filtering by query checks the title
   EXPECT_FILTER_RESULTS(kiwix::Filter().query("Exchange"),
@@ -990,7 +1051,7 @@ TEST_F(LibraryTest, filterByQuery)
 }
 
 
-TEST_F(LibraryTest, filteringByEmptyQueryReturnsAllEntries)
+TEST_P(LibraryTest, filteringByEmptyQueryReturnsAllEntries)
 {
   EXPECT_FILTER_RESULTS(kiwix::Filter().query(""),
     "An example ZIM archive",
@@ -1012,7 +1073,7 @@ TEST_F(LibraryTest, filteringByEmptyQueryReturnsAllEntries)
   );
 }
 
-TEST_F(LibraryTest, filterByCreator)
+TEST_P(LibraryTest, filterByCreator)
 {
   EXPECT_FILTER_RESULTS(kiwix::Filter().creator("Wikipedia"),
     "Encyclopédie de la Tunisie",
@@ -1070,7 +1131,7 @@ TEST_F(LibraryTest, filterByCreator)
 
 }
 
-TEST_F(LibraryTest, filterByPublisher)
+TEST_P(LibraryTest, filterByPublisher)
 {
   EXPECT_FILTER_RESULTS(kiwix::Filter().publisher("Kiwix"),
     "An example ZIM archive",
@@ -1106,7 +1167,7 @@ TEST_F(LibraryTest, filterByPublisher)
   );
 }
 
-TEST_F(LibraryTest, filterByName)
+TEST_P(LibraryTest, filterByName)
 {
   EXPECT_FILTER_RESULTS(kiwix::Filter().name("wikibooks.de"),
     "An example ZIM archive"
@@ -1142,7 +1203,7 @@ TEST_F(LibraryTest, filterByName)
   );
 }
 
-TEST_F(LibraryTest, filterByCategory)
+TEST_P(LibraryTest, filterByCategory)
 {
   EXPECT_FILTER_RESULTS(kiwix::Filter().category("category_element_overrides_tags"),
     "Géographie par Wikipédia",
@@ -1159,14 +1220,14 @@ TEST_F(LibraryTest, filterByCategory)
   );
 }
 
-TEST_F(LibraryTest, filterByMaxSize)
+TEST_P(LibraryTest, filterByMaxSize)
 {
   EXPECT_FILTER_RESULTS(kiwix::Filter().maxSize(200000),
     "An example ZIM archive"
   );
 }
 
-TEST_F(LibraryTest, filterByMultipleCriteria)
+TEST_P(LibraryTest, filterByMultipleCriteria)
 {
   EXPECT_FILTER_RESULTS(kiwix::Filter().query("Wiki").creator("Wikipedia"),
     "Encyclopédie de la Tunisie",
@@ -1194,7 +1255,7 @@ TEST_F(LibraryTest, filterByMultipleCriteria)
   );
 }
 
-TEST_F(LibraryTest, getBookByPath)
+TEST_P(LibraryTest, getBookByPath)
 {
   kiwix::Book book = lib->getBookById(lib->getBooksIds()[0]);
 #ifdef _WIN32
@@ -1208,7 +1269,7 @@ TEST_F(LibraryTest, getBookByPath)
   EXPECT_THROW(lib->getBookByPath("non/existant/path.zim"), std::out_of_range);
 }
 
-TEST_F(LibraryTest, removeBookByIdRemovesTheBook)
+TEST_P(LibraryTest, removeBookByIdRemovesTheBook)
 {
   const auto initialBookCount = lib->getBookCount(true, true);
   ASSERT_GT(initialBookCount, 0U);
@@ -1218,14 +1279,14 @@ TEST_F(LibraryTest, removeBookByIdRemovesTheBook)
   EXPECT_THROW(lib->getBookById("raycharles"), std::out_of_range);
 };
 
-TEST_F(LibraryTest, removeBookByIdDropsTheReader)
+TEST_P(LibraryTest, removeBookByIdDropsTheReader)
 {
   EXPECT_NE(nullptr, lib->getArchiveById("raycharles"));
   lib->removeBookById("raycharles");
   EXPECT_THROW(lib->getArchiveById("raycharles"), std::out_of_range);
 };
 
-TEST_F(LibraryTest, removeBookByIdUpdatesTheSearchDB)
+TEST_P(LibraryTest, removeBookByIdUpdatesTheSearchDB)
 {
   kiwix::Filter f;
   f.local(true).valid(true).query(R"(title:"ray charles")", false);
@@ -1243,7 +1304,7 @@ TEST_F(LibraryTest, removeBookByIdUpdatesTheSearchDB)
   EXPECT_THROW(lib->getBookById("raycharles"), std::out_of_range);
 };
 
-TEST_F(LibraryTest, removeBooksNotUpdatedSince)
+TEST_P(LibraryTest, removeBooksNotUpdatedSince)
 {
   EXPECT_FILTER_RESULTS(kiwix::Filter(),
     "An example ZIM archive",

--- a/test/library_server.cpp
+++ b/test/library_server.cpp
@@ -6,11 +6,13 @@
 #define SERVER_PORT 8001
 #include "server_testing_tools.h"
 
+#include "../src/tools/stringTools.h"
+
 ////////////////////////////////////////////////////////////////////////////////
 // Testing of the library-related functionality of the server
 ////////////////////////////////////////////////////////////////////////////////
 
-class LibraryServerTest : public ::testing::Test
+class LibraryServerTest : public ::testing::TestWithParam<std::string>
 {
 protected:
   std::unique_ptr<ZimFileServer>   zfs1_;
@@ -20,7 +22,7 @@ protected:
 protected:
   void resetServer(ZimFileServer::Cfg cfg) {
     zfs1_.reset();
-    zfs1_.reset(new ZimFileServer(PORT, cfg, "./test/library.xml"));
+    zfs1_.reset(new ZimFileServer(PORT, cfg, GetParam()));
   }
 
   void resetServer(ZimFileServer::Options options, std::string contentServerUrl="") {
@@ -30,13 +32,16 @@ protected:
   }
 
   void SetUp() override {
-    zfs1_.reset(new ZimFileServer(PORT, ZimFileServer::DEFAULT_OPTIONS, "./test/library.xml"));
+    zfs1_.reset(new ZimFileServer(PORT, ZimFileServer::DEFAULT_OPTIONS, GetParam()));
   }
 
   void TearDown() override {
     zfs1_.reset();
   }
 };
+
+INSTANTIATE_TEST_CASE_P(XmlAndOpds, LibraryServerTest,
+    ::testing::Values("./test/library.xml", "./test/library.opds"));
 
 // Returns a copy of 'text' where every line that fully matches 'pattern'
 // preceded by optional whitespace is replaced with the fixed string
@@ -180,7 +185,7 @@ std::string maskVariableOPDSFeedData(std::string s)
 "    <link rel=\"http://opds-spec.org/acquisition/open-access\" type=\"application/x-zim\" href=\"https://github.com/kiwix/libkiwix/raw/master/test/data/nosuchzimfile.zim\" length=\"20736925696\" />\n" \
 "  </entry>\n"
 
-TEST_F(LibraryServerTest, catalog_root_xml)
+TEST_P(LibraryServerTest, catalog_root_xml)
 {
   const auto r = zfs1_->GET("/ROOT%23%3F/catalog/root.xml");
   EXPECT_EQ(r->status, 200);
@@ -198,7 +203,28 @@ TEST_F(LibraryServerTest, catalog_root_xml)
   );
 }
 
-TEST_F(LibraryServerTest, catalog_searchdescription_xml)
+TEST_P(LibraryServerTest, ThumbnailMimeTypeHandling)
+{
+  // "inaccessiblezim" is only listed in catalog-only mode; fetch everything
+  // (including it) via /catalog/v2/entries in that mode, like
+  // catalog_v2_entries_catalog_only_mode does.
+  resetServer(ZimFileServer::CATALOG_ONLY_MODE);
+  const auto r = zfs1_->GET("/ROOT%23%3F/catalog/v2/entries");
+  EXPECT_EQ(r->status, 200);
+
+  // mimetype provided: thumbnail is served with that mimetype, regardless
+  // of the library format
+  EXPECT_TRUE(kiwix::contains(r->body,
+    "<link rel=\"http://opds-spec.org/image/thumbnail\"\n"
+    "          href=\"/ROOT%23%3F/catalog/v2/illustration/raycharles/?size=48\"\n"
+    "          type=\"image/png;width=48;height=48;scale=1\"/>"
+  ));
+
+  EXPECT_FALSE(kiwix::contains(r->body, "illustration/charlesray/"));
+  EXPECT_FALSE(kiwix::contains(r->body, "illustration/inaccessiblezim/"));
+}
+
+TEST_P(LibraryServerTest, catalog_searchdescription_xml)
 {
   const auto r = zfs1_->GET("/ROOT%23%3F/catalog/searchdescription.xml");
   EXPECT_EQ(r->status, 200);
@@ -216,7 +242,7 @@ TEST_F(LibraryServerTest, catalog_searchdescription_xml)
   );
 }
 
-TEST_F(LibraryServerTest, catalog_search_by_phrase)
+TEST_P(LibraryServerTest, catalog_search_by_phrase)
 {
   const auto r = zfs1_->GET("/ROOT%23%3F/catalog/search?q=\"ray%20charles\"");
   EXPECT_EQ(r->status, 200);
@@ -235,7 +261,7 @@ TEST_F(LibraryServerTest, catalog_search_by_phrase)
   );
 }
 
-TEST_F(LibraryServerTest, catalog_search_by_words)
+TEST_P(LibraryServerTest, catalog_search_by_words)
 {
   const auto r = zfs1_->GET("/ROOT%23%3F/catalog/search?q=ray%20charles");
   EXPECT_EQ(r->status, 200);
@@ -255,7 +281,7 @@ TEST_F(LibraryServerTest, catalog_search_by_words)
   );
 }
 
-TEST_F(LibraryServerTest, catalog_prefix_search)
+TEST_P(LibraryServerTest, catalog_prefix_search)
 {
   {
     const auto r = zfs1_->GET("/ROOT%23%3F/catalog/search?q=description:ray%20description:charles");
@@ -292,7 +318,7 @@ TEST_F(LibraryServerTest, catalog_prefix_search)
   }
 }
 
-TEST_F(LibraryServerTest, catalog_search_with_word_exclusion)
+TEST_P(LibraryServerTest, catalog_search_with_word_exclusion)
 {
   const auto r = zfs1_->GET("/ROOT%23%3F/catalog/search?q=ray%20-uncategorized");
   EXPECT_EQ(r->status, 200);
@@ -311,7 +337,7 @@ TEST_F(LibraryServerTest, catalog_search_with_word_exclusion)
   );
 }
 
-TEST_F(LibraryServerTest, catalog_search_by_tag)
+TEST_P(LibraryServerTest, catalog_search_by_tag)
 {
   const auto r = zfs1_->GET("/ROOT%23%3F/catalog/search?tag=_category:jazz");
   EXPECT_EQ(r->status, 200);
@@ -329,7 +355,7 @@ TEST_F(LibraryServerTest, catalog_search_by_tag)
   );
 }
 
-TEST_F(LibraryServerTest, catalog_search_by_category)
+TEST_P(LibraryServerTest, catalog_search_by_category)
 {
 
   {
@@ -368,7 +394,7 @@ TEST_F(LibraryServerTest, catalog_search_by_category)
   }
 }
 
-TEST_F(LibraryServerTest, catalog_search_by_language)
+TEST_P(LibraryServerTest, catalog_search_by_language)
 {
   {
     const auto r = zfs1_->GET("/ROOT%23%3F/catalog/search?lang=eng");
@@ -408,7 +434,7 @@ TEST_F(LibraryServerTest, catalog_search_by_language)
   }
 }
 
-TEST_F(LibraryServerTest, catalog_search_results_pagination)
+TEST_P(LibraryServerTest, catalog_search_results_pagination)
 {
   {
     // count=-1 disables the limit on the number of results
@@ -494,7 +520,7 @@ TEST_F(LibraryServerTest, catalog_search_results_pagination)
   }
 }
 
-TEST_F(LibraryServerTest, catalog_v2_root)
+TEST_P(LibraryServerTest, catalog_v2_root)
 {
   const auto r = zfs1_->GET("/ROOT%23%3F/catalog/v2/root.xml");
   EXPECT_EQ(r->status, 200);
@@ -555,7 +581,7 @@ TEST_F(LibraryServerTest, catalog_v2_root)
   EXPECT_EQ(maskVariableOPDSFeedData(r->body), expected_output);
 }
 
-TEST_F(LibraryServerTest, catalog_v2_searchdescription_xml)
+TEST_P(LibraryServerTest, catalog_v2_searchdescription_xml)
 {
   const auto r = zfs1_->GET("/ROOT%23%3F/catalog/v2/searchdescription.xml");
   EXPECT_EQ(r->status, 200);
@@ -573,7 +599,7 @@ TEST_F(LibraryServerTest, catalog_v2_searchdescription_xml)
   );
 }
 
-TEST_F(LibraryServerTest, catalog_v2_categories)
+TEST_P(LibraryServerTest, catalog_v2_categories)
 {
   const auto r = zfs1_->GET("/ROOT%23%3F/catalog/v2/categories");
   EXPECT_EQ(r->status, 200);
@@ -622,7 +648,7 @@ TEST_F(LibraryServerTest, catalog_v2_categories)
   EXPECT_EQ(maskVariableOPDSFeedData(r->body), expected_output);
 }
 
-TEST_F(LibraryServerTest, catalog_v2_languages)
+TEST_P(LibraryServerTest, catalog_v2_languages)
 {
   const auto r = zfs1_->GET("/ROOT%23%3F/catalog/v2/languages");
   EXPECT_EQ(r->status, 200);
@@ -711,7 +737,7 @@ TEST_F(LibraryServerTest, catalog_v2_languages)
 #define CATALOG_V2_PARTIAL_ENTRIES_PREAMBLE(q) \
             CATALOG_V2_ENTRIES_PREAMBLE0("partial_entries" q)
 
-TEST_F(LibraryServerTest, catalog_v2_entries)
+TEST_P(LibraryServerTest, catalog_v2_entries)
 {
   const auto r = zfs1_->GET("/ROOT%23%3F/catalog/v2/entries");
   EXPECT_EQ(r->status, 200);
@@ -727,7 +753,7 @@ TEST_F(LibraryServerTest, catalog_v2_entries)
   );
 }
 
-TEST_F(LibraryServerTest, catalog_v2_entries_catalog_only_mode)
+TEST_P(LibraryServerTest, catalog_v2_entries_catalog_only_mode)
 {
   const std::string contentServerUrl = "https://demo.kiwix.org";
   const auto fixContentLinks = [=](std::string s) -> std::string {
@@ -770,7 +796,7 @@ TEST_F(LibraryServerTest, catalog_v2_entries_catalog_only_mode)
   }
 }
 
-TEST_F(LibraryServerTest, catalog_v2_entries_filtered_by_range)
+TEST_P(LibraryServerTest, catalog_v2_entries_filtered_by_range)
 {
   {
     const auto r = zfs1_->GET("/ROOT%23%3F/catalog/v2/entries?start=1");
@@ -853,7 +879,7 @@ TEST_F(LibraryServerTest, catalog_v2_entries_filtered_by_range)
   }
 }
 
-TEST_F(LibraryServerTest, catalog_v2_entries_filtered_by_search_terms)
+TEST_P(LibraryServerTest, catalog_v2_entries_filtered_by_search_terms)
 {
   const auto r = zfs1_->GET("/ROOT%23%3F/catalog/v2/entries?q=\"ray%20charles\"");
   EXPECT_EQ(r->status, 200);
@@ -870,7 +896,7 @@ TEST_F(LibraryServerTest, catalog_v2_entries_filtered_by_search_terms)
   );
 }
 
-TEST_F(LibraryServerTest, catalog_v2_entries_filtering_special_queries)
+TEST_P(LibraryServerTest, catalog_v2_entries_filtering_special_queries)
 {
   {
   // 'or' doesn't act as a Xapian boolean operator
@@ -1031,7 +1057,7 @@ TEST_F(LibraryServerTest, catalog_v2_entries_filtering_special_queries)
   }
 }
 
-TEST_F(LibraryServerTest, catalog_v2_entries_filtered_by_language)
+TEST_P(LibraryServerTest, catalog_v2_entries_filtered_by_language)
 {
   {
     const auto r = zfs1_->GET("/ROOT%23%3F/catalog/v2/entries?lang=eng");
@@ -1067,7 +1093,7 @@ TEST_F(LibraryServerTest, catalog_v2_entries_filtered_by_language)
   }
 }
 
-TEST_F(LibraryServerTest, catalog_v2_entries_filtered_by_category)
+TEST_P(LibraryServerTest, catalog_v2_entries_filtered_by_category)
 {
   {
     const auto r = zfs1_->GET("/ROOT%23%3F/catalog/v2/entries?category=jazz");
@@ -1101,7 +1127,7 @@ TEST_F(LibraryServerTest, catalog_v2_entries_filtered_by_category)
   }
 }
 
-TEST_F(LibraryServerTest, catalog_v2_entries_multiple_filters)
+TEST_P(LibraryServerTest, catalog_v2_entries_multiple_filters)
 {
   {
     const auto r = zfs1_->GET("/ROOT%23%3F/catalog/v2/entries?lang=fra&category=jazz");
@@ -1119,7 +1145,7 @@ TEST_F(LibraryServerTest, catalog_v2_entries_multiple_filters)
   }
 }
 
-TEST_F(LibraryServerTest, catalog_v2_individual_entry_access)
+TEST_P(LibraryServerTest, catalog_v2_individual_entry_access)
 {
   const auto r = zfs1_->GET("/ROOT%23%3F/catalog/v2/entry/raycharles");
   EXPECT_EQ(r->status, 200);
@@ -1132,7 +1158,7 @@ TEST_F(LibraryServerTest, catalog_v2_individual_entry_access)
   EXPECT_EQ(r1->status, 404);
 }
 
-TEST_F(LibraryServerTest, catalog_v2_partial_entries)
+TEST_P(LibraryServerTest, catalog_v2_partial_entries)
 {
   const auto r = zfs1_->GET("/ROOT%23%3F/catalog/v2/partial_entries");
   EXPECT_EQ(r->status, 200);
@@ -1189,7 +1215,7 @@ TEST_F(LibraryServerTest, catalog_v2_partial_entries)
     );                                                                      \
   }
 
-TEST_F(LibraryServerTest, catalog_search_includes_public_tags)
+TEST_P(LibraryServerTest, catalog_search_includes_public_tags)
 {
   EXPECT_SEARCH_RESULTS("public_tag_without_a_value",
                         1,
@@ -1222,13 +1248,13 @@ TEST_F(LibraryServerTest, catalog_search_includes_public_tags)
 
 #define EXPECT_ZERO_RESULTS(SEARCH_TERM) EXPECT_SEARCH_RESULTS(SEARCH_TERM, 0, )
 
-TEST_F(LibraryServerTest, catalog_search_on_tags_is_not_an_any_substring_match)
+TEST_P(LibraryServerTest, catalog_search_on_tags_is_not_an_any_substring_match)
 {
   EXPECT_ZERO_RESULTS("tag_with")
   EXPECT_ZERO_RESULTS("alue_of_a_public_tag")
 }
 
-TEST_F(LibraryServerTest, catalog_search_excludes_hidden_tags)
+TEST_P(LibraryServerTest, catalog_search_excludes_hidden_tags)
 {
   EXPECT_ZERO_RESULTS("_private_tag_without_a_value");
   EXPECT_ZERO_RESULTS("private_tag_without_a_value");
@@ -1237,7 +1263,7 @@ TEST_F(LibraryServerTest, catalog_search_excludes_hidden_tags)
 #undef EXPECT_ZERO_RESULTS
 }
 
-TEST_F(LibraryServerTest, no_name_mapper_returned_catalog_use_uuid_in_link)
+TEST_P(LibraryServerTest, no_name_mapper_returned_catalog_use_uuid_in_link)
 {
   resetServer(ZimFileServer::NO_NAME_MAPPER);
   const auto r = zfs1_->GET("/ROOT%23%3F/catalog/search?tag=_category:jazz");
@@ -1257,7 +1283,7 @@ TEST_F(LibraryServerTest, no_name_mapper_returned_catalog_use_uuid_in_link)
 }
 
 
-TEST_F(LibraryServerTest, no_name_mapper_catalog_v2_individual_entry_access)
+TEST_P(LibraryServerTest, no_name_mapper_catalog_v2_individual_entry_access)
 {
   resetServer(ZimFileServer::NO_NAME_MAPPER);
   const auto r = zfs1_->GET("/ROOT%23%3F/catalog/v2/entry/raycharles");
@@ -1533,7 +1559,7 @@ TEST_F(LibraryServerTest, no_name_mapper_catalog_v2_individual_entry_access)
   "</body>\n" \
   "</html>"
 
-TEST_F(LibraryServerTest, noJS) {
+TEST_P(LibraryServerTest, noJS) {
   // no_js_default
   auto r = zfs1_->GET("/ROOT%23%3F/nojs");
   EXPECT_EQ(r->status, 200);
@@ -1572,7 +1598,7 @@ TEST_F(LibraryServerTest, noJS) {
   EXPECT_EQ(r->body, RAY_CHARLES_UNCTZ_DOWNLOAD);
 }
 
-TEST_F(LibraryServerTest, noJS_catalogOnlyMode) {
+TEST_P(LibraryServerTest, noJS_catalogOnlyMode) {
   const std::string contentServerUrl = "https://demo.kiwix.org";
   const auto fixContentLinks = [=](std::string s) -> std::string {
     s = replace(s, "/ROOT%23%3F/content", contentServerUrl + "/content");

--- a/test/libxml_dumper.cpp
+++ b/test/libxml_dumper.cpp
@@ -184,9 +184,6 @@ TEST_F(LibXMLDumperTest, aliasBookWithOrigIdOnlyEmitsIdAndOrigId)
 
 TEST_F(LibXMLDumperTest, dumpLibXMLContentThrowsForUnknownBookId)
 {
-  // Unlike LibOPDSDumper::dumpOPDSContent (which silently skips book ids no
-  // longer present in the library), LibXMLDumper::dumpLibXMLContent uses
-  // Library::getBookById() directly and lets std::out_of_range propagate.
   EXPECT_THROW(dumper.dumpLibXMLContent({"no-such-book"}), std::out_of_range);
 }
 

--- a/test/manager.cpp
+++ b/test/manager.cpp
@@ -9,17 +9,18 @@
 namespace
 {
 
-// parseXmlDom() are protected - this subclass re-exposes it
-// as public so it can be exercised directly, without going through the
-// readXml() wrapper.
+// parseXmlDom()/parseOpdsDom() are protected - this subclass re-exposes them
+// as public so they can be exercised directly, without going through the
+// readXml()/readOpds() wrappers.
 struct TestManager : public kiwix::Manager
 {
   using kiwix::Manager::Manager;
   using kiwix::Manager::parseXmlDom;
+  using kiwix::Manager::parseOpdsDom;
 };
 
 // XMLDoc helper needs to build a pugi::xml_document from a string before
-// handing it to parseXmlDom
+// handing it to parseXmlDom/parseOpdsDo
 struct XMLDoc : pugi::xml_document
 {
   explicit XMLDoc(const std::string& xml)
@@ -188,6 +189,91 @@ TEST(ManagerTest, parseXmlDomWithTrustLibraryFalseAndValidPathAdoptsZimMetadata)
     EXPECT_NE(book.getTitle(), "Stale title from XML");
 }
 
+const char sampleOpdsFeed[] = R"(
+<feed xmlns="http://www.w3.org/2005/Atom"
+      xmlns:opds="https://specs.opds.io/opds-1.2">
+  <totalResults>2</totalResults>
+  <startIndex>0</startIndex>
+  <itemsPerPage>2</itemsPerPage>
+  <entry>
+    <id>urn:uuid:book1</id>
+    <title>Book One</title>
+    <link rel="http://opds-spec.org/acquisition/open-access"
+          type="application/x-zim"
+          href="https://example.com/book1.zim"
+          length="111" />
+  </entry>
+  <entry>
+    <id>urn:uuid:book2</id>
+    <title>Book Two</title>
+    <link rel="http://opds-spec.org/acquisition/open-access"
+          type="application/x-zim"
+          href="https://example.com/book2.zim"
+          length="222" />
+  </entry>
+</feed>
+)";
+
+TEST(ManagerTest, parseOpdsDomAddsEntriesAndParsesSearchMetadata)
+{
+    auto lib = kiwix::Library::create();
+    TestManager manager(lib);
+
+    const XMLDoc doc(sampleOpdsFeed);
+
+    EXPECT_TRUE(manager.parseOpdsDom(doc, "http://example.com"));
+
+    EXPECT_TRUE(manager.m_hasSearchResult);
+    EXPECT_EQ(manager.m_totalBooks, 2U);
+    EXPECT_EQ(manager.m_startIndex, 0U);
+    EXPECT_EQ(manager.m_itemsPerPage, 2U);
+
+    EXPECT_EQ(lib->getBooksIds(), (kiwix::Library::BookIdCollection{"book1", "book2"}));
+
+    // Unlike parseXmlDom(), OPDS-sourced books are always mutable.
+    kiwix::Book book1 = lib->getBookById("book1");
+    EXPECT_FALSE(book1.readOnly());
+    EXPECT_EQ(book1.getUrl(), "https://example.com/book1.zim");
+}
+
+TEST(ManagerTest, parseOpdsDomWithoutSearchMetadata)
+{
+    // strtoull() on the empty string returned for missing <totalResults> /
+    // <startIndex> / <itemsPerPage> elements yields 0 without throwing, so
+    // the try/catch in parseOpdsDom() never actually observes an error here
+    // - m_hasSearchResult ends up true, with all counters at 0.
+    auto lib = kiwix::Library::create();
+    TestManager manager(lib);
+
+    const XMLDoc doc(R"(
+      <feed xmlns="http://www.w3.org/2005/Atom">
+        <entry>
+          <id>urn:uuid:book1</id>
+          <title>Book One</title>
+        </entry>
+      </feed>
+    )");
+
+    EXPECT_TRUE(manager.parseOpdsDom(doc, "http://example.com"));
+
+    EXPECT_TRUE(manager.m_hasSearchResult);
+    EXPECT_EQ(manager.m_totalBooks, 0U);
+    EXPECT_EQ(manager.m_startIndex, 0U);
+    EXPECT_EQ(manager.m_itemsPerPage, 0U);
+
+    EXPECT_EQ(lib->getBooksIds(), (kiwix::Library::BookIdCollection{"book1"}));
+}
+
+TEST(ManagerTest, parseOpdsDomWithNoEntriesReturnsTrue)
+{
+    auto lib = kiwix::Library::create();
+    TestManager manager(lib);
+
+    const XMLDoc doc(R"(<feed xmlns="http://www.w3.org/2005/Atom"></feed>)");
+
+    EXPECT_TRUE(manager.parseOpdsDom(doc, "http://example.com"));
+    EXPECT_TRUE(lib->getBooksIds().empty());
+}
 
 TEST(Manager, reload)
 {

--- a/test/manager.cpp
+++ b/test/manager.cpp
@@ -205,12 +205,14 @@ TEST(ManagerTest, readOpdsWithMalformedInputAddsNoBooks)
   EXPECT_TRUE(lib->getBooksIds().empty());
 }
 
-TEST(ManagerTest, reload)
+class ManagerReloadTest : public ::testing::TestWithParam<std::string> {};
+
+TEST_P(ManagerReloadTest, reload)
 {
   auto lib = kiwix::Library::create();
   kiwix::Manager manager(lib);
 
-  manager.reload({ "./test/library.xml" });
+  manager.reload({GetParam()});
   EXPECT_EQ(lib->getBooksIds(), (kiwix::Library::BookIdCollection{
         "charlesray",
         "inaccessiblezim",
@@ -225,7 +227,7 @@ TEST(ManagerTest, reload)
         "raycharles_uncategorized"
   }));
 
-  manager.reload({ "./test/library.xml" });
+  manager.reload({GetParam()});
   EXPECT_EQ(lib->getBooksIds(), kiwix::Library::BookIdCollection({
         "charlesray",
         "inaccessiblezim",
@@ -233,6 +235,9 @@ TEST(ManagerTest, reload)
         "raycharles_uncategorized"
   }));
 }
+
+INSTANTIATE_TEST_CASE_P(XmlAndOpds, ManagerReloadTest,
+    ::testing::Values("./test/library.xml", "./test/library.opds"));
 
 const char sampleOpdsFeed[] = R"(
 <feed xmlns="http://www.w3.org/2005/Atom"

--- a/test/manager.cpp
+++ b/test/manager.cpp
@@ -3,8 +3,32 @@
 #include "../include/library.h"
 #include "../include/book.h"
 #include "../include/tools.h"
-#include <iostream>
+#include <pugixml.hpp>
 #include <fstream>
+
+namespace
+{
+
+// parseXmlDom() are protected - this subclass re-exposes it
+// as public so it can be exercised directly, without going through the
+// readXml() wrapper.
+struct TestManager : public kiwix::Manager
+{
+  using kiwix::Manager::Manager;
+  using kiwix::Manager::parseXmlDom;
+};
+
+// XMLDoc helper needs to build a pugi::xml_document from a string before
+// handing it to parseXmlDom
+struct XMLDoc : pugi::xml_document
+{
+  explicit XMLDoc(const std::string& xml)
+  {
+    load_buffer(xml.c_str(), xml.size());
+  }
+};
+
+} // unnamed namespace
 
 TEST(ManagerTest, addBookFromPathAndGetIdTest)
 {
@@ -79,6 +103,91 @@ TEST(ManagerTest, readXml)
     EXPECT_EQ(45U, book.getMediaCount());
     EXPECT_EQ(678U*1024, book.getSize());
 }
+
+TEST(ManagerTest, parseXmlDomAddsAllBooksAndHonorsReadOnly)
+{
+    const XMLDoc doc(R"(
+      <library version="1.0">
+        <book id="book1" path="book1.zim" title="Book One"></book>
+        <book id="book2" path="book2.zim" title="Book Two"></book>
+      </library>
+    )");
+
+    {
+      auto lib = kiwix::Library::create();
+      TestManager manager(lib);
+      EXPECT_TRUE(manager.parseXmlDom(doc, /*readOnly=*/false, LIB_ABS_PATH, /*trustLibrary=*/true));
+
+      EXPECT_EQ(lib->getBooksIds(), (kiwix::Library::BookIdCollection{"book1", "book2"}));
+      EXPECT_FALSE(lib->getBookById("book1").readOnly());
+      EXPECT_FALSE(lib->getBookById("book2").readOnly());
+    }
+
+    {
+      auto lib = kiwix::Library::create();
+      TestManager manager(lib);
+      EXPECT_TRUE(manager.parseXmlDom(doc, /*readOnly=*/true, LIB_ABS_PATH, /*trustLibrary=*/true));
+
+      EXPECT_TRUE(lib->getBookById("book1").readOnly());
+      EXPECT_TRUE(lib->getBookById("book2").readOnly());
+    }
+}
+
+TEST(ManagerTest, parseXmlDomWithNoBooksReturnsTrue)
+{
+    auto lib = kiwix::Library::create();
+    TestManager manager(lib);
+
+    const XMLDoc doc(R"(<library version="1.0"></library>)");
+
+    EXPECT_TRUE(manager.parseXmlDom(doc, true, LIB_ABS_PATH, true));
+    EXPECT_TRUE(lib->getBooksIds().empty());
+}
+
+TEST(ManagerTest, parseXmlDomWithTrustLibraryFalseAndInvalidPath)
+{
+    // With trustLibrary=false and a path that can't be opened as a ZIM,
+    // readBookFromPath() fails and the book is added as-is, using the
+    // metadata coming from the XML.
+    auto lib = kiwix::Library::create();
+    TestManager manager(lib);
+
+    const XMLDoc doc(R"(
+      <library version="1.0">
+        <book id="book1" path="does-not-exist.zim" title="Book From XML"></book>
+      </library>
+    )");
+
+    EXPECT_TRUE(manager.parseXmlDom(doc, true, "./test/lib.xml", /*trustLibrary=*/false));
+
+    kiwix::Book book = lib->getBookById("book1");
+    EXPECT_FALSE(book.isPathValid());
+    EXPECT_EQ(book.getTitle(), "Book From XML");
+}
+
+TEST(ManagerTest, parseXmlDomWithTrustLibraryFalseAndValidPathAdoptsZimMetadata)
+{
+    // With trustLibrary=false and a path pointing to a real ZIM,
+    // readBookFromPath() re-reads the ZIM's own metadata - including its
+    // UUID, which becomes the book's id - discarding whatever the XML said.
+    auto lib = kiwix::Library::create();
+    TestManager manager(lib);
+
+    const XMLDoc doc(R"(
+      <library version="1.0">
+        <book id="book1" path="example.zim" title="Stale title from XML"></book>
+      </library>
+    )");
+
+    EXPECT_TRUE(manager.parseXmlDom(doc, true, "./test/lib.xml", /*trustLibrary=*/false));
+
+    const auto ids = lib->getBooksIds();
+    ASSERT_EQ(ids.size(), 1U);
+    kiwix::Book book = lib->getBookById(ids[0]);
+    EXPECT_TRUE(book.isPathValid());
+    EXPECT_NE(book.getTitle(), "Stale title from XML");
+}
+
 
 TEST(Manager, reload)
 {

--- a/test/manager.cpp
+++ b/test/manager.cpp
@@ -14,6 +14,19 @@ std::string resolveAbsPath(const std::string& basePath, const std::string& relPa
     return kiwix::computeAbsolutePath(kiwix::removeLastPathElement(basePath), relPath);
 }
 
+// Absolute path of test/library.opds, computed (rather than hardcoded) so
+// it resolves correctly regardless of the checkout location - unlike
+// LIB_ABS_PATH below, this one has to point to a real file, since
+// (unlike the readXml() tests) readFile()/readOpds() actually open it.
+// Built from single, separator-free path segments (rather than a
+// "test/library.opds"-style literal) because computeAbsolutePath() splits
+// on the OS-native separator only, so a literal using the "wrong" slash
+// would silently fail to be split into components on Windows.
+const std::string LIB_OPDS_ABS_PATH
+    = kiwix::computeAbsolutePath(
+        kiwix::computeAbsolutePath(kiwix::getCurrentDirectory(), "test"),
+        "library.opds");
+
 } // unnamed namespace
 
 TEST(ManagerTest, addBookFromPathAndGetIdTest)
@@ -277,14 +290,33 @@ TEST(ManagerTest, readOpdsAddsEntriesAndParsesSearchMetadata)
     kiwix::Book book1 = lib->getBookById("book1");
     EXPECT_EQ(book1.getTitle(), "Book One");
     EXPECT_EQ(book1.getUrl(), "https://example.com/book1.zim");
-    // OPDS entries carry no local path at this point (unlike XML's "path"
-    // attribute - see ManagerTest.readXml above): this feed has no
-    // rel="self" link, so the resolved path stays empty and invalid.
+
     EXPECT_EQ(book1.getPath(), "");
     EXPECT_FALSE(book1.isPathValid());
-    // Unlike readXml() (readOnly defaults to true), OPDS-sourced books are
-    // always mutable.
+
     EXPECT_FALSE(book1.readOnly());
+}
+
+TEST(ManagerTest, readOpdsWithInvalidSelfPath)
+{
+  auto lib = kiwix::Library::create();
+  kiwix::Manager manager(lib);
+
+  const std::string feed = R"(
+      <feed xmlns="http://www.w3.org/2005/Atom">
+        <entry>
+          <id>urn:uuid:book1</id>
+          <title>Book From OPDS</title>
+          <link rel="self" href="does-not-exist.zim" />
+        </entry>
+      </feed>
+    )";
+
+  EXPECT_TRUE(manager.readOpds(feed, "http://example.com", /*readOnly=*/false, /*libraryPath=*/"./test/library.opds"));
+
+  kiwix::Book book = lib->getBookById("book1");
+  EXPECT_FALSE(book.isPathValid());
+  EXPECT_EQ(book.getTitle(), "Book From OPDS");
 }
 
 TEST(ManagerTest, readOpdsWithoutSearchMetadata)
@@ -338,12 +370,10 @@ TEST(ManagerTest, readFileDetectsXmlFormat)
 
 TEST(ManagerTest, readFileDetectsOpdsFormat)
 {
-    // library.opds contains a "<feed" element, so it's routed through
-    // readOpds() instead readXml().
     auto lib = kiwix::Library::create();
     kiwix::Manager manager(lib);
 
-    EXPECT_TRUE(manager.readFile("./test/library.opds", /*readOnly=*/false));
+    EXPECT_TRUE(manager.readFile(LIB_OPDS_ABS_PATH, /*readOnly=*/false));
 
     EXPECT_EQ(lib->getBooksIds(), (kiwix::Library::BookIdCollection{
           "charlesray",
@@ -352,13 +382,11 @@ TEST(ManagerTest, readFileDetectsOpdsFormat)
           "raycharles_uncategorized"
     }));
 
-    // library.opds is the OPDS analogue of library.xml - same books, with
-    // every XML attribute mapped to its corresponding OPDS element/link
-    // (see the comment at the top of library.opds). Check the "raycharles"
-    // entry field-by-field, the same way ManagerTest.readXml does for its
-    // XML-sourced equivalent.
     kiwix::Book book = lib->getBookById("raycharles");
-    EXPECT_EQ(book.getPath(), ""); // no path on OPDS
+
+    EXPECT_EQ(book.getPath(), resolveAbsPath(LIB_OPDS_ABS_PATH, "./zimfile_raycharles.zim"));
+    EXPECT_TRUE(book.isPathValid());
+
     EXPECT_EQ(book.getUrl(), "https://github.com/kiwix/libkiwix/raw/master/test/data/zimfile_raycharles.zim");
     EXPECT_EQ(book.getTitle(), "Ray Charles");
     EXPECT_EQ(book.getDescription(), "Wikipedia articles about Ray Charles (not all of them but near to what an average newborn may find more than enough)");
@@ -371,21 +399,12 @@ TEST(ManagerTest, readFileDetectsOpdsFormat)
     EXPECT_EQ(book.getArticleCount(), 284U);
     EXPECT_EQ(book.getMediaCount(), 2U);
 
-    // Unlike XML's "size" (KiB, converted to bytes by updateFromXml()),
-    // OPDS's acquisition link "length" is taken as-is, already in bytes -
-    // library.opds was written with 556*1024 to match library.xml's
-    // size="556".
     EXPECT_EQ(book.getSize(), 556U*1024U);
 
     auto illustration = book.getIllustration(48);
-    // mimeType is the thumbnail link's "type" attribute taken verbatim
-    // (see Book::updateFromOpds() in book.cpp), so it retains the
-    // width/height/scale parameters present in library.opds.
-    EXPECT_EQ(illustration->mimeType, "image/png;width=48;height=48;scale=1");
-    // urlHost is "" for readFile(), so the relative thumbnail href is left
-    // untouched.
-    EXPECT_EQ(illustration->url, "https://example.com/favicon/raycharles.png");
 
+    EXPECT_EQ(illustration->mimeType, "image/png;width=48;height=48;scale=1");
+    EXPECT_EQ(illustration->url, "https://example.com/favicon/raycharles.png");
     EXPECT_FALSE(book.readOnly());
 }
 

--- a/test/manager.cpp
+++ b/test/manager.cpp
@@ -221,54 +221,56 @@ TEST(Manager, reload)
   }));
 }
 
+const char sampleOpdsFeed[] = R"(
+<feed xmlns="http://www.w3.org/2005/Atom"
+      xmlns:opds="https://specs.opds.io/opds-1.2">
+  <totalResults>9</totalResults>
+  <startIndex>7</startIndex>
+  <itemsPerPage>10</itemsPerPage>
+  <entry>
+    <id>urn:uuid:book1</id>
+    <title>Book One</title>
+    <link rel="http://opds-spec.org/acquisition/open-access"
+          type="application/x-zim"
+          href="https://example.com/book1.zim"
+          length="111" />
+  </entry>
+  <entry>
+    <id>urn:uuid:book2</id>
+    <title>Book Two</title>
+    <link rel="http://opds-spec.org/acquisition/open-access"
+          type="application/x-zim"
+          href="https://example.com/book2.zim"
+          length="222" />
+  </entry>
+</feed>
+)";
+
 TEST(ManagerTest, readOpdsAddsEntriesAndParsesSearchMetadata)
 {
-  auto lib = kiwix::Library::create();
-  kiwix::Manager manager(lib);
+    auto lib = kiwix::Library::create();
+    kiwix::Manager manager(lib);
 
-  EXPECT_TRUE(manager.readOpds(R"(
-    <feed xmlns="http://www.w3.org/2005/Atom"
-          xmlns:opds="https://specs.opds.io/opds-1.2">
-      <totalResults>9</totalResults>
-      <startIndex>7</startIndex>
-      <itemsPerPage>10</itemsPerPage>
-      <entry>
-        <id>urn:uuid:book1</id>
-        <title>Book One</title>
-        <link rel="http://opds-spec.org/acquisition/open-access"
-              type="application/x-zim"
-              href="https://example.com/book1.zim"
-              length="111" />
-      </entry>
-      <entry>
-        <id>urn:uuid:book2</id>
-        <title>Book Two</title>
-        <link rel="http://opds-spec.org/acquisition/open-access"
-              type="application/x-zim"
-              href="https://example.com/book2.zim"
-              length="222" />
-      </entry>
-    </feed>
-    )", "http://example.com"));
+    EXPECT_TRUE(manager.readOpds(sampleOpdsFeed, "http://example.com"));
 
-  EXPECT_TRUE(manager.m_hasSearchResult);
-  EXPECT_EQ(manager.m_totalBooks, 9U);
-  EXPECT_EQ(manager.m_startIndex, 7U);
-  EXPECT_EQ(manager.m_itemsPerPage, 10U);
+    EXPECT_TRUE(manager.m_hasSearchResult);
+    EXPECT_EQ(manager.m_totalBooks, 9U);
+    EXPECT_EQ(manager.m_startIndex, 7U);
+    EXPECT_EQ(manager.m_itemsPerPage, 10U);
 
-  EXPECT_EQ(lib->getBooksIds(), (kiwix::Library::BookIdCollection{"book1", "book2"}));
+    EXPECT_EQ(lib->getBooksIds(), (kiwix::Library::BookIdCollection{"book1", "book2"}));
 
-  kiwix::Book book1 = lib->getBookById("book1");
-  EXPECT_EQ(book1.getTitle(), "Book One");
-  EXPECT_EQ(book1.getUrl(), "https://example.com/book1.zim");
-  // OPDS entries carry no local path at this point (unlike XML's "path"
-  // attribute - see ManagerTest.readXml above): this feed has no
-  // rel="self" link, so the resolved path stays empty and invalid.
-  EXPECT_EQ(book1.getPath(), "");
-  EXPECT_FALSE(book1.isPathValid());
-  // Unlike readXml() (readOnly defaults to true), OPDS-sourced books are
-  // always mutable.
-  EXPECT_FALSE(book1.readOnly());
+    kiwix::Book book1 = lib->getBookById("book1");
+    EXPECT_EQ(book1.getTitle(), "Book One");
+    EXPECT_EQ(book1.getUrl(), "https://example.com/book1.zim");
+    // OPDS entries carry no local path at this point (unlike XML's "path"
+    // attribute - see ManagerTest.readXml above): this feed has no
+    // rel="self" link, so the resolved path stays empty and invalid.
+    EXPECT_EQ(book1.getPath(), "");
+    EXPECT_FALSE(book1.isPathValid());
+    // Unlike readXml() (readOnly defaults to true), OPDS-sourced books are
+    // always mutable.
+    EXPECT_FALSE(book1.readOnly());
 }
 
 TEST(ManagerTest, readOpdsWithoutSearchMetadata)

--- a/test/manager.cpp
+++ b/test/manager.cpp
@@ -246,6 +246,20 @@ const char sampleOpdsFeed[] = R"(
 </feed>
 )";
 
+TEST(ManagerTest, readOpdsHonorsReadOnlyTrue)
+{
+    // readOpds() defaults to readOnly=false (see
+    // ManagerTest.readOpdsAddsEntriesAndParsesSearchMetadata below, which
+    // covers that case) - this checks that readOnly=true is honored too.
+    auto lib = kiwix::Library::create();
+    kiwix::Manager manager(lib);
+
+    EXPECT_TRUE(manager.readOpds(sampleOpdsFeed, "http://example.com", /*readOnly=*/true));
+
+    EXPECT_TRUE(lib->getBookById("book1").readOnly());
+    EXPECT_TRUE(lib->getBookById("book2").readOnly());
+}
+
 TEST(ManagerTest, readOpdsAddsEntriesAndParsesSearchMetadata)
 {
     auto lib = kiwix::Library::create();

--- a/test/manager.cpp
+++ b/test/manager.cpp
@@ -4,7 +4,6 @@
 #include "../include/book.h"
 #include "../include/tools.h"
 #include <pugixml.hpp>
-#include <fstream>
 
 namespace
 {
@@ -221,7 +220,7 @@ TEST(ManagerTest, parseOpdsDomAddsEntriesAndParsesSearchMetadata)
 
     const XMLDoc doc(sampleOpdsFeed);
 
-    EXPECT_TRUE(manager.parseOpdsDom(doc, "http://example.com"));
+    EXPECT_TRUE(manager.parseOpdsDom(doc, "http://example.com", /*readOnly=*/false, /*trustLibrary=*/true));
 
     EXPECT_TRUE(manager.m_hasSearchResult);
     EXPECT_EQ(manager.m_totalBooks, 2U);
@@ -229,11 +228,7 @@ TEST(ManagerTest, parseOpdsDomAddsEntriesAndParsesSearchMetadata)
     EXPECT_EQ(manager.m_itemsPerPage, 2U);
 
     EXPECT_EQ(lib->getBooksIds(), (kiwix::Library::BookIdCollection{"book1", "book2"}));
-
-    // Unlike parseXmlDom(), OPDS-sourced books are always mutable.
-    kiwix::Book book1 = lib->getBookById("book1");
-    EXPECT_FALSE(book1.readOnly());
-    EXPECT_EQ(book1.getUrl(), "https://example.com/book1.zim");
+    EXPECT_EQ(lib->getBookById("book1").getUrl(), "https://example.com/book1.zim");
 }
 
 TEST(ManagerTest, parseOpdsDomWithoutSearchMetadata)
@@ -254,7 +249,7 @@ TEST(ManagerTest, parseOpdsDomWithoutSearchMetadata)
       </feed>
     )");
 
-    EXPECT_TRUE(manager.parseOpdsDom(doc, "http://example.com"));
+    EXPECT_TRUE(manager.parseOpdsDom(doc, "http://example.com", /*readOnly=*/false, /*trustLibrary=*/true));
 
     EXPECT_TRUE(manager.m_hasSearchResult);
     EXPECT_EQ(manager.m_totalBooks, 0U);
@@ -271,8 +266,52 @@ TEST(ManagerTest, parseOpdsDomWithNoEntriesReturnsTrue)
 
     const XMLDoc doc(R"(<feed xmlns="http://www.w3.org/2005/Atom"></feed>)");
 
-    EXPECT_TRUE(manager.parseOpdsDom(doc, "http://example.com"));
+    EXPECT_TRUE(manager.parseOpdsDom(doc, "http://example.com", /*readOnly=*/false, /*trustLibrary=*/true));
     EXPECT_TRUE(lib->getBooksIds().empty());
+}
+
+TEST(ManagerTest, parseOpdsDomHonorsReadOnly)
+{
+    const XMLDoc doc(sampleOpdsFeed);
+
+    {
+      auto lib = kiwix::Library::create();
+      TestManager manager(lib);
+      EXPECT_TRUE(manager.parseOpdsDom(doc, "http://example.com", /*readOnly=*/false, /*trustLibrary=*/true));
+
+      EXPECT_FALSE(lib->getBookById("book1").readOnly());
+      EXPECT_FALSE(lib->getBookById("book2").readOnly());
+    }
+
+    {
+      auto lib = kiwix::Library::create();
+      TestManager manager(lib);
+      EXPECT_TRUE(manager.parseOpdsDom(doc, "http://example.com", /*readOnly=*/true, /*trustLibrary=*/true));
+
+      EXPECT_TRUE(lib->getBookById("book1").readOnly());
+      EXPECT_TRUE(lib->getBookById("book2").readOnly());
+    }
+}
+
+TEST(ManagerTest, parseOpdsDomWithTrustLibraryFalseHasNoEffect)
+{
+    // Unlike XML library entries, OPDS entries never carry a local path -
+    // Book::updateFromOpds() never sets book.getPath() (see
+    // BookTest.updateFromOPDSTest in test/book.cpp). So even with
+    // trustLibrary=false, parseOpdsDom()'s "!book.getPath().empty()" guard
+    // is never true, readBookFromPath() is never invoked, and the book
+    // keeps exactly the metadata coming from the OPDS entry.
+    auto lib = kiwix::Library::create();
+    TestManager manager(lib);
+
+    const XMLDoc doc(sampleOpdsFeed);
+
+    EXPECT_TRUE(manager.parseOpdsDom(doc, "http://example.com", /*readOnly=*/false, /*trustLibrary=*/false));
+
+    kiwix::Book book1 = lib->getBookById("book1");
+    EXPECT_EQ(book1.getTitle(), "Book One");
+    EXPECT_EQ(book1.getPath(), "");
+    EXPECT_FALSE(book1.isPathValid());
 }
 
 TEST(Manager, reload)

--- a/test/manager.cpp
+++ b/test/manager.cpp
@@ -312,7 +312,7 @@ TEST(ManagerTest, readOpdsWithInvalidSelfPath)
       </feed>
     )";
 
-  EXPECT_TRUE(manager.readOpds(feed, "http://example.com", /*readOnly=*/false, /*libraryPath=*/"./test/library.opds"));
+  EXPECT_TRUE(manager.readOpds(feed, "http://example.com", /*readOnly=*/false));
 
   kiwix::Book book = lib->getBookById("book1");
   EXPECT_FALSE(book.isPathValid());

--- a/test/manager.cpp
+++ b/test/manager.cpp
@@ -192,7 +192,7 @@ TEST(ManagerTest, readOpdsWithMalformedInputAddsNoBooks)
   EXPECT_TRUE(lib->getBooksIds().empty());
 }
 
-TEST(Manager, reload)
+TEST(ManagerTest, reload)
 {
   auto lib = kiwix::Library::create();
   kiwix::Manager manager(lib);
@@ -311,4 +311,92 @@ TEST(ManagerTest, readOpdsWithoutSearchMetadata)
   EXPECT_EQ(manager.m_itemsPerPage, 0U);
 
   EXPECT_EQ(lib->getBooksIds(), (kiwix::Library::BookIdCollection{"book1"}));
+}
+
+TEST(ManagerTest, readFileDetectsXmlFormat)
+{
+    // readFile() sniffs the file content for a "<feed" substring to tell
+    // OPDS files apart from XML library files (see detectFormat() in
+    // manager.cpp).
+    auto lib = kiwix::Library::create();
+    kiwix::Manager manager(lib);
+
+    EXPECT_TRUE(manager.readFile("./test/library.xml"));
+
+    EXPECT_EQ(lib->getBooksIds(), (kiwix::Library::BookIdCollection{
+          "charlesray",
+          "inaccessiblezim",
+          "raycharles",
+          "raycharles_uncategorized"
+    }));
+
+    kiwix::Book book = lib->getBookById("raycharles");
+    EXPECT_EQ(book.getPath(), resolveAbsPath("./test/library.xml", "./zimfile_raycharles.zim"));
+    // readOnly defaults to true.
+    EXPECT_TRUE(book.readOnly());
+}
+
+TEST(ManagerTest, readFileDetectsOpdsFormat)
+{
+    // library.opds contains a "<feed" element, so it's routed through
+    // readOpds() instead readXml().
+    auto lib = kiwix::Library::create();
+    kiwix::Manager manager(lib);
+
+    EXPECT_TRUE(manager.readFile("./test/library.opds", /*readOnly=*/false));
+
+    EXPECT_EQ(lib->getBooksIds(), (kiwix::Library::BookIdCollection{
+          "charlesray",
+          "inaccessiblezim",
+          "raycharles",
+          "raycharles_uncategorized"
+    }));
+
+    // library.opds is the OPDS analogue of library.xml - same books, with
+    // every XML attribute mapped to its corresponding OPDS element/link
+    // (see the comment at the top of library.opds). Check the "raycharles"
+    // entry field-by-field, the same way ManagerTest.readXml does for its
+    // XML-sourced equivalent.
+    kiwix::Book book = lib->getBookById("raycharles");
+    EXPECT_EQ(book.getPath(), ""); // no path on OPDS
+    EXPECT_EQ(book.getUrl(), "https://github.com/kiwix/libkiwix/raw/master/test/data/zimfile_raycharles.zim");
+    EXPECT_EQ(book.getTitle(), "Ray Charles");
+    EXPECT_EQ(book.getDescription(), "Wikipedia articles about Ray Charles (not all of them but near to what an average newborn may find more than enough)");
+    EXPECT_EQ(book.getCommaSeparatedLanguages(), "eng");
+    EXPECT_EQ(book.getCreator(), "Wikipedia");
+    EXPECT_EQ(book.getPublisher(), "Kiwix");
+    EXPECT_EQ(book.getDate(), "2020-03-31");
+    EXPECT_EQ(book.getName(), "wikipedia_en_ray_charles");
+    EXPECT_EQ(book.getTags(), "public_tag_without_a_value;_private_tag_without_a_value;wikipedia;_category:wikipedia;_pictures:no;_videos:no;_details:no;_ftindex:yes");
+    EXPECT_EQ(book.getArticleCount(), 284U);
+    EXPECT_EQ(book.getMediaCount(), 2U);
+
+    // Unlike XML's "size" (KiB, converted to bytes by updateFromXml()),
+    // OPDS's acquisition link "length" is taken as-is, already in bytes -
+    // library.opds was written with 556*1024 to match library.xml's
+    // size="556".
+    EXPECT_EQ(book.getSize(), 556U*1024U);
+
+    auto illustration = book.getIllustration(48);
+    // mimeType is the thumbnail link's "type" attribute taken verbatim
+    // (see Book::updateFromOpds() in book.cpp), so it retains the
+    // width/height/scale parameters present in library.opds.
+    EXPECT_EQ(illustration->mimeType, "image/png;width=48;height=48;scale=1");
+    // urlHost is "" for readFile(), so the relative thumbnail href is left
+    // untouched.
+    EXPECT_EQ(illustration->url, "https://example.com/favicon/raycharles.png");
+
+    EXPECT_FALSE(book.readOnly());
+}
+
+TEST(ManagerTest, readFileWithOpdsFormatHonorsReadOnly)
+{
+    auto lib = kiwix::Library::create();
+    kiwix::Manager manager(lib);
+
+    EXPECT_TRUE(manager.readFile("./test/library.opds", /*readOnly=*/true, /*trustLibrary=*/true));
+
+    for (const auto& id : lib->getBooksIds()) {
+      EXPECT_TRUE(lib->getBookById(id).readOnly());
+    }
 }

--- a/test/manager.cpp
+++ b/test/manager.cpp
@@ -55,10 +55,14 @@ TEST(ManagerTest, addBookFromPathAndGetIdTest)
 # define UNITTEST_ZIM_PATH "zimfiles\\unittest.zim"
 # define LIB_ABS_PATH  "C:\\data\\lib.xml"
 # define ZIM_ABS_PATH  "C:\\data\\zimfiles\\unittest.zim"
+# define TEST_LIB_XML_PATH      ".\\test\\lib.xml"
+# define TEST_LIBRARY_OPDS_PATH ".\\test\\library.opds"
 #else
 # define UNITTEST_ZIM_PATH "zimfiles/unittest.zim"
 # define LIB_ABS_PATH "/data/lib.xml"
 # define ZIM_ABS_PATH "/data/zimfiles/unittest.zim"
+# define TEST_LIB_XML_PATH      "./test/lib.xml"
+# define TEST_LIBRARY_OPDS_PATH "./test/library.opds"
 #endif
 
 const char sampleLibraryXML[] = R"(
@@ -158,7 +162,7 @@ TEST(ManagerTest, parseXmlDomWithTrustLibraryFalseAndInvalidPath)
       </library>
     )");
 
-    EXPECT_TRUE(manager.parseXmlDom(doc, true, "./test/lib.xml", /*trustLibrary=*/false));
+    EXPECT_TRUE(manager.parseXmlDom(doc, true, TEST_LIB_XML_PATH, /*trustLibrary=*/false));
 
     kiwix::Book book = lib->getBookById("book1");
     EXPECT_FALSE(book.isPathValid());
@@ -179,7 +183,7 @@ TEST(ManagerTest, parseXmlDomWithTrustLibraryFalseAndValidPathAdoptsZimMetadata)
       </library>
     )");
 
-    EXPECT_TRUE(manager.parseXmlDom(doc, true, "./test/lib.xml", /*trustLibrary=*/false));
+    EXPECT_TRUE(manager.parseXmlDom(doc, true, TEST_LIB_XML_PATH, /*trustLibrary=*/false));
 
     const auto ids = lib->getBooksIds();
     ASSERT_EQ(ids.size(), 1U);
@@ -220,7 +224,7 @@ TEST(ManagerTest, parseOpdsDomAddsEntriesAndParsesSearchMetadata)
 
     const XMLDoc doc(sampleOpdsFeed);
 
-    EXPECT_TRUE(manager.parseOpdsDom(doc, "http://example.com", /*readOnly=*/false, /*trustLibrary=*/true));
+    EXPECT_TRUE(manager.parseOpdsDom(doc, "http://example.com", /*libraryPath=*/"", /*readOnly=*/false, /*trustLibrary=*/true));
 
     EXPECT_TRUE(manager.m_hasSearchResult);
     EXPECT_EQ(manager.m_totalBooks, 2U);
@@ -249,7 +253,7 @@ TEST(ManagerTest, parseOpdsDomWithoutSearchMetadata)
       </feed>
     )");
 
-    EXPECT_TRUE(manager.parseOpdsDom(doc, "http://example.com", /*readOnly=*/false, /*trustLibrary=*/true));
+    EXPECT_TRUE(manager.parseOpdsDom(doc, "http://example.com", /*libraryPath=*/"", /*readOnly=*/false, /*trustLibrary=*/true));
 
     EXPECT_TRUE(manager.m_hasSearchResult);
     EXPECT_EQ(manager.m_totalBooks, 0U);
@@ -266,7 +270,7 @@ TEST(ManagerTest, parseOpdsDomWithNoEntriesReturnsTrue)
 
     const XMLDoc doc(R"(<feed xmlns="http://www.w3.org/2005/Atom"></feed>)");
 
-    EXPECT_TRUE(manager.parseOpdsDom(doc, "http://example.com", /*readOnly=*/false, /*trustLibrary=*/true));
+    EXPECT_TRUE(manager.parseOpdsDom(doc, "http://example.com", /*libraryPath=*/"", /*readOnly=*/false, /*trustLibrary=*/true));
     EXPECT_TRUE(lib->getBooksIds().empty());
 }
 
@@ -277,7 +281,7 @@ TEST(ManagerTest, parseOpdsDomHonorsReadOnly)
     {
       auto lib = kiwix::Library::create();
       TestManager manager(lib);
-      EXPECT_TRUE(manager.parseOpdsDom(doc, "http://example.com", /*readOnly=*/false, /*trustLibrary=*/true));
+      EXPECT_TRUE(manager.parseOpdsDom(doc, "http://example.com", /*libraryPath=*/"", /*readOnly=*/false, /*trustLibrary=*/true));
 
       EXPECT_FALSE(lib->getBookById("book1").readOnly());
       EXPECT_FALSE(lib->getBookById("book2").readOnly());
@@ -286,32 +290,92 @@ TEST(ManagerTest, parseOpdsDomHonorsReadOnly)
     {
       auto lib = kiwix::Library::create();
       TestManager manager(lib);
-      EXPECT_TRUE(manager.parseOpdsDom(doc, "http://example.com", /*readOnly=*/true, /*trustLibrary=*/true));
+      EXPECT_TRUE(manager.parseOpdsDom(doc, "http://example.com", /*libraryPath=*/"", /*readOnly=*/true, /*trustLibrary=*/true));
 
       EXPECT_TRUE(lib->getBookById("book1").readOnly());
       EXPECT_TRUE(lib->getBookById("book2").readOnly());
     }
 }
 
-TEST(ManagerTest, parseOpdsDomWithTrustLibraryFalseHasNoEffect)
+TEST(ManagerTest, parseOpdsDomWithTrustLibraryFalseHasNoEffectWithoutSelfLink)
 {
-    // Unlike XML library entries, OPDS entries never carry a local path -
+    // sampleOpdsFeed's entries carry no rel="self" link, so
     // Book::updateFromOpds() never sets book.getPath() (see
     // BookTest.updateFromOPDSTest in test/book.cpp). So even with
     // trustLibrary=false, parseOpdsDom()'s "!book.getPath().empty()" guard
     // is never true, readBookFromPath() is never invoked, and the book
     // keeps exactly the metadata coming from the OPDS entry.
+    // Contrast with parseOpdsDomWithTrustLibraryFalseAndInvalidSelfPath /
+    // ...AndValidSelfPathAdoptsZimMetadata below, where a rel="self" link
+    // does make trustLibrary=false take effect.
     auto lib = kiwix::Library::create();
     TestManager manager(lib);
 
     const XMLDoc doc(sampleOpdsFeed);
 
-    EXPECT_TRUE(manager.parseOpdsDom(doc, "http://example.com", /*readOnly=*/false, /*trustLibrary=*/false));
+    EXPECT_TRUE(manager.parseOpdsDom(doc, "http://example.com", /*libraryPath=*/"./test/lib.xml", /*readOnly=*/false, /*trustLibrary=*/false));
 
     kiwix::Book book1 = lib->getBookById("book1");
     EXPECT_EQ(book1.getTitle(), "Book One");
     EXPECT_EQ(book1.getPath(), "");
     EXPECT_FALSE(book1.isPathValid());
+}
+
+TEST(ManagerTest, parseOpdsDomWithTrustLibraryFalseAndInvalidSelfPath)
+{
+    // With trustLibrary=false and a rel="self" link that can't be opened as
+    // a ZIM, readBookFromPath() fails and the book is added as-is, using
+    // the metadata coming from the OPDS entry (mirrors
+    // ManagerTest.parseXmlDomWithTrustLibraryFalseAndInvalidPath above).
+    auto lib = kiwix::Library::create();
+    TestManager manager(lib);
+
+    const XMLDoc doc(R"(
+      <feed xmlns="http://www.w3.org/2005/Atom">
+        <entry>
+          <id>urn:uuid:book1</id>
+          <title>Book From OPDS</title>
+          <link rel="self" href="does-not-exist.zim" />
+        </entry>
+      </feed>
+    )");
+
+    EXPECT_TRUE(manager.parseOpdsDom(doc, "http://example.com", /*libraryPath=*/"./test/lib.xml", /*readOnly=*/false, /*trustLibrary=*/false));
+
+    kiwix::Book book = lib->getBookById("book1");
+    EXPECT_FALSE(book.isPathValid());
+    EXPECT_EQ(book.getTitle(), "Book From OPDS");
+}
+
+TEST(ManagerTest, parseOpdsDomWithTrustLibraryFalseAndValidSelfPathAdoptsZimMetadata)
+{
+    // With trustLibrary=false and a rel="self" link pointing to a real
+    // ZIM, readBookFromPath() re-reads the ZIM's own metadata - including
+    // its UUID, which becomes the book's id - discarding whatever the OPDS
+    // entry said (mirrors
+    // ManagerTest.parseXmlDomWithTrustLibraryFalseAndValidPathAdoptsZimMetadata
+    // above). The relative href is resolved against libraryPath's directory
+    // ("./test"), exactly like updateFromXml()'s "path" attribute.
+    auto lib = kiwix::Library::create();
+    TestManager manager(lib);
+
+    const XMLDoc doc(R"(
+      <feed xmlns="http://www.w3.org/2005/Atom">
+        <entry>
+          <id>urn:uuid:book1</id>
+          <title>Stale title from OPDS</title>
+          <link rel="self" href="example.zim" />
+        </entry>
+      </feed>
+    )");
+
+    EXPECT_TRUE(manager.parseOpdsDom(doc, "http://example.com", /*libraryPath=*/TEST_LIB_XML_PATH, /*readOnly=*/false, /*trustLibrary=*/false));
+
+    const auto ids = lib->getBooksIds();
+    ASSERT_EQ(ids.size(), 1U);
+    kiwix::Book book = lib->getBookById(ids[0]);
+    EXPECT_TRUE(book.isPathValid());
+    EXPECT_NE(book.getTitle(), "Stale title from OPDS");
 }
 
 TEST(ManagerTest, readFileDetectsXmlFormat)
@@ -351,7 +415,7 @@ TEST(ManagerTest, readFileDetectsOpdsFormat)
     auto lib = kiwix::Library::create();
     kiwix::Manager manager(lib);
 
-    EXPECT_TRUE(manager.readFile("./test/library.opds", /*readOnly=*/false, /*trustLibrary=*/true));
+    EXPECT_TRUE(manager.readFile(TEST_LIBRARY_OPDS_PATH, /*readOnly=*/false, /*trustLibrary=*/true));
 
     EXPECT_EQ(lib->getBooksIds(), (kiwix::Library::BookIdCollection{
           "charlesray",
@@ -366,7 +430,18 @@ TEST(ManagerTest, readFileDetectsOpdsFormat)
     // entry field-by-field, the same way ManagerTest.readXml does for its
     // XML-sourced equivalent.
     kiwix::Book book = lib->getBookById("raycharles");
-    EXPECT_EQ(book.getPath(), ""); // no path on OPDS
+
+    // Like XML's "path" attribute, the OPDS rel="self" link's href is
+    // resolved against the library file's own directory (readFile() passes
+    // its own `path` as parseOpdsDom()'s libraryPath) - library.opds's
+    // "./zimfile_raycharles.zim" self link resolves to the same file as
+    // library.xml's "path" attribute of the same value.
+
+    EXPECT_EQ(book.getPath(),
+            kiwix::computeAbsolutePath(kiwix::removeLastPathElement(TEST_LIBRARY_OPDS_PATH),
+                                        "./zimfile_raycharles.zim"));
+    EXPECT_TRUE(book.isPathValid());
+
     EXPECT_EQ(book.getUrl(), "https://github.com/kiwix/libkiwix/raw/master/test/data/zimfile_raycharles.zim");
     EXPECT_EQ(book.getTitle(), "Ray Charles");
     EXPECT_EQ(book.getDescription(), "Wikipedia articles about Ray Charles (not all of them but near to what an average newborn may find more than enough)");

--- a/test/manager.cpp
+++ b/test/manager.cpp
@@ -314,6 +314,98 @@ TEST(ManagerTest, parseOpdsDomWithTrustLibraryFalseHasNoEffect)
     EXPECT_FALSE(book1.isPathValid());
 }
 
+TEST(ManagerTest, readFileDetectsXmlFormat)
+{
+    // readFile() sniffs the file content for a "<feed" substring to tell
+    // OPDS files apart from XML library files (see detectFormat() in
+    // manager.cpp). library.xml contains no such substring, so it's routed
+    // through parseXmlDom(), which - unlike the OPDS branch - resolves
+    // relative "path" attributes against the file's own path (readFile()'s
+    // 3rd argument to parseXmlDom() is `path`, not an empty string).
+    auto lib = kiwix::Library::create();
+    kiwix::Manager manager(lib);
+
+    EXPECT_TRUE(manager.readFile("./test/library.xml"));
+
+    EXPECT_EQ(lib->getBooksIds(), (kiwix::Library::BookIdCollection{
+          "charlesray",
+          "inaccessiblezim",
+          "raycharles",
+          "raycharles_uncategorized"
+    }));
+
+    kiwix::Book book = lib->getBookById("raycharles");
+    EXPECT_EQ(book.getPath(),
+              kiwix::computeAbsolutePath(kiwix::removeLastPathElement("./test/library.xml"),
+                                          "./zimfile_raycharles.zim"));
+    // readOnly defaults to true.
+    EXPECT_TRUE(book.readOnly());
+}
+
+TEST(ManagerTest, readFileDetectsOpdsFormat)
+{
+    // library.opds contains a "<feed" element, so it's routed through
+    // parseOpdsDom() instead. Note readFile() always passes an empty
+    // urlHost to parseOpdsDom(), unlike readOpds() which forwards the
+    // caller-supplied one - so any relative link in the feed is left as-is.
+    auto lib = kiwix::Library::create();
+    kiwix::Manager manager(lib);
+
+    EXPECT_TRUE(manager.readFile("./test/library.opds", /*readOnly=*/false, /*trustLibrary=*/true));
+
+    EXPECT_EQ(lib->getBooksIds(), (kiwix::Library::BookIdCollection{
+          "charlesray",
+          "inaccessiblezim",
+          "raycharles",
+          "raycharles_uncategorized"
+    }));
+
+    // library.opds is the OPDS analogue of library.xml - same books, with
+    // every XML attribute mapped to its corresponding OPDS element/link
+    // (see the comment at the top of library.opds). Check the "raycharles"
+    // entry field-by-field, the same way ManagerTest.readXml does for its
+    // XML-sourced equivalent.
+    kiwix::Book book = lib->getBookById("raycharles");
+    EXPECT_EQ(book.getPath(), ""); // no path on OPDS
+    EXPECT_EQ(book.getUrl(), "https://github.com/kiwix/libkiwix/raw/master/test/data/zimfile_raycharles.zim");
+    EXPECT_EQ(book.getTitle(), "Ray Charles");
+    EXPECT_EQ(book.getDescription(), "Wikipedia articles about Ray Charles (not all of them but near to what an average newborn may find more than enough)");
+    EXPECT_EQ(book.getCommaSeparatedLanguages(), "eng");
+    EXPECT_EQ(book.getCreator(), "Wikipedia");
+    EXPECT_EQ(book.getPublisher(), "Kiwix");
+    EXPECT_EQ(book.getDate(), "2020-03-31");
+    EXPECT_EQ(book.getName(), "wikipedia_en_ray_charles");
+    EXPECT_EQ(book.getTags(), "public_tag_without_a_value;_private_tag_without_a_value;wikipedia;_category:wikipedia;_pictures:no;_videos:no;_details:no;_ftindex:yes");
+    EXPECT_EQ(book.getArticleCount(), 284U);
+    EXPECT_EQ(book.getMediaCount(), 2U);
+
+    // Unlike XML's "size" (KiB, converted to bytes by updateFromXml()),
+    // OPDS's acquisition link "length" is taken as-is, already in bytes -
+    // library.opds was written with 556*1024 to match library.xml's
+    // size="556".
+    EXPECT_EQ(book.getSize(), 556U*1024U);
+
+    auto illustration = book.getIllustration(48);
+    EXPECT_EQ(illustration->mimeType, "image/png");
+    // urlHost is "" for readFile(), so the relative thumbnail href is left
+    // untouched.
+    EXPECT_EQ(illustration->url, "https://example.com/favicon/raycharles.png");
+
+    EXPECT_FALSE(book.readOnly());
+}
+
+TEST(ManagerTest, readFileWithOpdsFormatHonorsReadOnly)
+{
+    auto lib = kiwix::Library::create();
+    kiwix::Manager manager(lib);
+
+    EXPECT_TRUE(manager.readFile("./test/library.opds", /*readOnly=*/true, /*trustLibrary=*/true));
+
+    for (const auto& id : lib->getBooksIds()) {
+      EXPECT_TRUE(lib->getBookById(id).readOnly());
+    }
+}
+
 TEST(Manager, reload)
 {
   auto lib = kiwix::Library::create();

--- a/test/meson.build
+++ b/test/meson.build
@@ -50,6 +50,7 @@ if gtest_dep.found() and not meson.is_cross_build()
       'library.xml',
       'library.opds',
       'lib_for_server_search_test.xml',
+      'lib_for_server_search_test.opds',
       'customized_resources.txt',
       'helloworld.txt',
       'welcome.html',

--- a/test/meson.build
+++ b/test/meson.build
@@ -48,6 +48,7 @@ if gtest_dep.found() and not meson.is_cross_build()
       'poor.zim',
       'spelling_correction_test.zim',
       'library.xml',
+      'library.opds',
       'lib_for_server_search_test.xml',
       'customized_resources.txt',
       'helloworld.txt',

--- a/test/opds_entry_rendering.cpp
+++ b/test/opds_entry_rendering.cpp
@@ -217,6 +217,45 @@ TEST(FullEntryOpdsTest, rendersThumbnailLinkForBookIllustration)
   );
 }
 
+TEST(FullEntryOpdsTest, omitsSelfLinkWhenSelfPathIsEmpty)
+{
+  const Book book = createBook();
+  // selfPath left at its default ("") - mirrors how OPDSDumper calls this
+  // function for the live HTTP catalog, which must never leak a local path.
+  EXPECT_EQ(fullEntryOpds(book, "http://root.location", "", "book-id"),
+    "  <entry>\n"
+    CORE_ENTRY_BODY
+    "    <author>\n"
+    "      <name>Some Creator</name>\n"
+    "    </author>\n"
+    "    <publisher>\n"
+    "      <name>Some Publisher</name>\n"
+    "    </publisher>\n"
+    "    <dc:issued>2021-03-25T00:00:00Z</dc:issued>\n"
+    "    \n"
+    "  </entry>\n"
+  );
+}
+
+TEST(FullEntryOpdsTest, rendersSelfLinkWhenSelfPathIsSet)
+{
+  const Book book = createBook();
+  EXPECT_EQ(fullEntryOpds(book, "http://root.location", "", "book-id",
+                          /*selfPath=*/"/local/path/book.zim"),
+    "  <entry>\n"
+    CORE_ENTRY_BODY
+    "    <author>\n"
+    "      <name>Some Creator</name>\n"
+    "    </author>\n"
+    "    <publisher>\n"
+    "      <name>Some Publisher</name>\n"
+    "    </publisher>\n"
+    "    <dc:issued>2021-03-25T00:00:00Z</dc:issued>\n"
+    "    <link rel=\"self\" href=\"/local/path/book.zim\" type=\"application/x-zim\"/>\n"
+    "  </entry>\n"
+  );
+}
+
 TEST(FullEntryOpdsTest, specialCharactersInBookMetadataAreEscaped)
 {
   Book book = createBook();

--- a/test/opds_entry_rendering.cpp
+++ b/test/opds_entry_rendering.cpp
@@ -74,7 +74,6 @@ TEST(FullEntryOpdsTest, rendersCoreBookFields)
   EXPECT_EQ(fullEntryOpds(book, "http://root.location", /*contentAccessUrl=*/"", /*contentId=*/"book-id"),
     "  <entry>\n"
     CORE_ENTRY_BODY
-    "    \n"
     "    <author>\n"
     "      <name>Some Creator</name>\n"
     "    </author>\n"
@@ -94,7 +93,6 @@ TEST(FullEntryOpdsTest, omitsAcquisitionLinkWhenUrlIsEmpty)
   EXPECT_EQ(fullEntryOpds(book, "http://root.location", "", "book-id"),
     "  <entry>\n"
     CORE_ENTRY_BODY
-    "    \n"
     "    <author>\n"
     "      <name>Some Creator</name>\n"
     "    </author>\n"
@@ -116,7 +114,6 @@ TEST(FullEntryOpdsTest, rendersAcquisitionLinkWhenUrlIsSet)
   EXPECT_EQ(fullEntryOpds(book, "http://root.location", "", "book-id"),
     "  <entry>\n"
     CORE_ENTRY_BODY
-    "    \n"
     "    <author>\n"
     "      <name>Some Creator</name>\n"
     "    </author>\n"
@@ -136,7 +133,6 @@ TEST(FullEntryOpdsTest, omitsContentLinkWhenContentAccessUrlIsEmpty)
   EXPECT_EQ(fullEntryOpds(book, "http://root.location", /*contentAccessUrl=*/"", "book-id"),
     "  <entry>\n"
     CORE_ENTRY_BODY
-    "    \n"
     "    <author>\n"
     "      <name>Some Creator</name>\n"
     "    </author>\n"
@@ -275,7 +271,6 @@ TEST(FullEntryOpdsTest, specialCharactersInBookMetadataAreEscaped)
     "    <tags>tag1;tag2;_category:wikipedia</tags>\n"
     "    <articleCount>42</articleCount>\n"
     "    <mediaCount>7</mediaCount>\n"
-    "    \n"
     "    <author>\n"
     "      <name>Some Creator</name>\n"
     "    </author>\n"

--- a/test/pathTools.cpp
+++ b/test/pathTools.cpp
@@ -178,6 +178,50 @@ TEST(pathTools, removeLastPathElement)
             A2("a","b"));
 }
 
+TEST(pathTools, resolveContentOrigin)
+{
+  {
+    const auto origin = kiwix::resolveContentOrigin("https://library.kiwix.org/catalog/v2/entries");
+    ASSERT_EQ(origin.urlHost, "https://library.kiwix.org");
+    ASSERT_EQ(origin.baseDir, "");
+  }
+  {
+    const auto origin = kiwix::resolveContentOrigin("http://example.com");
+    ASSERT_EQ(origin.urlHost, "http://example.com");
+    ASSERT_EQ(origin.baseDir, "");
+  }
+  {
+    const auto origin = kiwix::resolveContentOrigin("https://library.kiwix.org/");
+    ASSERT_EQ(origin.urlHost, "https://library.kiwix.org");
+    ASSERT_EQ(origin.baseDir, "");
+  }
+  {
+    // removeLastPathElement() (which this delegates to for local paths)
+    // normalizes away the leading "." component - see
+    // pathTools.normalizePartsRelative above.
+    const auto origin = kiwix::resolveContentOrigin(P3(".","test","lib.xml"));
+    ASSERT_EQ(origin.urlHost, "");
+    ASSERT_EQ(origin.baseDir, "test");
+  }
+  {
+    const auto origin = kiwix::resolveContentOrigin(A2("data","library.opds"));
+    ASSERT_EQ(origin.urlHost, "");
+    ASSERT_EQ(origin.baseDir, A1("data"));
+  }
+#ifdef _WIN32
+  {
+    const auto origin = kiwix::resolveContentOrigin("C:\\data\\library.opds");
+    ASSERT_EQ(origin.urlHost, "");
+    ASSERT_EQ(origin.baseDir, "C:\\data");
+  }
+#endif
+  {
+    const auto origin = kiwix::resolveContentOrigin("");
+    ASSERT_EQ(origin.urlHost, "");
+    ASSERT_EQ(origin.baseDir, "");
+  }
+}
+
 TEST(pathTools, appendToDirectory)
 {
   ASSERT_EQ(kiwix::appendToDirectory(P3("a","b","c"), "foo.xml"),

--- a/test/server_search.cpp
+++ b/test/server_search.cpp
@@ -950,7 +950,9 @@ struct TestData
   }
 };
 
-TEST(ServerSearchTest, searchResults)
+class LibForServerSearchTest : public ::testing::TestWithParam<std::string> {};
+
+TEST_P(LibForServerSearchTest, searchResults)
 {
   const TestData testData[] = {
     {
@@ -1556,8 +1558,7 @@ TEST(ServerSearchTest, searchResults)
     },
   };
 
-  ZimFileServer zfs(SERVER_PORT, ZimFileServer::DEFAULT_OPTIONS,
-                    "./test/lib_for_server_search_test.xml");
+  ZimFileServer zfs(SERVER_PORT, ZimFileServer::DEFAULT_OPTIONS, GetParam());
 
   for ( const auto& t : testData ) {
     const std::string htmlSearchUrl = t.url();
@@ -1675,10 +1676,9 @@ std::string noBookFoundErrorHtml(std::string url)
   );
 }
 
-TEST(ServerSearchTest, bookSelectionNegativeTests)
+TEST_P(LibForServerSearchTest, bookSelectionNegativeTests)
 {
-  ZimFileServer zfs(SERVER_PORT, ZimFileServer::DEFAULT_OPTIONS,
-                    "./test/lib_for_server_search_test.xml");
+  ZimFileServer zfs(SERVER_PORT, ZimFileServer::DEFAULT_OPTIONS, GetParam());
 
   {
     // books.name (unlike books.filter.name) DOESN'T consider the book name
@@ -1703,3 +1703,7 @@ TEST(ServerSearchTest, bookSelectionNegativeTests)
     EXPECT_EQ(r->body, noBookFoundErrorHtml(url));
   }
 }
+
+INSTANTIATE_TEST_CASE_P(XmlAndOpds, LibForServerSearchTest,
+    ::testing::Values("./test/lib_for_server_search_test.xml",
+                       "./test/lib_for_server_search_test.opds"));


### PR DESCRIPTION
# Reading OPDS library file

## Why

Addresses issue [#1309](https://github.com/kiwix/libkiwix/issues/1309) — "Allow to ingest directly an OPDS feed." The long-term goal stated in the issue is to eventually drop `library.xml` support entirely in favor of OPDS, to simplify the format libkiwix has to maintain over time. This PR is the first step toward that: it makes `Manager` and `Server` able to read OPDS as a library source through the same entry point as XML, without yet removing XML support. It is a prerequisite for any follow-up PR that would deprecate or drop `library.xml`. The next PR will cover OPDS file writing functionality.

## What

`Manager::readFile()` now auto-detects whether the file it's given is a `library.xml` or an OPDS file, and parses it accordingly — previously OPDS content could only be loaded via the separate `readOpds()` string-based API. `parseOpdsDom()` was extended to accept the same `readOnly`/`trustLibrary` flags `readFile()` already exposes for XML, and `Book::updateFromOpds()` was fixed up to capture a book's own path (via the OPDS `rel="self"` link) and to not stomp on existing illustrations when re-parsing.

## Impact on libkiwix users/devs

No breaking changes to the public API — `readFile(path, readOnly, trustLibrary)` keeps the same signature. Callers can now point it at either a `library.xml` or an OPDS feed and get consistent behavior (same read-only/trust-library semantics either way), instead of needing to know the format up front and call a different method. `trustLibrary=false` on an OPDS file now actually re-verifies book metadata from disk rather than blindly trusting the feed, matching existing XML behavior.

## Fundamental change

Format detection is content-based, not extension-based: `detectFormat()` sniffs for a `<feed` tag in the file content. This means `readFile()` is no longer XML-only — it's now a dual-format entry point, with OPDS parsing brought up to parity with XML parsing on the flags that control trust and mutability of loaded books.

## Important notes
kiwix-manage and kiwix-serve automatically work with these new changes, so we will not introduce a PR for kiwix-tools. 