### PR TITLE
Fix Manager::readFile() losing writableLibraryPath for new libraries

### DIFF
--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -200,21 +200,19 @@ bool Manager::readFile(
   bool readOnly,
   bool trustLibrary)
 {
+  /* This has to be set (although if the file does not exists) to be
+   * able to know where to save the library if new content are
+   * available */
+  if (!readOnly) { // todo XXX, better to introduce setWritableLibraryPath and remove this code from the readFile
+    this->writableLibraryPath = path;
+  }
+
   if (!kiwix::fileExists(path)) {
     return false;
   }
 
   const std::string xml = getFileContent(path);
-  const bool retVal = this->readXml(xml, readOnly, path, trustLibrary);
-
-  /* This has to be set (although if the file does not exists) to be
-   * able to know where to save the library if new content are
-   * available */
-  if (!readOnly) {
-    this->writableLibraryPath = path;
-  }
-
-  return retVal;
+  return this->readXml(xml, readOnly, path, trustLibrary);
 }
 
 

--- a/test/manager.cpp
+++ b/test/manager.cpp
@@ -6,6 +6,16 @@
 #include <iostream>
 #include <fstream>
 
+namespace
+{
+
+std::string resolveAbsPath(const std::string& basePath, const std::string& relPath)
+{
+    return kiwix::computeAbsolutePath(kiwix::removeLastPathElement(basePath), relPath);
+}
+
+} // unnamed namespace
+
 TEST(ManagerTest, addBookFromPathAndGetIdTest)
 {
     auto lib = kiwix::Library::create();
@@ -20,7 +30,7 @@ TEST(ManagerTest, addBookFromPathAndGetIdTest)
     const std::string url = "url";
     bookId = manager.addBookFromPathAndGetId("./test/example.zim", pathToSave, url, true);
     book = lib->getBookById(bookId);
-    auto savedPath = kiwix::computeAbsolutePath(kiwix::removeLastPathElement(manager.writableLibraryPath), pathToSave);
+    auto savedPath = resolveAbsPath(manager.writableLibraryPath, pathToSave);
     EXPECT_EQ(book.getPath(), savedPath);
     EXPECT_EQ(book.getUrl(), url);
 }

--- a/test/manager.cpp
+++ b/test/manager.cpp
@@ -35,6 +35,27 @@ TEST(ManagerTest, addBookFromPathAndGetIdTest)
     EXPECT_EQ(book.getUrl(), url);
 }
 
+TEST(ManagerTest, readFileSetsWritableLibraryPathEvenIfFileDoesNotExist)
+{
+    auto lib = kiwix::Library::create();
+    kiwix::Manager manager(lib);
+
+    const std::string nonExistentPath
+        = kiwix::computeAbsolutePath(
+              kiwix::computeAbsolutePath(kiwix::getCurrentDirectory(), "test"),
+              "does_not_exist.xml");
+
+    EXPECT_FALSE(manager.readFile(nonExistentPath, /*readOnly=*/false));
+    EXPECT_EQ(manager.writableLibraryPath, nonExistentPath);
+
+    const std::string pathToSave = "./relative.zim";
+    auto bookId = manager.addBookFromPathAndGetId("./test/example.zim", pathToSave);
+    ASSERT_NE(bookId, "");
+    kiwix::Book book = lib->getBookById(bookId);
+    auto savedPath = resolveAbsPath(nonExistentPath, pathToSave);
+    EXPECT_EQ(book.getPath(), savedPath);
+}
+
 
 
 #if _WIN32


### PR DESCRIPTION
## Why

`Manager::readFile()` is how a library file gets loaded — including the still-nonexistent path of a brand-new library about to be created. The `fileExists()` early-return skipped setting `writableLibraryPath` in that case, so a caller who then added a book with a relative `--zimPathToSave` had it resolved against the process's CWD instead of the new library's own directory — silently wrong output paths for anyone creating a library from scratch.

## What

- In `Manager::readFile()`, moved the `writableLibraryPath` assignment ahead of the `fileExists()` early return, so it's set whether or not the file exists yet.
- Added `resolveAbsPath()` test helper (wraps the recurring `computeAbsolutePath(removeLastPathElement(...), ...)` pattern) and used it in the existing `addBookFromPathAndGetIdTest`.
- Added `readFileSetsWritableLibraryPathEvenIfFileDoesNotExist` regression test, using the new helper.

## Impact on libkiwix users/devs

No API changes. Fixes incorrect path resolution for any caller (e.g. `kiwix-manage`) that creates a new library and saves a book with a relative path before the library file itself exists on disk.

## Fundamental change

None — this is an ordering fix inside `readFile()`; behavior for existing/readable libraries is unchanged.