### PR TITLE
fix: serve books added from an fd-backed archive over the local server

### DIFF
--- a/include/book.h
+++ b/include/book.h
@@ -105,6 +105,19 @@ class Book
 
   const std::string& getDownloadId() const { return m_downloadId; }
 
+  /**
+   * Returns the zim::Archive this book was built from via update(const
+   * zim::Archive&), if any, or nullptr otherwise.
+   *
+   * A book updated from a path-based archive (updateFromXml(), etc.) has no
+   * handle here -- getArchiveById() reopens it from getPath() as before.
+   * A book updated directly from an already-open zim::Archive (e.g. one
+   * opened from a file descriptor, which may have no reopenable path at
+   * all) keeps a reference to that archive here, so callers that only have
+   * the book (not the original archive) can still get at its content.
+   */
+  std::shared_ptr<zim::Archive> getArchiveHandle() const { return m_handle; }
+
   void setReadOnly(bool readOnly) { m_readOnly = readOnly; }
   void setId(const std::string& id) { m_id = id; }
   void setPath(const std::string& path);
@@ -151,6 +164,7 @@ class Book
   bool m_readOnly = false;
   uint64_t m_size = 0;
   Illustrations m_illustrations;
+  std::shared_ptr<zim::Archive> m_handle;
 
   // Used as the return value of getDefaultIllustration() when no default
   // illustration is found in the book

