### PR TITLE
Bump linux builder image version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
       HOME: /home/runner
     runs-on: ubuntu-24.04
     container:
-      image: "ghcr.io/kiwix/kiwix-build_ci_${{matrix.image_variant}}:2026-04-25"
+      image: "ghcr.io/kiwix/kiwix-build_ci_${{matrix.image_variant}}:2026-07-22"
     steps:
     - name: Checkout code
       uses: actions/checkout@v6


### PR DESCRIPTION
kiwix-build's CI/CD which produces the deps archives for this project now uses a builder image with OpenSSL develepment package installed which results in the libcurl dependency being configured with ssl support enabled. That dependency is unusable on the old builder because of missing OpenSSL dev package.