### PR TITLE
fix: wire up the taskbar download button for the current book (#1083)

### DIFF
--- a/static/skin/download.js
+++ b/static/skin/download.js
@@ -2,6 +2,27 @@ function downloadButtonText(zimSize) {
     return $t("download") + (zimSize ? ` - ${zimSize}`: '');
 }
 
+// Moved here from index.js so viewer.js (which shows a download button in
+// the taskbar for the book currently being read) can also format sizes
+// coming straight from a catalog entry's acquisition link, without
+// duplicating the formatting logic.
+function humanFriendlyNumStr(num, precision) {
+    const n = Math.abs(num).toFixed().length;
+    return num.toFixed(Math.max(0, precision - n));
+}
+
+function humanFriendlySize(fileSize) {
+    if (fileSize === 0) {
+        return '';
+    }
+    const units = ['bytes', 'KiB', 'MiB', 'GiB', 'TiB'];
+    let quotient = Math.floor(Math.log2(fileSize) / 10);
+    quotient = Math.min(quotient, units.length - 1);
+    fileSize /= (1024 ** quotient);
+    const fileSizeStr = humanFriendlyNumStr(fileSize, 3);
+    return `${fileSizeStr} ${units[quotient]}`;
+}
+
 /* hack for library.kiwix.org magnet links (created by MirrorBrain)
    See https://github.com/kiwix/container-images/issues/242 */
 async function getFixedMirrorbrainMagnet(magnetLink) {
@@ -59,61 +80,73 @@ async function getMagnetLink(downloadLink) {
     return magnetLink;
 }
 
+// Registers a click listener on `button` that always opens the modal for
+// the same fixed downloadLink/downloadSize - used by index.js, where each
+// book card's download button targets one book for its whole lifetime.
 function insertDownloadZimModal(button, downloadLink, downloadSize, root) {
     button.addEventListener('click', async (event) => {
         event.preventDefault();
-        const magnetLink = await getMagnetLink(downloadLink);
-        document.body.insertAdjacentHTML('beforeend', `<div class="modal-wrapper">
-            <div class="modal">
-                <div class="modal-heading">
-                    <div class="modal-title">
-                        <div>
-                            ${downloadButtonText(downloadSize)}
-                        </div>
-                    </div>
-                    <div onclick="closeModal()" class="modal-close-button">
-                        <div>
-                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 14 14" fill="none">
-                                <path fill-rule="evenodd" clip-rule="evenodd" d="M13.7071 1.70711C14.0976 1.31658 14.0976
-                                0.683417 13.7071 0.292893C13.3166 -0.0976311 12.6834 -0.0976311 12.2929 0.292893L7 5.58579L1.70711
-                                0.292893C1.31658 -0.0976311 0.683417 -0.0976311 0.292893 0.292893C-0.0976311 0.683417
-                                -0.0976311 1.31658 0.292893 1.70711L5.58579 7L0.292893 12.2929C-0.0976311 12.6834
-                                -0.0976311 13.3166 0.292893 13.7071C0.683417 14.0976 1.31658 14.0976 1.70711 13.7071L7
-                                8.41421L12.2929 13.7071C12.6834 14.0976 13.3166 14.0976 13.7071 13.7071C14.0976 13.3166
-                                14.0976 12.6834 13.7071 12.2929L8.41421 7L13.7071 1.70711Z" fill="black" />
-                            </svg>
-                        </div>
+        await showDownloadZimModal(downloadLink, downloadSize, root);
+    });
+}
+
+// The actual modal-building logic, split out so callers whose download
+// target changes over time (e.g. viewer.js, where the taskbar's download
+// button follows whichever book is currently being read) can look up the
+// current downloadLink/downloadSize at click time instead of baking stale
+// values into a listener registered once at page load.
+async function showDownloadZimModal(downloadLink, downloadSize, root) {
+    const magnetLink = await getMagnetLink(downloadLink);
+    document.body.insertAdjacentHTML('beforeend', `<div class="modal-wrapper">
+        <div class="modal">
+            <div class="modal-heading">
+                <div class="modal-title">
+                    <div>
+                        ${downloadButtonText(downloadSize)}
                     </div>
                 </div>
-                <div class="modal-content">
-                    <div class="modal-regular-download">
-                        <a href="${downloadLink}" download>
-                            <img src="${root}/skin/download.png?KIWIXCACHEID" alt="${$t("direct-download-alt-text")}" />
-                            <div>${$t("direct-download-link-text")}</div>
-                        </a>
-                    </div>
-                    <div class="modal-regular-download">
-                        <a href="${downloadLink}.sha256" download>
-                            <img src="${root}/skin/hash.png?KIWIXCACHEID" alt="${$t("hash-download-alt-text")}" />
-                            <div>${$t("hash-download-link-text")}</div>
-                        </a>
-                    </div>
-                    ${magnetLink ?
-                    `<div class="modal-regular-download">
-                        <a href="${magnetLink}" target="_blank">
-                            <img src="${root}/skin/magnet.png?KIWIXCACHEID" alt="${$t("magnet-alt-text")}" />
-                            <div>${$t("magnet-link-text")}</div>
-                        </a>
-                    </div>` : ``}
-                    <div class="modal-regular-download">
-                        <a href="${downloadLink}.torrent" download>
-                             <img src="${root}/skin/bittorrent.png?KIWIXCACHEID" alt="${$t("torrent-download-alt-text")}" />
-                            <div>${$t("torrent-download-link-text")}</div>
-                        </a>
+                <div onclick="closeModal()" class="modal-close-button">
+                    <div>
+                        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 14 14" fill="none">
+                            <path fill-rule="evenodd" clip-rule="evenodd" d="M13.7071 1.70711C14.0976 1.31658 14.0976
+                            0.683417 13.7071 0.292893C13.3166 -0.0976311 12.6834 -0.0976311 12.2929 0.292893L7 5.58579L1.70711
+                            0.292893C1.31658 -0.0976311 0.683417 -0.0976311 0.292893 0.292893C-0.0976311 0.683417
+                            -0.0976311 1.31658 0.292893 1.70711L5.58579 7L0.292893 12.2929C-0.0976311 12.6834
+                            -0.0976311 13.3166 0.292893 13.7071C0.683417 14.0976 1.31658 14.0976 1.70711 13.7071L7
+                            8.41421L12.2929 13.7071C12.6834 14.0976 13.3166 14.0976 13.7071 13.7071C14.0976 13.3166
+                            14.0976 12.6834 13.7071 12.2929L8.41421 7L13.7071 1.70711Z" fill="black" />
+                        </svg>
                     </div>
                 </div>
             </div>
-        </div>`);
-    })
+            <div class="modal-content">
+                <div class="modal-regular-download">
+                    <a href="${downloadLink}" download>
+                        <img src="${root}/skin/download.png?KIWIXCACHEID" alt="${$t("direct-download-alt-text")}" />
+                        <div>${$t("direct-download-link-text")}</div>
+                    </a>
+                </div>
+                <div class="modal-regular-download">
+                    <a href="${downloadLink}.sha256" download>
+                        <img src="${root}/skin/hash.png?KIWIXCACHEID" alt="${$t("hash-download-alt-text")}" />
+                        <div>${$t("hash-download-link-text")}</div>
+                    </a>
+                </div>
+                ${magnetLink ?
+                `<div class="modal-regular-download">
+                    <a href="${magnetLink}" target="_blank">
+                        <img src="${root}/skin/magnet.png?KIWIXCACHEID" alt="${$t("magnet-alt-text")}" />
+                        <div>${$t("magnet-link-text")}</div>
+                    </a>
+                </div>` : ``}
+                <div class="modal-regular-download">
+                    <a href="${downloadLink}.torrent" download>
+                         <img src="${root}/skin/bittorrent.png?KIWIXCACHEID" alt="${$t("torrent-download-alt-text")}" />
+                        <div>${$t("torrent-download-link-text")}</div>
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>`);
 }
 

--- a/static/skin/index.js
+++ b/static/skin/index.js
@@ -78,22 +78,8 @@
         return result;
     }
 
-    function humanFriendlyNumStr(num, precision) {
-        const n = Math.abs(num).toFixed().length;
-        return num.toFixed(Math.max(0, precision - n));
-    }
-
-    const humanFriendlySize = (fileSize) => {
-        if (fileSize === 0) {
-            return '';
-        }
-        const units = ['bytes', 'KiB', 'MiB', 'GiB', 'TiB'];
-        let quotient = Math.floor(Math.log2(fileSize) / 10);
-        quotient = Math.min(quotient, units.length - 1);
-        fileSize /= (1024 ** quotient);
-        const fileSizeStr = humanFriendlyNumStr(fileSize, 3);
-        return `${fileSizeStr} ${units[quotient]}`;
-    };
+    // humanFriendlyNumStr/humanFriendlySize moved to download.js (loaded
+    // before this file) so viewer.js can reuse them too.
 
     const humanFriendlyTitle = (title) => {
         if (typeof title === 'string' && title.length > 0) {

--- a/static/skin/viewer.js
+++ b/static/skin/viewer.js
@@ -47,11 +47,28 @@ function getBookFromUserUrl(url) {
 
 let currentBook = null;
 let currentBookTitle = null;
+let currentBookDownloadLink = null;
+let currentBookDownloadSize = null;
 
 const bookUIGroup = document.getElementById('kiwix_serve_taskbar_book_ui_group');
 const homeButton = document.getElementById('kiwix_serve_taskbar_home_button');
+const downloadButton = document.getElementById('kiwix_serve_taskbar_download_button');
 const contentIframe = document.getElementById('content_iframe');
 
+// The download button's target changes with whichever book is currently
+// being read, so - unlike index.js's book-grid cards, each of which gets
+// its own insertDownloadZimModal() call bound to one fixed book - this
+// listener is registered once and reads the current download link/size at
+// click time (see showDownloadZimModal() in download.js).
+if ( downloadButton ) {
+  downloadButton.addEventListener('click', async (event) => {
+    event.preventDefault();
+    if ( !currentBookDownloadLink ) {
+      return;
+    }
+    await showDownloadZimModal(currentBookDownloadLink, currentBookDownloadSize, root);
+  });
+}
 
 function gotoMainPageOfCurrentBook() {
   location.hash = currentBook + '/';
@@ -117,18 +134,28 @@ function setTitle(element, text) {
   }
 }
 
-function setCurrentBook(book, title) {
+function setCurrentBook(book, title, downloadLink, downloadSize) {
   currentBook = book;
   currentBookTitle = title;
+  currentBookDownloadLink = downloadLink;
+  currentBookDownloadSize = downloadSize;
   setTitle(homeButton, $t("home-button-text", {BOOK_TITLE: title}));
   homeButton.innerHTML = `<button>${title}</button>`;
   bookUIGroup.style.display = 'inline';
+  if ( downloadButton ) {
+    // Not every previewed book has a download URL - e.g. a ZIM added
+    // locally with no library.xml/OPDS entry - so hide the button rather
+    // than open a modal with nothing to download.
+    downloadButton.style.display = downloadLink ? 'inline' : 'none';
+  }
   updateSearchBoxForBookChange();
 }
 
 function noCurrentBook() {
   currentBook = null;
   currentBookTitle = null;
+  currentBookDownloadLink = null;
+  currentBookDownloadSize = null;
   bookUIGroup.style.display = 'none';
   updateSearchBoxForBookChange();
 }
@@ -140,13 +167,44 @@ function updateCurrentBookIfNeeded(userUrl) {
   }
 }
 
+// Looks up the current book's download link/size, if any, from its
+// catalog entry - the same acquisition link index.js already reads for
+// the book-grid download buttons (see book.querySelector('link[type=
+// "application/x-zim"]') there). "name" is matched as an exact boolean
+// term server-side (see kiwix::nameQuery() in src/library.cpp), so this
+// can't accidentally match a different book.
+async function fetchBookDownloadInfo(book) {
+  try {
+    const resp = await fetch(
+      `${root}/catalog/v2/entries?name=${encodeURIComponent(book)}&count=1`
+    );
+    if ( !resp.ok ) {
+      return { downloadLink: null, downloadSize: null };
+    }
+    const data = new window.DOMParser().parseFromString(await resp.text(), 'application/xml');
+    const downloadBookLink = data.querySelector('link[type="application/x-zim"]');
+    if ( !downloadBookLink ) {
+      return { downloadLink: null, downloadSize: null };
+    }
+    return {
+      downloadLink: downloadBookLink.getAttribute('href').split('.meta4')[0],
+      downloadSize: humanFriendlySize(parseInt(downloadBookLink.getAttribute('length')))
+    };
+  } catch (err) {
+    console.log("Error fetching book download info: " + err);
+    return { downloadLink: null, downloadSize: null };
+  }
+}
+
 function updateCurrentBook(book) {
   if ( book == null ) {
     noCurrentBook();
   } else {
     fetch(`./raw/${book}/meta/Title`).then(async (resp) => {
       if ( resp.ok ) {
-        setCurrentBook(book, await resp.text());
+        const title = await resp.text();
+        const { downloadLink, downloadSize } = await fetchBookDownloadInfo(book);
+        setCurrentBook(book, title, downloadLink, downloadSize);
       } else {
         noCurrentBook();
       }

--- a/static/viewer.html
+++ b/static/viewer.html
@@ -85,7 +85,7 @@
                  title="Download current ZIM file"
                  accesskey="d"
                  aria-label="Download current ZIM file"
-                 onclick="insertDownloadZimModal(downloadButton, `${root}`)">
+                 style="display: none">
                 <button>&#x21E9;</button>
               </a>
             </span>

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -67,10 +67,12 @@ const ResourceCollection resources200Compressible{
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/error.css?cacheid=b3fa90cf" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/i18n.js" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/i18n.js?cacheid=e9a10ac1" },
+  { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/download.js" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/download.js?cacheid=3c61efe7" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/index.css" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/index.css?cacheid=ae79e41a" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/index.js" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/index.js?cacheid=e3305ca0" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/index.js?cacheid=c7e866ce" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/iso6391To3.js" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/iso6391To3.js?cacheid=ecde2bb3" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/isotope.pkgd.min.js" },
@@ -82,7 +84,7 @@ const ResourceCollection resources200Compressible{
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/taskbar.css" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/taskbar.css?cacheid=42e90cb9" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/viewer.js" },
-  { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=f78c03d9" },
+  { STATIC_CONTENT,  "/ROOT%23%3F/skin/viewer.js?cacheid=a0aab37e" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Poppins.ttf" },
   { STATIC_CONTENT,  "/ROOT%23%3F/skin/fonts/Poppins.ttf?cacheid=af705837" },
   { DYNAMIC_CONTENT, "/ROOT%23%3F/skin/fonts/Roboto.ttf" },
@@ -304,12 +306,13 @@ R"EXPECTEDRESULT(      href="/ROOT%23%3F/skin/kiwix.css?cacheid=b4e29e64"
     <link rel="mask-icon" href="/ROOT%23%3F/skin/favicon/safari-pinned-tab.svg?cacheid=8d487e95" color="#5bbad5">
     <link rel="shortcut icon" href="/ROOT%23%3F/skin/favicon/favicon.ico?cacheid=92663314">
     <meta name="msapplication-config" content="/ROOT%23%3F/skin/favicon/browserconfig.xml?cacheid=f29a7c4a">
-    <script type="text/javascript" src="./skin/polyfills.js?cacheid=a0e0343d"></script>
+    <script type="text/javascript" src="/ROOT%23%3F/skin/polyfills.js?cacheid=a0e0343d"></script>
     <script type="module" src="/ROOT%23%3F/skin/i18n.js?cacheid=e9a10ac1" defer></script>
     <script type="text/javascript" src="/ROOT%23%3F/skin/languages.js?cacheid=d2d6933b" defer></script>
     <script src="/ROOT%23%3F/skin/isotope.pkgd.min.js?cacheid=2e48d392" defer></script>
     <script src="/ROOT%23%3F/skin/iso6391To3.js?cacheid=ecde2bb3"></script>
-    <script type="text/javascript" src="/ROOT%23%3F/skin/index.js?cacheid=e3305ca0" defer></script>
+    <script type="text/javascript" src="/ROOT%23%3F/skin/download.js?cacheid=3c61efe7" defer></script>
+    <script type="text/javascript" src="/ROOT%23%3F/skin/index.js?cacheid=c7e866ce" defer></script>
         <img src="/ROOT%23%3F/skin/feed.svg?cacheid=055b333f"
         <img src="/ROOT%23%3F/skin/langSelector.svg?cacheid=00b59961"
 )EXPECTEDRESULT"
@@ -328,10 +331,17 @@ R"EXPECTEDRESULT(    background-image: url('../skin/search-icon.svg?cacheid=b10a
     {
       /* url */ "/ROOT%23%3F/skin/index.js",
 R"EXPECTEDRESULT(                  <img src="${root}/skin/download-white.svg?cacheid=079ab989">
-                                <img src="${root}/skin/download.png?cacheid=a39aa502" alt="${$t("direct-download-alt-text")}" />
-                                <img src="${root}/skin/hash.png?cacheid=f836e872" alt="${$t("hash-download-alt-text")}" />
-                                <img src="${root}/skin/magnet.png?cacheid=73b6bddf" alt="${$t("magnet-alt-text")}" />
-                                <img src="${root}/skin/bittorrent.png?cacheid=4f5c6882" alt="${$t("torrent-download-alt-text")}" />
+)EXPECTEDRESULT"
+    },
+    {
+      // The download-modal building code (and the image references below)
+      // moved from index.js into the shared download.js, so viewer.js can
+      // reuse it for the taskbar download button. See #1083.
+      /* url */ "/ROOT%23%3F/skin/download.js",
+R"EXPECTEDRESULT(                        <img src="${root}/skin/download.png?cacheid=a39aa502" alt="${$t("direct-download-alt-text")}" />
+                        <img src="${root}/skin/hash.png?cacheid=f836e872" alt="${$t("hash-download-alt-text")}" />
+                        <img src="${root}/skin/magnet.png?cacheid=73b6bddf" alt="${$t("magnet-alt-text")}" />
+                         <img src="${root}/skin/bittorrent.png?cacheid=4f5c6882" alt="${$t("torrent-download-alt-text")}" />
 )EXPECTEDRESULT"
     },
     {
@@ -343,7 +353,8 @@ R"EXPECTEDRESULT(    <link type="text/css" href="./skin/kiwix.css?cacheid=b4e29e
     <script type="text/javascript" src="./skin/polyfills.js?cacheid=a0e0343d"></script>
     <script type="module" src="./skin/i18n.js?cacheid=e9a10ac1" defer></script>
     <script type="text/javascript" src="./skin/languages.js?cacheid=d2d6933b" defer></script>
-    <script type="text/javascript" src="./skin/viewer.js?cacheid=f78c03d9" defer></script>
+    <script type="text/javascript" src="./skin/download.js?cacheid=3c61efe7" defer></script>
+    <script type="text/javascript" src="./skin/viewer.js?cacheid=a0aab37e" defer></script>
     <script type="text/javascript" src="./skin/autoComplete/autoComplete.min.js?cacheid=1191aaaf"></script>
       const blankPageUrl = root + "/skin/blank.html?cacheid=6b1fa032";
           <label for="kiwix_button_show_toggle"><img src="./skin/caret.png?cacheid=22b942b4" alt=""></label>


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

Completes this branch's stub wiring for the taskbar download button (#1083).

## What was missing

This branch correctly extracted the download modal into a shared `static/skin/download.js` (addressing the "reuse the same code base" objection @kelson42 raised on #1270), but the actual button wiring in `viewer.html` was left unfinished:

```html
onclick="insertDownloadZimModal(downloadButton, `${root}`)"
```

`insertDownloadZimModal(button, downloadLink, downloadSize, root)` takes 4 arguments; this passes 2, and `downloadButton` isn't defined anywhere in `viewer.js`/`viewer.html` - clicking it would throw `ReferenceError`. There was also no code fetching a download link for whichever book is currently open, which `viewer.html`'s static, book-agnostic shell page (reused across every book via the URL-hash router) has no way to know at load time.

## The fix

Followed the same pattern `viewer.js` already uses to learn the current book's *title* on every book switch - a small async fetch in `updateCurrentBook()`, independent of the page-load lifecycle:

- `fetchBookDownloadInfo(book)` queries the existing `GET /catalog/v2/entries?name={book}&count=1` and reads the acquisition link exactly the way `index.js`'s book-grid cards already do (`book.querySelector('link[type="application/x-zim"]')`). `name` is matched as an **exact boolean term** server-side (`kiwix::nameQuery()`, `"XN"` prefix in `src/library.cpp`), not a fuzzy/tokenized search, so this can't accidentally match a different book.
- Books with no download URL (e.g. a ZIM added locally with no `library.xml`/OPDS entry) correctly get no acquisition link back at all, per the `{{#url}}...{{/url}}` conditional in `catalog_v2_entry.xml` - this is what addresses @kelson42's second objection on #1270 ("you can't fabricate a download URL for every book").
- `setCurrentBook()`/`noCurrentBook()` now track `currentBookDownloadLink`/`currentBookDownloadSize` alongside the existing `currentBook`/`currentBookTitle`, and show/hide the taskbar button accordingly.
- The click listener is registered **once** (the button's target changes per book, unlike `index.js`'s fixed-per-card buttons), calling a new `showDownloadZimModal(downloadLink, downloadSize, root)` - the actual modal-building logic split out of `insertDownloadZimModal` so both call sites (fixed target in `index.js`, current target in `viewer.js`) share it without duplicating listeners or changing `index.js`'s existing behavior.
- Moved `humanFriendlySize()`/`humanFriendlyNumStr()` from `index.js` into `download.js` so `viewer.js` can format the size the same way.

## Also fixed

Two pre-existing gaps in this branch's own `CacheIdsOfStaticResources` test coverage, found while updating it for this change (this test would already fail on this branch as-is, before my commit):
- `download.js` was never added to the resource list or the root/viewer page rendered-output checks.
- The root-page check still expected `index.js`'s now-moved `download.png`/`hash.png`/`magnet.png`/`bittorrent.png` references, which left for `download.js` when this branch first split the modal out.
- (Unrelated one-liner, same test block) `polyfills.js`'s expected src still used the old `./skin/` prefix after this branch changed the template to `{{root}}/skin/`.

## Verification

- `node --check` on all three modified JS files.
- Manually recomputed sha1sum(file)[:8] for every changed static file (per `README.md`'s cache-busting section) and cross-checked each `cacheid` value against `test/server.cpp`'s expectations line by line.
- **Was not able to run `meson test` locally in this environment** - getting the full dependency chain (`mustache.hpp`, `libzim`) building would have taken longer than the fix itself. Please run the actual suite before merging; I'm fairly confident in the cacheid/content-block bookkeeping but haven't seen a green run.

cc @kelson42 @rajvi0106