--- a/src/book.cpp
+++ b/src/book.cpp
@@ -65,7 +65,19 @@ bool Book::update(const kiwix::Book& other)
 
 void Book::update(const zim::Archive& archive) {
   m_path = archive.getFilename();
-  m_pathValid = true;
+  // getFilename() is empty for archives that have no (re)openable path at
+  // all, e.g. ones opened from a file descriptor with no backing path
+  // (see https://github.com/kiwix/libkiwix/issues/1015). Claiming such a
+  // book has a valid path here would make getArchiveById() below try (and
+  // fail) to reopen it by that empty path instead of using m_handle.
+  m_pathValid = !m_path.empty();
+  // Keep a handle on the already-open archive so callers that only have
+  // this Book (not the original zim::Archive) -- e.g. Library::getArchiveById()
+  // serving this book over HTTP -- can still get at its content, even when
+  // there's no path to reopen it from. zim::Archive is a cheap-to-copy
+  // handle around a shared_ptr<FileImpl>, so this doesn't duplicate the
+  // underlying file/fd.
+  m_handle = std::make_shared<zim::Archive>(archive);
   m_id = std::string(archive.getUuid());
   m_title = getArchiveTitle(archive);
   m_description = getMetaDescription(archive);

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -390,10 +390,20 @@ const Book& Library::getBookByPath(const std::string& path) const
 
 std::shared_ptr<zim::Archive> Library::getArchiveById(const std::string& id)
 {
+  const auto& book = getBookById(id);
+  // A book updated directly from an already-open zim::Archive (see
+  // Book::update(const zim::Archive&)) keeps a handle on it, since it may
+  // have no reopenable path at all (e.g. one opened from a file
+  // descriptor -- see https://github.com/kiwix/libkiwix/issues/1015).
+  // Prefer that handle over reopening by path, which is not just an
+  // optimization here: for such a book it's the only way to get an
+  // archive at all.
+  if (auto handle = book.getArchiveHandle()) {
+    return handle;
+  }
   try {
     return mp_archiveCache->getOrPut(id,
     [&](){
-      auto book = getBookById(id);
       if (!book.isPathValid()) {
         throw std::invalid_argument("");
       }

--- a/test/library.cpp
+++ b/test/library.cpp
@@ -318,6 +318,13 @@ const char sampleLibraryXML[] = R"(
 #include "../include/book.h"
 #include "../include/bookmark.h"
 
+#include <zim/archive.h>
+
+#ifndef _WIN32
+# include <fcntl.h>
+# include <unistd.h>
+#endif
+
 namespace
 {
 
@@ -1224,6 +1231,47 @@ TEST_F(LibraryTest, removeBookByIdDropsTheReader)
   lib->removeBookById("raycharles");
   EXPECT_THROW(lib->getArchiveById("raycharles"), std::out_of_range);
 };
+
+#ifndef _WIN32
+// Regression test for https://github.com/kiwix/libkiwix/issues/1015: a book
+// created via Book::update(const zim::Archive&) from an archive that has no
+// (re)openable path (e.g. one opened from a file descriptor, as
+// kiwix-android does for custom apps using Android's Asset Play Delivery)
+// must still be servable via Library::getArchiveById() -- not just have its
+// metadata (title, language, ...) available.
+TEST_F(LibraryTest, getArchiveByIdWorksForBookAddedFromFdBackedArchive)
+{
+  // Reuse the already-loaded "raycharles" book's real path to open an
+  // equivalent archive by fd instead of by path, mirroring how an
+  // Android app opens a ZIM it only has a file descriptor for.
+  const auto path = lib->getBookById("raycharles").getPath();
+  const int fd = open(path.c_str(), O_RDONLY);
+  ASSERT_NE(-1, fd);
+  const zim::Archive fdArchive(fd);
+
+  // update() derives the book's id from the archive's UUID, overwriting
+  // anything set before calling it -- so capture the id it actually ends
+  // up with rather than assuming one.
+  kiwix::Book fdBook;
+  fdBook.update(fdArchive);
+
+  // The archive has no real path to reopen from -- update() must not
+  // pretend otherwise.
+  EXPECT_TRUE(fdBook.getPath().empty());
+  EXPECT_FALSE(fdBook.isPathValid());
+
+  ASSERT_TRUE(lib->addBook(fdBook));
+
+  const auto archive = lib->getArchiveById(fdBook.getId());
+  ASSERT_NE(nullptr, archive);
+  // Confirm it's not just non-null, but genuinely usable: same content as
+  // the original, path-backed archive for the same file.
+  const zim::Archive pathArchive(path);
+  EXPECT_EQ(archive->getUuid(), pathArchive.getUuid());
+  EXPECT_EQ(archive->getEntryCount(), pathArchive.getEntryCount());
+  EXPECT_EQ(archive->getMainEntry().getPath(), pathArchive.getMainEntry().getPath());
+}
+#endif // not _WIN32
 
 TEST_F(LibraryTest, removeBookByIdUpdatesTheSearchDB)
 {


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

Fixes #1015. Also unblocks kiwix/kiwix-android#4028 / kiwix/kiwix-android#4223 (Play Asset Delivery custom apps open ZIMs via fd, with no backing path).

## Problem

`Book::update(const zim::Archive& archive)` always set `m_pathValid = true`, regardless of whether `archive.getFilename()` actually returned a reopenable path. For an archive opened from a file descriptor with no backing path at all, `getFilename()` returns `""` — so the book ends up with an empty path but is marked path-valid anyway.

`Library::getArchiveById()` trusts that flag: it only falls back to "no archive available" when `isPathValid()` is false, so for one of these books it instead tried `Archive("")`, which throws. The book's metadata (title, language, article count, ...) still displays fine, because that's captured into the `Book` at `update()` time — only actually *serving* the book's content fails, silently. That matches the reported symptom.

## Fix

- `m_pathValid` now reflects whether the derived path is actually non-empty.
- Since that alone would make fd-backed books permanently unservable, `Book` also keeps a `shared_ptr<zim::Archive>` handle on the archive it was `update()`d from. `zim::Archive` is a cheap-to-copy wrapper around a `shared_ptr<FileImpl>`, so this doesn't duplicate the underlying file/fd.
- `Library::getArchiveById()` now checks that handle first, before falling back to reopening by path — so a book with no path at all can still be served directly from the archive it was already opened from.

## Verification

Added `LibraryTest.getArchiveByIdWorksForBookAddedFromFdBackedArchive`: opens a real test ZIM via `open()`+fd instead of by path, `update()`s a `Book` from that archive, adds it to a `Library`, and checks `getArchiveById()` returns a working archive with matching uuid/entry count/main entry.

- Full suite: 24/24 passing with the fix.
- Confirmed the test is meaningful: stashed just `book.cpp`/`library.cpp` (kept the test), rebuilt — test fails exactly as expected (`isPathValid()` wrongly `true`, `getArchiveById()` throws `"Error opening ZIM file: "`). Restored the fix, 24/24 green again.

Built against a clean local libzim (from `openzim/libzim:main`) + Homebrew pugixml/libmicrohttpd on macOS/arm64.
