### PR TITLE
Reimplemented Manager::readFile() via Manager::readXml()

### DIFF
--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -20,7 +20,6 @@
 #include "manager.h"
 
 #include "tools.h"
-#include "tools/pathTools.h"
 
 #include <pugixml.hpp>
 #include <filesystem>
@@ -201,20 +200,12 @@ bool Manager::readFile(
   bool readOnly,
   bool trustLibrary)
 {
-  bool retVal = true;
-  pugi::xml_document doc;
-
-#ifdef _WIN32
-  pugi::xml_parse_result result = doc.load_file(Utf8ToWide(path).c_str());
-#else
-  pugi::xml_parse_result result = doc.load_file(path.c_str());
-#endif
-
-  if (result) {
-    this->parseXmlDom(doc, readOnly, path, trustLibrary);
-  } else {
-    retVal = false;
+  if (!kiwix::fileExists(path)) {
+    return false;
   }
+
+  const std::string xml = getFileContent(path);
+  const bool retVal = this->readXml(xml, readOnly, path, trustLibrary);
 
   /* This has to be set (although if the file does not exists) to be
    * able to know where to save the library if new content are

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -135,10 +135,10 @@ bool Manager::readXml(const std::string& xml,
       = doc.load_buffer((void*)xml.data(), xml.size());
 
   if (result) {
-    this->parseXmlDom(doc, readOnly, libraryPath, trustLibrary);
+    return this->parseXmlDom(doc, readOnly, libraryPath, trustLibrary);
   }
 
-  return true;
+  return false;
 }
 
 

--- a/test/manager.cpp
+++ b/test/manager.cpp
@@ -131,6 +131,36 @@ TEST(ManagerTest, readXmlNotXml)
     EXPECT_TRUE(lib->getBooksIds().empty());
 }
 
+TEST(ManagerTest, readOpdsWithNoEntriesReturnsTrue)
+{
+  auto lib = kiwix::Library::create();
+  kiwix::Manager manager(lib);
+
+  EXPECT_TRUE(manager.readOpds(R"(<feed xmlns="http://www.w3.org/2005/Atom"></feed>)", "http://example.com"));
+  EXPECT_TRUE(lib->getBooksIds().empty());
+}
+
+TEST(ManagerTest, readOpdsWithMalformedInputAddsNoBooks)
+{
+  auto lib = kiwix::Library::create();
+  kiwix::Manager manager(lib);
+
+  const std::string feed = R"(
+      <feed xmlns="http://www.w3.org/2005/Atom">
+        <entry>
+          <id>urn:uuid:book1</id>
+          <title>Book One</title>
+        </entry>
+        <entry>
+          <id>urn:uuid:book2</id>
+          <title>Book Two</title>
+      </feed>
+    )";
+
+  EXPECT_FALSE(manager.readOpds(feed, "http://example.com"));
+  EXPECT_TRUE(lib->getBooksIds().empty());
+}
+
 TEST(Manager, reload)
 {
   auto lib = kiwix::Library::create();

--- a/test/manager.cpp
+++ b/test/manager.cpp
@@ -65,7 +65,14 @@ TEST(ManagerTest, readXml)
 
     EXPECT_EQ(true, manager.readXml(sampleLibraryXML, true, LIB_ABS_PATH, true));
     kiwix::Book book = lib->getBookById("0d0bcd57-d3f6-cb22-44cc-a723ccb4e1b2");
+
+    // "path" is relative in the XML - readXml() resolves it against the
+    // directory of LIB_ABS_PATH, yielding ZIM_ABS_PATH.
     EXPECT_EQ(ZIM_ABS_PATH, book.getPath());
+    // ... but ZIM_ABS_PATH doesn't exist on disk, so the resolved path is
+    // not considered valid.
+    EXPECT_FALSE(book.isPathValid());
+    EXPECT_TRUE(book.readOnly());
     EXPECT_EQ("https://example.com/zimfiles/unittest.zim", book.getUrl());
     EXPECT_EQ("Unit Test", book.getTitle());
     EXPECT_EQ("Wikipedia articles about unit testing", book.getDescription());
@@ -78,6 +85,50 @@ TEST(ManagerTest, readXml)
     EXPECT_EQ(123U, book.getArticleCount());
     EXPECT_EQ(45U, book.getMediaCount());
     EXPECT_EQ(678U*1024, book.getSize());
+}
+
+TEST(ManagerTest, readXmlInvalid)
+{
+  auto lib = kiwix::Library::create();
+  kiwix::Manager manager = kiwix::Manager(lib);
+
+  const std::string invalidXML = R"(
+<library version="1.0">
+  <book
+        id="0d0bcd57-d3f6-cb22-44cc-a723ccb4e1b2"
+        path=")" UNITTEST_ZIM_PATH R"("
+        url="https://example.com/zimfiles/unittest.zim"
+        title="Unit Test"
+        description="Wikipedia articles about unit testing"
+        language="eng"
+        creator="Wikipedia"
+        publisher="Kiwix"
+        date="2020-03-31"
+        name="wikipedia_en_unit_testing"
+        tags="unittest;wikipedia"
+        articleCount="123"
+        mediaCount="45"
+        size="678"
+      ></book>
+  <book
+        id="1a1bcd57-d3f6-cb22-44cc-a723ccb4e1b3"
+        url="https://example.com/zimfiles/unittest2.zim"
+        title="Unit Test 2"
+)";
+
+  EXPECT_FALSE(manager.readXml(invalidXML, true, LIB_ABS_PATH, true));
+  EXPECT_TRUE(lib->getBooksIds().empty());
+}
+
+TEST(ManagerTest, readXmlNotXml)
+{
+    auto lib = kiwix::Library::create();
+    kiwix::Manager manager = kiwix::Manager(lib);
+
+    const std::string notXML = "this is definitely not xml content";
+
+    EXPECT_FALSE(manager.readXml(notXML, true, LIB_ABS_PATH, true));
+    EXPECT_TRUE(lib->getBooksIds().empty());
 }
 
 TEST(Manager, reload)


### PR DESCRIPTION
Refactor readFile() to use readXML() instead of parseXmlDom(). This is a prerequisite for upcoming OPDS format library enhancements.