### PR TITLE
Replace try/catch with explicit presence checks in parseOpdsDom()

### DIFF
--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -146,14 +146,24 @@ bool Manager::readXml(const std::string& xml,
 bool Manager::parseOpdsDom(const pugi::xml_document& doc, const std::string& urlHost)
 {
   pugi::xml_node libraryNode = doc.child("feed");
-
-  try {
-    m_totalBooks = strtoull(libraryNode.child("totalResults").child_value(), 0, 0);
-    m_startIndex = strtoull(libraryNode.child("startIndex").child_value(), 0, 0);
-    m_itemsPerPage = strtoull(libraryNode.child("itemsPerPage").child_value(), 0, 0);
-    m_hasSearchResult = true;
-  } catch(...) {
+  if (!libraryNode) {
     m_hasSearchResult = false;
+    return false;
+  }
+
+  const pugi::xml_node totalResultsNode = libraryNode.child("totalResults");
+  const pugi::xml_node startIndexNode = libraryNode.child("startIndex");
+  const pugi::xml_node itemsPerPageNode = libraryNode.child("itemsPerPage");
+
+  m_hasSearchResult = totalResultsNode && startIndexNode && itemsPerPageNode;
+  if (m_hasSearchResult) {
+    m_totalBooks = strtoull(totalResultsNode.child_value(), 0, 0);
+    m_startIndex = strtoull(startIndexNode.child_value(), 0, 0);
+    m_itemsPerPage = strtoull(itemsPerPageNode.child_value(), 0, 0);
+  } else {
+    m_totalBooks = 0;
+    m_startIndex = 0;
+    m_itemsPerPage = 0;
   }
 
   for (pugi::xml_node entryNode = libraryNode.child("entry"); entryNode;

--- a/test/manager.cpp
+++ b/test/manager.cpp
@@ -108,3 +108,79 @@ TEST(Manager, reload)
         "raycharles_uncategorized"
   }));
 }
+
+TEST(ManagerTest, readOpdsAddsEntriesAndParsesSearchMetadata)
+{
+  auto lib = kiwix::Library::create();
+  kiwix::Manager manager(lib);
+
+  EXPECT_TRUE(manager.readOpds(R"(
+    <feed xmlns="http://www.w3.org/2005/Atom"
+          xmlns:opds="https://specs.opds.io/opds-1.2">
+      <totalResults>9</totalResults>
+      <startIndex>7</startIndex>
+      <itemsPerPage>10</itemsPerPage>
+      <entry>
+        <id>urn:uuid:book1</id>
+        <title>Book One</title>
+        <link rel="http://opds-spec.org/acquisition/open-access"
+              type="application/x-zim"
+              href="https://example.com/book1.zim"
+              length="111" />
+      </entry>
+      <entry>
+        <id>urn:uuid:book2</id>
+        <title>Book Two</title>
+        <link rel="http://opds-spec.org/acquisition/open-access"
+              type="application/x-zim"
+              href="https://example.com/book2.zim"
+              length="222" />
+      </entry>
+    </feed>
+    )", "http://example.com"));
+
+  EXPECT_TRUE(manager.m_hasSearchResult);
+  EXPECT_EQ(manager.m_totalBooks, 9U);
+  EXPECT_EQ(manager.m_startIndex, 7U);
+  EXPECT_EQ(manager.m_itemsPerPage, 10U);
+
+  EXPECT_EQ(lib->getBooksIds(), (kiwix::Library::BookIdCollection{"book1", "book2"}));
+
+  kiwix::Book book1 = lib->getBookById("book1");
+  EXPECT_EQ(book1.getTitle(), "Book One");
+  EXPECT_EQ(book1.getUrl(), "https://example.com/book1.zim");
+  // OPDS entries carry no local path at this point (unlike XML's "path"
+  // attribute - see ManagerTest.readXml above): this feed has no
+  // rel="self" link, so the resolved path stays empty and invalid.
+  EXPECT_EQ(book1.getPath(), "");
+  EXPECT_FALSE(book1.isPathValid());
+  // Unlike readXml() (readOnly defaults to true), OPDS-sourced books are
+  // always mutable.
+  EXPECT_FALSE(book1.readOnly());
+}
+
+TEST(ManagerTest, readOpdsWithoutSearchMetadata)
+{
+  auto lib = kiwix::Library::create();
+  kiwix::Manager manager(lib);
+
+  const std::string feed = R"(
+      <feed xmlns="http://www.w3.org/2005/Atom">
+        <entry>
+          <id>urn:uuid:book1</id>
+          <title>Book One</title>
+        </entry>
+      </feed>
+    )";
+
+  EXPECT_TRUE(manager.readOpds(feed, "http://example.com"));
+
+  // None of <totalResults>/<startIndex>/<itemsPerPage> are present, so
+  // there's no search result to report.
+  EXPECT_FALSE(manager.m_hasSearchResult);
+  EXPECT_EQ(manager.m_totalBooks, 0U);
+  EXPECT_EQ(manager.m_startIndex, 0U);
+  EXPECT_EQ(manager.m_itemsPerPage, 0U);
+
+  EXPECT_EQ(lib->getBooksIds(), (kiwix::Library::BookIdCollection{"book1"}));
+}


### PR DESCRIPTION
totalResults/startIndex/itemsPerPage were parsed inside a try/catch, but strtoull() never throws on malformed input, so a feed missing those elements silently fell through with zeroed-out fields and no way to distinguish "not a search result" from "search result of size zero". Check each node's presence directly instead, and cover both paths with new Manager tests.